### PR TITLE
Add missing licences to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 graft src/_pyinstaller_hooks_contrib
+include LICENSE
+include LICENSE.APL.txt


### PR DESCRIPTION
Fixes #31 - i.e. we forgot to add the licenses to the `MANIFEST.in` so that they are included in `sdist`s. @Legorooj Can you confirm if both the `LICENSE` and `LICENSE.APL.txt` should be included or just the former? And does this warrant a changelog entry?