### PR TITLE
Add hook for dask

### DIFF
--- a/news/12.new.rst
+++ b/news/12.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``dask``, which includes .yaml data files. 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dask.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dask.py
@@ -1,0 +1,18 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+"""
+Collects in-repo dask.yaml and dask-schema.yaml data files.
+"""
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('dask', includes=['*.yml', '*.yaml'])


### PR DESCRIPTION
Fixes [4984](https://github.com/pyinstaller/pyinstaller/issues/4984) as scikit-image uses dask in Anaconda.