### PR TITLE
hooks: tensorflow: avoid collecting import libraries on Windows

### DIFF
--- a/news/55.update.rst
+++ b/news/55.update.rst
@@ -1,0 +1,1 @@
+(Windows) Avoid collecting ``tensorflow`` import libraries.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tensorflow.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tensorflow.py
@@ -23,10 +23,12 @@ tf_pre_2_2_0 = is_module_satisfies("tensorflow < 2.2.0")
 #  - development headers in include subdirectory
 #  - XLA AOT runtime sources
 #  - libtensorflow_framework shared library (to avoid duplication)
+#  - import library (.lib) files (Windows-only)
 data_excludes = [
     "include",
     "xla_aot_runtime_src",
-    "libtensorflow_framework.*"
+    "libtensorflow_framework.*",
+    "**/*.lib",
 ]
 
 # Under tensorflow 2.3.0 (the most recent version at the time of writing),


### PR DESCRIPTION
The import libraries should not be required at the runtime, and they drive up the resulting program size.

See discussion at pyinstaller/pyinstaller#5236.