### PR TITLE
hooks: win32com: avoid printing ModuleNotFindError when module is unavailable

### DIFF
--- a/news/67.update.rst
+++ b/news/67.update.rst
@@ -1,0 +1,2 @@
+(Windows) Fix the ``win32com`` pre-safe-import hook to avoid printing the
+``ModuleNotFoundError`` when the module is not available.

--- a/src/_pyinstaller_hooks_contrib/hooks/pre_safe_import_module/hook-win32com.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/pre_safe_import_module/hook-win32com.py
@@ -22,14 +22,25 @@ module 'win32com.shell' is in reality 'win32comext.shell'.
 
 import os
 
-from PyInstaller.utils.hooks import logger, get_module_file_attribute
+from PyInstaller.utils.hooks import logger, exec_statement
 from PyInstaller.compat import is_win, is_cygwin
 
 
 def pre_safe_import_module(api):
     if not (is_win or is_cygwin):
         return
-    win32com_dir = os.path.dirname(get_module_file_attribute('win32com'))
+    win32com_file = exec_statement(
+        """
+        try:
+            from win32com import __file__
+            print(__file__)
+        except Exception:
+            pass
+        """).strip()
+    if not win32com_file:
+        logger.debug('win32com: module not available')
+        return  # win32com unavailable
+    win32com_dir = os.path.dirname(win32com_file)
     comext_dir = os.path.join(os.path.dirname(win32com_dir), 'win32comext')
     logger.debug('win32com: extending __path__ with dir %r' % comext_dir)
     # Append the __path__ where PyInstaller will look for 'win32com' modules.'


### PR DESCRIPTION
Use a custom `exec_statement()` to query the `win32com.__file__` instead of using `get_module_file_attribute()`, as the latter
will print a `ModuleNotFindError` to stderr when the module is unavailable. The error message, while harmless, appears
to be bothering the users.

Fixes pyinstaller/pyinstaller#3733.