### PR TITLE
Add hook for pydantic

### DIFF
--- a/news/78.new.rst
+++ b/news/78.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``pydantic`` to improve support for its extension-compiled
+distribution (default on PyPi).

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
@@ -10,24 +10,15 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import exec_statement, collect_submodules
+from PyInstaller.utils.hooks import get_module_attribute, collect_submodules
 
 # By default, pydantic from PyPi comes with all modules compiled as
-# cpython extensions, which seems to  prevent the pyinstaller from
-# automatically picking the submodules
-is_compiled = exec_statement(
-    """
-        import pydantic
-        if pydantic.compiled:
-            print('\\nTrue')
-        else:
-            print('\\nFalse')
-    """
-).split()[-1] == 'True'
-
+# cpython extensions, which seems to prevent pyinstaller from automatically
+# picking up the submodules
+is_compiled = get_module_attribute('pydantic', 'compiled') == 'True'
 if is_compiled:
     # Compiled version; we need to manually collect the submodules from
-    # pyadantic...
+    # pydantic...
     hiddenimports = collect_submodules('pydantic')
     # ... as well as the following modules from the standard library
     hiddenimports += [

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
@@ -1,0 +1,40 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import exec_statement, collect_submodules
+
+# By default, pydantic from PyPi comes with all modules compiled as
+# cpython extensions, which seems to  prevent the pyinstaller from
+# automatically picking the submodules
+is_compiled = exec_statement(
+    """
+        import pydantic
+        if pydantic.compiled:
+            print('\\nTrue')
+        else:
+            print('\\nFalse')
+    """
+).split()[-1] == 'True'
+
+if is_compiled:
+    # Compiled version; we need to manually collect the submodules from
+    # pyadantic...
+    hiddenimports = collect_submodules('pydantic')
+    # ... as well as the following modules from the standard library
+    hiddenimports += [
+        'colorsys',
+        'decimal',
+        'json',
+        'ipaddress',
+        'pathlib',
+        'uuid',
+    ]

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -422,3 +422,10 @@ def test_pyproj(pyi_builder):
         )
         print(result)
         """)
+
+
+@importorskip('pydantic')
+def test_pydantic(pyi_builder):
+    pyi_builder.test_source("""
+        import pydantic
+        """)


### PR DESCRIPTION
The PyPi version of `pydantic` comes with all its modules compiled as cpython extensions. This prevents `pyinstaller` from properly discovering the dependant modules, both from the `pydantic` package itself and from the standard library.

Fixes pyinstaller/pyinstaller#5359.