### PR TITLE
Add gmplot hook

### DIFF
--- a/news/21.new.rst
+++ b/news/21.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``gmplot``, which has some data files.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gmplot.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gmplot.py
@@ -1,12 +1,13 @@
 # ------------------------------------------------------------------
 # Copyright (c) 2005-2020 PyInstaller Development Team.
 #
-# This file is distributed under the terms of the Apache License 2.0
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
 #
-# The full license is available in LICENSE.APL.txt, distributed with
+# The full license is available in LICENSE.GPL.txt, distributed with
 # this software.
 #
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import collect_data_files

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gmplot.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gmplot.py
@@ -1,15 +1,14 @@
 # ------------------------------------------------------------------
-# Copyright (c) 2020 PyInstaller Development Team.
+# Copyright (c) 2005-2020 PyInstaller Development Team.
 #
-# This file is distributed under the terms of the GNU General Public
-# License (version 2.0 or later).
+# This file is distributed under the terms of the Apache License 2.0
 #
-# The full license is available in LICENSE.GPL.txt, distributed with
+# The full license is available in LICENSE.APL.txt, distributed with
 # this software.
 #
-# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-License-Identifier: Apache-2.0
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import collect_data_files
 
-datas = collect_data_files('gmplot') 
+datas = collect_data_files('gmplot')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gmplot.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gmplot.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('gmplot') 


### PR DESCRIPTION
Due to the issue faced by users of gmplot with conversion to .exe using PyInstaller, this hook was created to include data files along with gmplot. Fixes #20.