### PR TITLE
Create.stdhooks.new.rst

### DIFF
--- a/news/stdhooks.new.rst
+++ b/news/stdhooks.new.rst
@@ -1,0 +1,1 @@
+ Add a hook for ``HtmlTestRunner``, which has a hidden import Template which fixes Error While Using With UnitTest Module.


### PR DESCRIPTION
 Add a hook for ``HtmlTestRunner``, which has a hidden import Template which fixes Error While Using With UnitTest Module.