### PR TITLE
Add default enabled sentry integrations dynamically to hidden imports

### DIFF
--- a/news/71.update.rst
+++ b/news/71.update.rst
@@ -1,0 +1,1 @@
+Add default enabled sentry integrations dynamically to hidden imports.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -18,7 +18,7 @@ pyusb==1.0.2
 pyzmq==19.0.0
 Unidecode==1.1.1
 zeep==3.4.0
-sentry-sdk==0.15.1
+sentry-sdk==0.19.3
 av==8.0.2
 passlib==1.7.2
 publicsuffix2==2.20191221

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sentry_sdk.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sentry_sdk.py
@@ -37,4 +37,3 @@ if hasattr(si, '_AUTO_ENABLING_INTEGRATIONS'):
 """
 
 hiddenimports.extend(json.loads(exec_statement(statement)))
-

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sentry_sdk.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sentry_sdk.py
@@ -27,7 +27,7 @@ import sentry_sdk.integrations as si
 
 integrations = []
 if hasattr(si, '_AUTO_ENABLING_INTEGRATIONS'):
-    # _AUTO_ENABLING_INTEGRATIONS is a list of strings with default enabled integrations 
+    # _AUTO_ENABLING_INTEGRATIONS is a list of strings with default enabled integrations
     # https://github.com/getsentry/sentry-python/blob/c6b6f2086b58ffc674df5c25a600b8a615079fb5/sentry_sdk/integrations/__init__.py#L54-L66
 
     def make_integration_name(integration_name: str):

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sentry_sdk.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sentry_sdk.py
@@ -22,6 +22,6 @@ hiddenimports = ["sentry_sdk.integrations.stdlib",
 
 if hasattr(si, '_AUTO_ENABLING_INTEGRATIONS'):
     def make_integration_name(integration_name: str):
-        return ".".join(integration_name.split(".")[:-1])
+        return integration_name.rsplit(".", maxsplit=1)[0]
 
     hiddenimports.extend(map(make_integration_name, si._AUTO_ENABLING_INTEGRATIONS))

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sentry_sdk.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sentry_sdk.py
@@ -9,7 +9,8 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-import sentry_sdk.integrations as si
+import json
+from PyInstaller.utils.hooks import exec_statement
 
 hiddenimports = ["sentry_sdk.integrations.stdlib",
                  "sentry_sdk.integrations.excepthook",
@@ -20,8 +21,20 @@ hiddenimports = ["sentry_sdk.integrations.stdlib",
                  "sentry_sdk.integrations.logging",
                  "sentry_sdk.integrations.threading"]
 
+statement = """
+import json
+import sentry_sdk.integrations as si
+
+integrations = []
 if hasattr(si, '_AUTO_ENABLING_INTEGRATIONS'):
+    # _AUTO_ENABLING_INTEGRATIONS is a list of strings with default enabled integrations 
+    # https://github.com/getsentry/sentry-python/blob/c6b6f2086b58ffc674df5c25a600b8a615079fb5/sentry_sdk/integrations/__init__.py#L54-L66
+
     def make_integration_name(integration_name: str):
         return integration_name.rsplit(".", maxsplit=1)[0]
 
-    hiddenimports.extend(map(make_integration_name, si._AUTO_ENABLING_INTEGRATIONS))
+    print(json.dumps(integrations.extend(map(make_integration_name, si._AUTO_ENABLING_INTEGRATIONS))))
+"""
+
+hiddenimports.extend(json.loads(exec_statement(statement)))
+

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sentry_sdk.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sentry_sdk.py
@@ -9,6 +9,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
+import sentry_sdk.integrations as si
 
 hiddenimports = ["sentry_sdk.integrations.stdlib",
                  "sentry_sdk.integrations.excepthook",
@@ -18,3 +19,10 @@ hiddenimports = ["sentry_sdk.integrations.stdlib",
                  "sentry_sdk.integrations.argv",
                  "sentry_sdk.integrations.logging",
                  "sentry_sdk.integrations.threading"]
+
+if hasattr(si, '_AUTO_ENABLING_INTEGRATIONS'):
+    def make_integration_name(integration_name: str):
+        return ".".join(integration_name.split(".")[:-1])
+
+
+    hiddenimports.extend(map(make_integration_name, si._AUTO_ENABLING_INTEGRATIONS))

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sentry_sdk.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sentry_sdk.py
@@ -24,5 +24,4 @@ if hasattr(si, '_AUTO_ENABLING_INTEGRATIONS'):
     def make_integration_name(integration_name: str):
         return ".".join(integration_name.split(".")[:-1])
 
-
     hiddenimports.extend(map(make_integration_name, si._AUTO_ENABLING_INTEGRATIONS))

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sentry_sdk.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sentry_sdk.py
@@ -33,7 +33,8 @@ if hasattr(si, '_AUTO_ENABLING_INTEGRATIONS'):
     def make_integration_name(integration_name: str):
         return integration_name.rsplit(".", maxsplit=1)[0]
 
-    print(json.dumps(integrations.extend(map(make_integration_name, si._AUTO_ENABLING_INTEGRATIONS))))
+    integrations.extend(map(make_integration_name, si._AUTO_ENABLING_INTEGRATIONS))
+print(json.dumps(integrations))
 """
 
 hiddenimports.extend(json.loads(exec_statement(statement)))


### PR DESCRIPTION
Sentry added in PR getsentry/sentry-python#625 by default enabled integrations. We need to add them to the hidden imports to be able to launch a application with sentry.

I added the hasattr check for backwards compatibility