### PR TITLE
hooks: add a hook for win32ctypes.core

### DIFF
--- a/news/58.new.rst
+++ b/news/58.new.rst
@@ -1,0 +1,1 @@
+(Windows) Add a hook for ``win32ctypes.core``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -37,5 +37,8 @@ uvloop==0.14.0; sys_platform != 'win32'
 # pydivert only runs on Windows
 pydivert==2.1.0; sys_platform == 'win32'
 
+# pywin32-ctypes runs on Windows
+pywin32-ctypes==0.2.0; sys_platform == 'win32'
+
 # Include the requirements for testing
 -r requirements-test.txt

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-win32ctypes.core.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-win32ctypes.core.py
@@ -1,0 +1,25 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import exec_statement, collect_submodules
+
+# We need to collect submodules from win32ctypes.core.cffi or
+# win32ctypes.core.ctypes for win32ctypes.core to work. The use of
+# the backend is determined by availability of cffi.
+cffi_available = exec_statement(
+    """try:import cffi;print('\\nTrue')\nexcept: print('\\nFalse')"""
+).split()[-1] == 'True'
+
+if cffi_available:
+    hiddenimports = collect_submodules('win32ctypes.core.cffi')
+else:
+    hiddenimports = collect_submodules('win32ctypes.core.ctypes')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -12,7 +12,7 @@
 
 import pytest
 
-from PyInstaller.compat import is_darwin
+from PyInstaller.compat import is_darwin, is_win
 from PyInstaller.utils.tests import importorskip, xfail, skipif_win
 from PyInstaller.utils.hooks import is_module_satisfies
 
@@ -391,4 +391,13 @@ def test_skimage(pyi_builder, submodule):
 def test_sklearn(pyi_builder, submodule):
     pyi_builder.test_source("""
         import sklearn.{0}
+        """.format(submodule))
+
+
+@importorskip('win32ctypes')
+@pytest.mark.skipif(not is_win, reason='pywin32-ctypes is supported only on Windows')
+@pytest.mark.parametrize('submodule', ['win32api', 'win32cred', 'pywintypes'])
+def test_pywin32ctypes(pyi_builder, submodule):
+    pyi_builder.test_source("""
+        from win32ctypes.pywin32 import {0}
         """.format(submodule))


### PR DESCRIPTION
We need a hook to collect all submodules from `win32ctypes.core.cffi` or `win32ctypes.core.ctypes` (depending on availability of `cffi`) to avoid missing module errors when using `win32ctypes` pywin32 compatibility layer.