### PR TITLE
Add iminuit hooks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,6 @@ New hooks
   (`#23 <https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/23>`_)
 * Add hook for ``trimesh`` which requires importing resource files. (`#25
   <https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/25>`_)
-* Add hook for ``iminuit`` which is missing hidden imports.
 
 
 Updated hooks

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ New hooks
   (`#23 <https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/23>`_)
 * Add hook for ``trimesh`` which requires importing resource files. (`#25
   <https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/25>`_)
+* Add hook for ``iminuit`` which is missing hidden imports.
 
 
 Updated hooks

--- a/news/26.new.rst
+++ b/news/26.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``iminuit`` which has hidden imports.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -16,6 +16,7 @@ boto==2.49.0
 boto3==1.12.33
 botocore==1.15.33
 h5py==2.10.0
+iminuit==1.4.0
 markdown==3.2.1
 pendulum==2.0.5
 phonenumbers==8.12.1

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-iminuit.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-iminuit.py
@@ -1,0 +1,25 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# add hooks for iminuit: https://github.com/scikit-hep/iminuit
+
+# iminuit imports subpackages through a cython module which aren't
+# found by default
+
+from PyInstaller.utils.hooks import collect_submodules
+
+hiddenimports = []
+
+# the iminuit package contains tests which aren't needed when distributing
+for mod in collect_submodules('iminuit'):
+    if not mod.startswith('iminuit.tests'):
+        hiddenimports.append(mod)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -296,3 +296,10 @@ def test_sentry(pyi_builder):
         import sentry_sdk
         sentry_sdk.init()
         """)
+
+
+@importorskip('iminuit')
+def test_iminuit(pyi_builder):
+    pyi_builder.test_source("""
+        from iminuit import Minuit
+        """)


### PR DESCRIPTION
iminuit uses a cython module which imports sub-modules. These are not normally detected by pyinstaller. This hook uses collect_submodules to add the missing modules as hidden imports, excluding tests.
