### PR TITLE
Add link to news/README.md to the main README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 #### New PyInstaller team members wanted! Email `legorooj@protonmail.com` if you're interested.
 
-What happens when (your?) package doesn't work with PyInstaller? Say you have data files that you need at runtime? 
+What happens when (your?) package doesn't work with PyInstaller? Say you have data files that you need at runtime?
 PyInstaller doesn't bundle those. Your package requires others which PyInstaller can't see? How do you fix that?
 
 In summary, a "hook" file extends PyInstaller to adapt it to the special needs and methods used by a Python package.
@@ -34,5 +34,7 @@ please see [the wiki](https://github.com/pyinstaller/pyinstaller-hooks-contrib/w
 ## I want to help!
 
 Please start by providing pull requests and helping solve issues.
+Please read [news/README.txt](https://github.com/pyinstaller/pyinstaller-hooks-contrib/blob/master/news/README.txt) before submitting you pull request.
 If you plan to contribute frequently or are interested in becoming a developer,
 send an email to `legorooj@protonmail.com` to let us know.
+


### PR DESCRIPTION
The instructions for adding to the changelog aren't visible enough. Hopefully this will help avoid having to re-explaining this in every new PR.

I meant to push this to my fork then PR but forgot to `git remote set-url`.  I'll try to fork in future.
Also the white-space changes weren't intentional. I can revert them if you want.