### PR TITLE
Exclude tinycss2 hook for versions after 1.0.0

### DIFF
--- a/news/54.update.rst
+++ b/news/54.update.rst
@@ -1,0 +1,1 @@
+Change hook for ``tinycss2``, no longer needed after version 1.0.0.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tinycss2.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tinycss2.py
@@ -12,11 +12,12 @@
 
 
 """
-Hook for tinycsss2. tinycss2 is a low-level CSS parser and generator.
+Hook for tinycss2. tinycss2 is a low-level CSS parser and generator.
 https://github.com/Kozea/tinycss2
 """
 from PyInstaller.utils.hooks import collect_data_files
 
 
+# Hook no longer required for tinycss2 >= 1.0.0
 def hook(hook_api):
     hook_api.add_datas(collect_data_files(hook_api.__name__))


### PR DESCRIPTION
tinycss2 https://github.com/Kozea/tinycss2/pull/27 updated the packaging which removes the need for a hook.