### PR TITLE
Add hook for eel to collect eel.js and an import

### DIFF
--- a/news/6.new.rst
+++ b/news/6.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``eel``, which needs to pull in ``eel.js`` and an extra library.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-eel.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-eel.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('eel')
+hiddenimports = ['bottle_websocket']

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -273,3 +273,8 @@ def test_pytest_runner(pyi_builder):
         import sys
         sys.exit(pytest.main(['--help']))
         """)
+
+
+@importorskip('eel')
+def test_eel(pyi_builder):
+    pyi_builder.test_source("import eel")


### PR DESCRIPTION
Hi! I hope this is the correct place to put up a contribution and the right way to do it.

I'm maintaining a project called [Eel](https://github.com/samuelhwilliams/Eel) which currently has a [custom build script](https://github.com/samuelhwilliams/Eel/blob/master/eel/__main__.py) to help pull in the correct files. It would be nice if that was less necessary by having a pyinstaller hook for it.

Please let me know if anything more is needed.