### PR TITLE
Add hook for tinycss2 for missing data files

### DIFF
--- a/news/16.new.rst
+++ b/news/16.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``tinycss2``, which is missing data files.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tinycss2.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tinycss2.py
@@ -1,0 +1,22 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+
+"""
+Hook for tinycsss2. tinycss2 is a low-level CSS parser and generator.
+https://github.com/Kozea/tinycss2
+"""
+from PyInstaller.utils.hooks import collect_data_files
+
+
+def hook(hook_api):
+    hook_api.add_datas(collect_data_files(hook_api.__name__))


### PR DESCRIPTION
Adds a hook for tinycss2. Credit goes to @Legorooj for your answer on StackOverflow: https://stackoverflow.com/questions/61467195/filenotfounderror-errno-2-no-such-file-or-directory-tinycss2-version