### PR TITLE
hooks: zmq: avoid triggering compilation of C extension for cffi backend

### DIFF
--- a/news/59.update.rst
+++ b/news/59.update.rst
@@ -1,0 +1,1 @@
+Avoid collecting non-functional ``zmq.backend.cffi`` backend in the ``zmq`` hook, and thus also prevent an attempt at compilation of its C extension during module collection. 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-zmq.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-zmq.py
@@ -15,7 +15,17 @@
 Hook for PyZMQ. Cython based Python bindings for messaging library ZeroMQ.
 http://www.zeromq.org/
 """
-from PyInstaller.utils.hooks import collect_submodules, get_module_file_attribute
-from PyInstaller.compat import is_win
+from PyInstaller.utils.hooks import collect_submodules
 
-hiddenimports = ['zmq.utils.garbage'] + collect_submodules('zmq.backend')
+hiddenimports = ['zmq.utils.garbage']
+
+# PyZMQ comes with two backends, cython and cffi. Calling collect_submodules()
+# on zmq.backend seems to trigger attempt at compilation of C extension
+# module for cffi backend, which will fail if ZeroMQ development files
+# are not installed on the system. On non-English locales, the resulting
+# localized error messages may cause UnicodeDecodeError. Collecting each
+# backend individually, however, does not seem to cause any problems.
+hiddenimports += ['zmq.backend']
+
+hiddenimports += collect_submodules('zmq.backend.cython')
+hiddenimports += collect_submodules('zmq.backend.cffi')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-zmq.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-zmq.py
@@ -15,9 +15,10 @@
 Hook for PyZMQ. Cython based Python bindings for messaging library ZeroMQ.
 http://www.zeromq.org/
 """
-from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.utils.hooks import collect_submodules, collect_data_files
 
 hiddenimports = ['zmq.utils.garbage']
+datas = []
 
 # PyZMQ comes with two backends, cython and cffi. Calling collect_submodules()
 # on zmq.backend seems to trigger attempt at compilation of C extension
@@ -27,5 +28,10 @@ hiddenimports = ['zmq.utils.garbage']
 # backend individually, however, does not seem to cause any problems.
 hiddenimports += ['zmq.backend']
 
+# cython backend
 hiddenimports += collect_submodules('zmq.backend.cython')
+
+# cffi backend: contains extra data that needs to be collected
+# (e.g., _cdefs.h)
 hiddenimports += collect_submodules('zmq.backend.cffi')
+datas += collect_data_files('zmq.backend.cffi', excludes=['**/__pycache__', ])

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-zmq.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-zmq.py
@@ -15,10 +15,9 @@
 Hook for PyZMQ. Cython based Python bindings for messaging library ZeroMQ.
 http://www.zeromq.org/
 """
-from PyInstaller.utils.hooks import collect_submodules, collect_data_files
+from PyInstaller.utils.hooks import collect_submodules
 
 hiddenimports = ['zmq.utils.garbage']
-datas = []
 
 # PyZMQ comes with two backends, cython and cffi. Calling collect_submodules()
 # on zmq.backend seems to trigger attempt at compilation of C extension
@@ -33,5 +32,12 @@ hiddenimports += collect_submodules('zmq.backend.cython')
 
 # cffi backend: contains extra data that needs to be collected
 # (e.g., _cdefs.h)
-hiddenimports += collect_submodules('zmq.backend.cffi')
-datas += collect_data_files('zmq.backend.cffi', excludes=['**/__pycache__', ])
+#
+# NOTE: the cffi backend requires compilation of C extension at runtime,
+# which appears to be broken in frozen program. So avoid collecting
+# it altogether...
+if False:
+    from PyInstaller.utils.hooks import collect_data_files
+
+    hiddenimports += collect_submodules('zmq.backend.cffi')
+    datas = collect_data_files('zmq.backend.cffi', excludes=['**/__pycache__', ])


### PR DESCRIPTION
This PR aims to work around the `UnicodeDecodeError` issue from pyinstaller/pyinstaller#2258. Trying to collect all submodules of `zmq.backend` triggers compilation of C extension for the `cffi` backend (provided cffi and C compiler are installed), but individually collecting each backend submodule does not, which means no potentially breaking error messages from MSC on Windows.

After some more investigation, it turned out that cffi backend requires collection of data files; otherwise lack thereof triggers a file-not-found error when trying to import the backend module.

But even with that, the `cffi` backend does not seem to be usable in a frozen program, as its import fails with `Failed to import zm.backend.cffi: PyZMQ CFFI backend couldn't find zeromq: invalid command 'build`. The error originates from `cffi`/`distutils` itself, so perhaps something is broken there. (And even if that worked, ZeroMQ development files would need to be installed on the target machine). So in short, I suspect `cffi` backend never really worked, so there's little point in collecting it at all. I put the corresponding statements under `if False` as a sort of documentation, and in case anyone wants to try making it work.