### PR TITLE
hooks: Add hook for ijson

### DIFF
--- a/news/64.new.rst
+++ b/news/64.new.rst
@@ -1,0 +1,1 @@
+Add hook for ijson which has dynamically loaded backends.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-ijson.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-ijson.py
@@ -1,0 +1,14 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_submodules
+hiddenimports = collect_submodules("ijson.backends")


### PR DESCRIPTION
Hook for the ijson package at: https://github.com/ICRAR/ijson

Ijson is an iterative JSON parser which is useful for reading very large json files. The backend modules necessary to run ijson are dynamically loaded hence the need for this hook.