### PR TITLE
Add hook-gcloud.py

### DIFF
--- a/news/68.new.rst
+++ b/news/68.new.rst
@@ -1,1 +1,1 @@
-Add a hook for ``gcloud``
+Add a hook for ``gcloud`` which requires its distribution metadata.

--- a/news/68.new.rst
+++ b/news/68.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``gcloud``

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gcloud.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gcloud.py
@@ -1,0 +1,14 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata
+datas = copy_metadata('gcloud')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gcloud.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gcloud.py
@@ -10,5 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
+
 from PyInstaller.utils.hooks import copy_metadata
 datas = copy_metadata('gcloud')


### PR DESCRIPTION
Add hook-cloud.py: pyinstaller not working with pyrebase google module.

Fixes [#5316](https://github.com/pyinstaller/pyinstaller/issues/5316).


