### PR TITLE
hooks: add hook for branca

### DIFF
--- a/news/61.new.rst
+++ b/news/61.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``branca``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -3,6 +3,7 @@
 boto==2.49.0
 boto3==1.12.33
 botocore==1.15.33
+branca==0.4.1
 dash==1.19.0
 dash-bootstrap-components==0.12.0
 iminuit==1.4.0

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-branca.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-branca.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+# Collect data files
+datas = collect_data_files('branca')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -551,3 +551,10 @@ def test_dash_bootstrap_components(pyi_builder):
         app = dash.Dash(external_stylesheets=[dbc.themes.BOOTSTRAP])
         alert = dbc.Alert([html.H4('Well done!', className='alert-heading')])
         """)
+
+
+@importorskip('branca')
+def test_branca(pyi_builder):
+    pyi_builder.test_source("""
+        import branca
+        """)


### PR DESCRIPTION
Partially fixes pyinstaller/pyinstaller#5256 and pyinstaller/pyinstaller#5262 (missing data files for `branca`, which `folium` depends on). Full fix requires pyinstaller/pyinstaller#5284, which is also required for the added test to pass.