### PR TITLE
Fix library duplication in tensorflow v.2.3 and avoid packaging unnecessary files

### DIFF
--- a/news/50.update.rst
+++ b/news/50.update.rst
@@ -1,0 +1,1 @@
+Fix shared library duplication in ``tensorflow`` v.2.3. Avoid packaging unnecessary data files (e.g., development headers) on all ``tensorflow`` versions.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tensorflow.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tensorflow.py
@@ -37,16 +37,18 @@ data_excludes = [
 #
 # See pyinstaller/pyinstaller-hooks-contrib#49 for details.
 excluded_submodules = ['tensorflow.python._pywrap_tensorflow_internal']
-submodules_filter = lambda x: x not in excluded_submodules
+
+def _submodules_filter(x):
+    return x not in excluded_submodules
 
 
 if tf_pre_1_15_0:
     # 1.14.x and earlier: collect everything from tensorflow
-    hiddenimports = collect_submodules('tensorflow', filter=submodules_filter)
+    hiddenimports = collect_submodules('tensorflow', filter=_submodules_filter)
     datas = collect_data_files('tensorflow', excludes=data_excludes)
 elif tf_post_1_15_0 and tf_pre_2_2_0:
     # 1.15.x - 2.1.x: collect everything from tensorflow_core
-    hiddenimports = collect_submodules('tensorflow_core', filter=submodules_filter)
+    hiddenimports = collect_submodules('tensorflow_core', filter=_submodules_filter)
     datas = collect_data_files('tensorflow_core', excludes=data_excludes)
 
     # Under 1.15.x, we seem to fail collecting a specific submodule,
@@ -56,7 +58,7 @@ elif tf_post_1_15_0 and tf_pre_2_2_0:
             ['tensorflow_core._api.v1.compat.v2.summary.experimental']
 else:
     # 2.2.0 and newer: collect everything from tensorflow again
-    hiddenimports = collect_submodules('tensorflow', filter=submodules_filter)
+    hiddenimports = collect_submodules('tensorflow', filter=_submodules_filter)
     datas = collect_data_files('tensorflow', excludes=data_excludes)
 
 excludedimports = excluded_submodules

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tensorflow.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tensorflow.py
@@ -18,6 +18,17 @@ tf_post_1_15_0 = is_module_satisfies("tensorflow >= 1.15.0")
 tf_pre_2_0_0 = is_module_satisfies("tensorflow < 2.0.0")
 tf_pre_2_2_0 = is_module_satisfies("tensorflow < 2.2.0")
 
+
+# Exclude from data collection:
+#  - development headers in include subdirectory
+#  - XLA AOT runtime sources
+#  - libtensorflow_framework shared library (to avoid duplication)
+data_excludes = [
+    "include",
+    "xla_aot_runtime_src",
+    "libtensorflow_framework.*"
+]
+
 # Under tensorflow 2.3.0 (the most recent version at the time of writing),
 # _pywrap_tensorflow_internal extension module ends up duplicated; once
 # as an extension, and once as a shared library. In addition to increasing
@@ -32,11 +43,11 @@ submodules_filter = lambda x: x not in excluded_submodules
 if tf_pre_1_15_0:
     # 1.14.x and earlier: collect everything from tensorflow
     hiddenimports = collect_submodules('tensorflow', filter=submodules_filter)
-    datas = collect_data_files('tensorflow')
+    datas = collect_data_files('tensorflow', excludes=data_excludes)
 elif tf_post_1_15_0 and tf_pre_2_2_0:
     # 1.15.x - 2.1.x: collect everything from tensorflow_core
     hiddenimports = collect_submodules('tensorflow_core', filter=submodules_filter)
-    datas = collect_data_files('tensorflow_core')
+    datas = collect_data_files('tensorflow_core', excludes=data_excludes)
 
     # Under 1.15.x, we seem to fail collecting a specific submodule,
     # and need to add it manually...
@@ -46,6 +57,6 @@ elif tf_post_1_15_0 and tf_pre_2_2_0:
 else:
     # 2.2.0 and newer: collect everything from tensorflow again
     hiddenimports = collect_submodules('tensorflow', filter=submodules_filter)
-    datas = collect_data_files('tensorflow')
+    datas = collect_data_files('tensorflow', excludes=data_excludes)
 
 excludedimports = excluded_submodules

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tensorflow.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tensorflow.py
@@ -38,17 +38,20 @@ data_excludes = [
 # See pyinstaller/pyinstaller-hooks-contrib#49 for details.
 excluded_submodules = ['tensorflow.python._pywrap_tensorflow_internal']
 
+
 def _submodules_filter(x):
     return x not in excluded_submodules
 
 
 if tf_pre_1_15_0:
     # 1.14.x and earlier: collect everything from tensorflow
-    hiddenimports = collect_submodules('tensorflow', filter=_submodules_filter)
+    hiddenimports = collect_submodules('tensorflow',
+                                       filter=_submodules_filter)
     datas = collect_data_files('tensorflow', excludes=data_excludes)
 elif tf_post_1_15_0 and tf_pre_2_2_0:
     # 1.15.x - 2.1.x: collect everything from tensorflow_core
-    hiddenimports = collect_submodules('tensorflow_core', filter=_submodules_filter)
+    hiddenimports = collect_submodules('tensorflow_core',
+                                       filter=_submodules_filter)
     datas = collect_data_files('tensorflow_core', excludes=data_excludes)
 
     # Under 1.15.x, we seem to fail collecting a specific submodule,
@@ -58,7 +61,8 @@ elif tf_post_1_15_0 and tf_pre_2_2_0:
             ['tensorflow_core._api.v1.compat.v2.summary.experimental']
 else:
     # 2.2.0 and newer: collect everything from tensorflow again
-    hiddenimports = collect_submodules('tensorflow', filter=_submodules_filter)
+    hiddenimports = collect_submodules('tensorflow',
+                                       filter=_submodules_filter)
     datas = collect_data_files('tensorflow', excludes=data_excludes)
 
 excludedimports = excluded_submodules


### PR DESCRIPTION
This is a follow-up to the previous `tensorflow` hook cleanup:
* fix #49 by explicitly excluding `tensorflow.python._pywrap_tensorflow_internal`. 
* avoid packaging tensorflow's development headers, XLA AOT runtime sources, and duplicating the `libtensorflow_framework` shared library (the unused copy picked up via `datas` ends up in `tensorflow` folder, while the one picked up by dependency analysis ends up in program root)