### PR TITLE
hooks: compatibility fix for markdown 3.3

### DIFF
--- a/news/56.update.rst
+++ b/news/56.update.rst
@@ -1,0 +1,1 @@
+Compatibility fix for ``markdown`` 3.3.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-markdown.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-markdown.py
@@ -10,6 +10,11 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import collect_submodules, collect_data_files
+from PyInstaller.utils.hooks import is_module_satisfies, collect_submodules
 
 hiddenimports = collect_submodules('markdown.extensions')
+
+# Markdown 3.3 introduced markdown.htmlparser submodule with hidden
+# dependency on html.parser
+if is_module_satisfies("markdown >= 3.3"):
+    hiddenimports += ['html.parser']


### PR DESCRIPTION
Markdown 3.3 introduces a new htmlparser submodule with hidden dependency on html.parser.