### PR TITLE
hooks: Add hook for afmformats.

### DIFF
--- a/news/69.new.rst
+++ b/news/69.new.rst
@@ -1,0 +1,1 @@
+Add hook for afmformats.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-afmformats.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-afmformats.py
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# Hook for afmformats: https://pypi.python.org/pypi/afmformats
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('afmformats')


### PR DESCRIPTION
afmformats is a library for opening common atomic force microscopy (AFM) data files.
https://afmformats.readthedocs.io