### PR TITLE
hooks: pydantic: add missing dataclasses and distutils.version hidden imports

### DIFF
--- a/news/81.update.rst
+++ b/news/81.update.rst
@@ -1,0 +1,1 @@
+Add missing ``dataclasses`` hidden import to ``pydantic`` hook.

--- a/news/81.update.rst
+++ b/news/81.update.rst
@@ -1,1 +1,3 @@
 Add missing ``dataclasses`` hidden import to ``pydantic`` hook.
+Add missing ``distutils.version`` hidden import to ``pydantic`` hook for
+versions of ``pydantic`` prior to ``1.4``.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
@@ -11,6 +11,7 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import get_module_attribute, collect_submodules
+from PyInstaller.utils.hooks import is_module_satisfies
 
 # By default, pydantic from PyPi comes with all modules compiled as
 # cpython extensions, which seems to prevent pyinstaller from automatically
@@ -30,3 +31,6 @@ if is_compiled:
         'pathlib',
         'uuid',
     ]
+    # Older releases (prior 1.4) also import distutils.version
+    if not is_module_satisfies('pydantic >= 1.4'):
+        hiddenimports += ['distutils.version']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
@@ -23,6 +23,7 @@ if is_compiled:
     # ... as well as the following modules from the standard library
     hiddenimports += [
         'colorsys',
+        'dataclasses',
         'decimal',
         'json',
         'ipaddress',


### PR DESCRIPTION
Addendum to previous attempt at the `pydantic` hook (#78).

As established in pyinstaller/pyinstaller#5432, the `dataclasses` module from standard library also needs to be added to `hiddenimports`. In older versions of compiled `pydantic`, this missing module would cause an error when importing `pydantic` itself (https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/78#issuecomment-739382401), while in newer ones the import is done within the functions and so the error is deferred until the function call.

Therefore, this partially addresses [the failing linux test from the previous one-shot test](https://github.com/rokm/pyinstaller-hooks-contrib/actions/runs/402946595). Afterwards, another issue crops up; versions of `pydantic` prior to 1.4 use `distutils.version` in `pydantic.version`, so that needs to be added to hidden imports as well (although judging by the tests, this actually affects only linux - presumably on other platforms, `distutils` is already pulled in by some other dependency).

Now, the pydantic import test passes on all tested versions [on Windows and Linux](https://github.com/rokm/pyinstaller-hooks-contrib/actions/runs/456533325), as well as [on macOS](https://github.com/rokm/pyinstaller-hooks-contrib/actions/runs/456542698).