### PR TITLE
hooks: update pyproj hook to improve compatibility across different versions

### DIFF
--- a/news/70.update.rst
+++ b/news/70.update.rst
@@ -1,0 +1,1 @@
+Update ``pyproj`` hook to improve compatibility across different versions of ``pyproj`` (from 2.1.3 to 3.0.0).

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -14,6 +14,7 @@ pycryptodome==3.9.7
 pycryptodomex==3.9.7
 pyexcelerate==0.8.0
 pylint==2.4.4
+pyproj==3.0.0
 pyusb==1.0.2
 pyzmq==19.0.0
 Unidecode==1.1.1

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -14,7 +14,6 @@ pycryptodome==3.9.7
 pycryptodomex==3.9.7
 pyexcelerate==0.8.0
 pylint==2.4.4
-pyproj==3.0.0
 pyusb==1.0.2
 pyzmq==19.0.0
 Unidecode==1.1.1

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyproj.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyproj.py
@@ -12,7 +12,7 @@
 
 import os
 import sys
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, is_module_satisfies
 from PyInstaller.compat import is_win
 
 
@@ -20,6 +20,18 @@ hiddenimports = [
     "pyproj.datadir"
 ]
 
+# Versions prior to 2.3.0 also require pyproj._datadir
+if not is_module_satisfies("pyproj >= 2.3.0"):
+    hiddenimports += ["pyproj._datadir"]
+
+# Starting with version 3.0.0, pyproj._compat is needed
+if is_module_satisfies("pyproj >= 3.0.0"):
+    hiddenimports += ["pyproj._compat"]
+    # Linux and macOS also require distutils.
+    if not is_win:
+        hiddenimports += ["distutils.util"]
+
+# Data collection
 datas = collect_data_files('pyproj')
 
 if hasattr(sys, 'real_prefix'):  # check if in a virtual environment

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -402,3 +402,23 @@ def test_pywin32ctypes(pyi_builder, submodule):
     pyi_builder.test_source("""
         from win32ctypes.pywin32 import {0}
         """.format(submodule))
+
+
+@importorskip('pyproj')
+@pytest.mark.skipif(not is_module_satisfies('pyproj >= 2.1.3'),
+                    reason='The test supports only pyproj >= 2.1.3.')
+def test_pyproj(pyi_builder):
+    pyi_builder.test_source("""
+        import pyproj
+        tf = pyproj.Transformer.from_crs(
+            7789,
+            8401
+        )
+        result = tf.transform(
+            xx=3496737.2679,
+            yy=743254.4507,
+            zz=5264462.9620,
+            tt=2019.0
+        )
+        print(result)
+        """)


### PR DESCRIPTION
On versions prior to 2.3.0, we require a hidden import of `pyproj._datadir`.

On versions 3.0.0 or newer, we require a hidden import of `pyproj._compat`, and on linux/macOS also `distutils.util`.

This allows the test to pass under wide range of pyproj versions, from 2.1.3 to 3.0.0.