### PR TITLE
hooks: Add hook for lxml

### DIFF
--- a/news/66.new.rst
+++ b/news/66.new.rst
@@ -1,0 +1,1 @@
+Add hook for lxml which has hidden imports.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-lxml.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-lxml.py
@@ -1,0 +1,20 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+#
+# lxml is not fully embedded when using standard hiddenimports
+# see https://github.com/pyinstaller/pyinstaller/issues/5306
+#
+# Tested with lxml 4.6.1
+
+from PyInstaller.utils.hooks import collect_submodules
+
+hiddenimports = collect_submodules('lxml')


### PR DESCRIPTION
lxml has hiddenimports and is not fully embedded when adding it to hiddenimports

`hiddenimports = ['lxml'] `is not enough
see https://github.com/pyinstaller/pyinstaller/issues/5306