### PR TITLE
Add hooks for skimage.feature and skimage.graph

### DIFF
--- a/news/52.new.rst
+++ b/news/52.new.rst
@@ -1,0 +1,1 @@
+Add hooks for ``skimage.feature`` and ``skimage.graph`` to fix issues with missing imports.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.feature.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.feature.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# The following missing module prevents import of skimage.feature
+# with skimage 0.17.x.
+hiddenimports = ['skimage.feature._orb_descriptor_positions',]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.feature.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.feature.py
@@ -12,4 +12,4 @@
 
 # The following missing module prevents import of skimage.feature
 # with skimage 0.17.x.
-hiddenimports = ['skimage.feature._orb_descriptor_positions',]
+hiddenimports = ['skimage.feature._orb_descriptor_positions', ]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.graph.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.graph.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# The following missing module prevents import of skimage.graph
+# with skimage 0.17.x.
+hiddenimports = ['skimage.graph.heap',]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.graph.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.graph.py
@@ -12,4 +12,4 @@
 
 # The following missing module prevents import of skimage.graph
 # with skimage 0.17.x.
-hiddenimports = ['skimage.graph.heap',]
+hiddenimports = ['skimage.graph.heap', ]

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -361,7 +361,7 @@ def test_pydivert(pyi_builder):
 
 @importorskip('skimage')
 @pytest.mark.skipif(not is_module_satisfies('skimage >= 0.16.0'),
-    reason='The test supports only skimage 0.16.0 or newer.')
+                    reason='The test supports only skimage 0.16.0 or newer.')
 @pytest.mark.parametrize('submodule', [
     'color', 'data', 'draw', 'exposure', 'feature', 'filters', 'future',
     'graph', 'io', 'measure', 'metrics', 'morphology', 'registration',

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -14,6 +14,7 @@ import pytest
 
 from PyInstaller.compat import is_darwin
 from PyInstaller.utils.tests import importorskip, xfail, skipif_win
+from PyInstaller.utils.hooks import is_module_satisfies
 
 
 @importorskip('jinxed')
@@ -356,3 +357,17 @@ def test_pydivert(pyi_builder):
         import pydivert
         pydivert.WinDivert.check_filter("inbound")
         """)
+
+
+@importorskip('skimage')
+@pytest.mark.skipif(not is_module_satisfies('skimage >= 0.16.0'),
+    reason='The test supports only skimage 0.16.0 or newer.')
+@pytest.mark.parametrize('submodule', [
+    'color', 'data', 'draw', 'exposure', 'feature', 'filters', 'future',
+    'graph', 'io', 'measure', 'metrics', 'morphology', 'registration',
+    'restoration', 'segmentation', 'transform', 'util', 'viewer'
+])
+def test_skimage(pyi_builder, submodule):
+    pyi_builder.test_source("""
+        import skimage.{0}
+        """.format(submodule))


### PR DESCRIPTION
This PR adds a basic import test for `skimage` based on the issues encountered while solving pyinstaller/pyinstaller#5197. 

Based on the test failures under scikit-image 0.17.2, we need additional hooks for `skimage.feature` and `skimage.graph` to deal with the missing (sub)modules.