### PR TITLE
hooks: Add hook for pydantic.

### DIFF
--- a/news/57.new.rst
+++ b/news/57.new.rst
@@ -1,0 +1,1 @@
+Add hook for pydantic.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
@@ -1,0 +1,35 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2005-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+# -----------------------------------------------------------------------------
+
+# pydatic ....
+
+hiddenimports = [
+    'pydantic.class_validators',
+    'pydantic.color', 'colorsys',
+    'pydantic.dataclasses',
+    'pydantic.datetime_parse',
+    'pydantic.decorator',
+    'pydantic.env_settings',
+    'pydantic.error_wrappers',
+    'pydantic.errors',
+    'pydantic.fields',
+    'pydantic.json', 'json', 'ipaddress', 'uuid',
+    'pydantic.main',
+    'pydantic.networks',
+    'pydantic.parse',
+    'pydantic.schema',
+    'pydantic.tools',
+    'pydantic.types',
+    'pydantic.typing',
+    'pydantic.utils',
+    'pydantic.validators',
+    'pydantic.version',
+]


### PR DESCRIPTION
pydanic is available in two flavours: a pure-python implementation and a
compiled implementation. This hook adds hidden imports required by the later
one.

This hook also requires https://github.com/pyinstaller/pyinstaller/pull/5157 to be merged.