### PR TITLE
tests: define the darwin/linux/win32 pytest markers

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,7 @@
 [pytest]
 addopts=--maxfail=3
+
+markers =
+    darwin: only run on macOS
+    linux: only runs on GNU/Linux
+    win32: only runs on Windows


### PR DESCRIPTION
In order to avoid `PytestUnknownMarkWarning` warnings.