### PR TITLE
Add hook for the pysnmp_mibs package

### DIFF
--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pysnmp_mibs.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pysnmp_mibs.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('pysnmp_mibs', include_py_files=True)


### PR DESCRIPTION
Hook for the pynsmp_mibs package at
https://pypi.org/project/pysnmp-mibs/

It is a package that contains a wide variety of MIB's precompiled for the pysnmp package