### PR TITLE
 hooks: add hook for metpy 

### DIFF
--- a/news/60.new.rst
+++ b/news/60.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``metpy``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -16,6 +16,7 @@ iminuit==2.8.3
 langdetect==1.0.9
 mariadb==1.0.7; sys_platform != "darwin"
 markdown==3.3.4
+MetPy==1.1.0
 mnemonic==0.20
 msoffcrypto-tool==4.12.0
 Office365-REST-Python-Client==2.3.8

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-metpy.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-metpy.py
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata, collect_data_files
+
+# MetPy requires metadata, because it queries its version via
+# pkg_resources.get_distribution(__package__).version or, in newer
+# versions, importlib.metadata.version(__package__)
+datas = copy_metadata('metpy')
+
+# Collect data files
+datas += collect_data_files('metpy')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -809,3 +809,11 @@ def test_folium(pyi_builder):
         import folium
         m = folium.Map(location=[0, 0], zoom_start=5)
         """)
+
+
+@importorskip("metpy")
+def test_metpy(pyi_builder):
+    # Import metpy.plots, which triggers search for colortables data.
+    pyi_builder.test_source("""
+        import metpy.plots
+        """)


### PR DESCRIPTION
Partially fixes pyinstaller/pyinstaller#5247 (missing metadata and data files). Full fix requires pyinstaller/pyinstaller#5284, which is also required for the added test to pass.