### PR TITLE
Migrate the required external test scripts from the main repository

### DIFF
--- a/src/_pyinstaller_hooks_contrib/tests/scripts/pyi_lib_boto.py
+++ b/src/_pyinstaller_hooks_contrib/tests/scripts/pyi_lib_boto.py
@@ -1,4 +1,4 @@
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Copyright (c) 2015-2020, PyInstaller Development Team.
 #
 # Distributed under the terms of the GNU General Public License (version 2
@@ -7,7 +7,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 from inspect import getmembers, isfunction
 from functools import partial
@@ -16,8 +16,7 @@ import boto.exception
 
 credentials = dict(
     aws_access_key_id='ASIAIH3F2FU3T63KIXKA',
-    aws_secret_access_key='lnN4qk1a0SuQAFVsGA+Y+ujo2/5rLq2j+a1O4Vuy'
-)
+    aws_secret_access_key='lnN4qk1a0SuQAFVsGA+Y+ujo2/5rLq2j+a1O4Vuy')
 # connect_cloudsearchdomain is broken in boto; the rest require custom params
 skip = {
     'connect_cloudsearchdomain',
@@ -29,12 +28,11 @@ skip = {
 }
 connect_funcs = [
     func for name, func in getmembers(boto)
-    if isfunction(func)
-        and name.startswith('connect_')
-        and name not in skip
+    if isfunction(func) and name.startswith('connect_') and name not in skip
 ]
 connect_funcs += [
-    partial(boto.connect_ec2_endpoint, 'https://ec2.amazonaws.com', **credentials),
+    partial(boto.connect_ec2_endpoint, 'https://ec2.amazonaws.com',
+            **credentials),
     partial(boto.connect_gs, gs_access_key_id='', gs_secret_access_key=''),
     partial(boto.connect_euca, host=None, **credentials),
     partial(boto.connect_ia, ia_access_key_id='', ia_secret_access_key=''),

--- a/src/_pyinstaller_hooks_contrib/tests/scripts/pyi_lib_enchant.py
+++ b/src/_pyinstaller_hooks_contrib/tests/scripts/pyi_lib_enchant.py
@@ -1,4 +1,4 @@
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Copyright (c) 2005-2020, PyInstaller Development Team.
 #
 # Distributed under the terms of the GNU General Public License (version 2
@@ -7,14 +7,12 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
-#-----------------------------------------------------------------------------
-
+# -----------------------------------------------------------------------------
 
 # Enchant hook test. Tested with PyEnchant 1.6.6.
 
 import sys
 import enchant
-
 
 print(80 * '-')
 print('PYTHONPATH: %s' % sys.path)
@@ -27,20 +25,19 @@ print(80 * '-')
 print('Backends: ' + ', '.join(backends))
 
 # Usually en_US dictionary should be bundled.
-langs = enchant.list_languages()
+languages = enchant.list_languages()
 dicts = [x[0] for x in enchant.list_dicts()]
 if len(dicts) < 1:
     raise SystemExit('No dictionary available')
 print(80 * '-')
-print('Languages: %s' % ', '.join(langs))
+print('Languages: %s' % ', '.join(languages))
 print('Dictionaries: %s' % dicts)
 print(80 * '-')
 
-
 # Try spell checking if English is availale
-l = 'en_US'
-if l in langs:
-    d = enchant.Dict(l)
+language = 'en_US'
+if language in languages:
+    d = enchant.Dict(language)
     print('d.check("hallo") %s' % d.check('hallo'))
     print('d.check("halllo") %s' % d.check('halllo'))
     print('d.suggest("halllo") %s' % d.suggest('halllo'))

--- a/src/_pyinstaller_hooks_contrib/tests/scripts/pyi_lib_pycparser.py
+++ b/src/_pyinstaller_hooks_contrib/tests/scripts/pyi_lib_pycparser.py
@@ -1,4 +1,4 @@
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Copyright (c) 2014-2020, PyInstaller Development Team.
 #
 # Distributed under the terms of the GNU General Public License (version 2
@@ -7,11 +7,9 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
-#-----------------------------------------------------------------------------
-
+# -----------------------------------------------------------------------------
 
 import os
-
 
 fnames_to_track = [
     'lextab.py',
@@ -20,10 +18,7 @@ fnames_to_track = [
 
 
 def fnames_found():
-    return [
-        fname for fname in fnames_to_track
-        if os.path.isfile(fname)
-    ]
+    return [fname for fname in fnames_to_track if os.path.isfile(fname)]
 
 
 if __name__ == '__main__':
@@ -57,4 +52,3 @@ if __name__ == '__main__':
             raise SystemExit('FAIL: Files generated but removed.')
 
     # Success.
-


### PR DESCRIPTION
Some of the tests depend on external scripts that were left in the main pyinstaller repository, causing test failures. Fixes #30.