### PR TITLE
hooks: add hook for folium

### DIFF
--- a/news/62.new.rst
+++ b/news/62.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``folium``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -9,6 +9,7 @@ cloudscraper==1.2.58
 dash==2.0.0
 dash-bootstrap-components==0.13.0
 dash-uploader==0.5.0
+folium==0.12.1
 h5py==3.4.0; python_version >= '3.7'
 humanize==3.11.0
 iminuit==2.8.3

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-folium.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-folium.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+# Collect data files (templates)
+datas = collect_data_files("folium")

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -801,3 +801,11 @@ def test_branca(pyi_builder):
     pyi_builder.test_source("""
         import branca
         """)
+
+
+@importorskip("folium")
+def test_folium(pyi_builder):
+    pyi_builder.test_source("""
+        import folium
+        m = folium.Map(location=[0, 0], zoom_start=5)
+        """)


### PR DESCRIPTION
Partially fixes pyinstaller/pyinstaller#5256 and pyinstaller/pyinstaller#5262 (missing data files for `folium`). Full fix requires pyinstaller/pyinstaller#5284 and #61, which are also required for the added test to pass.