### PR TITLE
hooks: add hook for googleapiclient.model

### DIFF
--- a/news/82.new.rst
+++ b/news/82.new.rst
@@ -1,0 +1,2 @@
+Add a hook for ``googleapiclient.model`` that collects the required
+metadata from the ``google-api-python-client`` package.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-googleapiclient.model.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-googleapiclient.model.py
@@ -1,0 +1,18 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata
+
+# googleapiclient.model queries the library version via
+# pkg_resources.get_distribution("google-api-python-client").version,
+# so we need to collect that package's metadata
+datas = copy_metadata('google_api_python_client')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -468,7 +468,4 @@ def test_torchvision_nms(pyi_builder):
 def test_googleapiclient(pyi_builder):
     pyi_builder.test_source("""
         from googleapiclient.discovery import build
-        # Actual access to the service requires API key...
-        #service = build('drive', 'v3')
-        #service.close()
-    """)
+        """)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -462,3 +462,13 @@ def test_torchvision_nms(pyi_builder):
         # is discarded.
         assert keep == 1
     """)
+
+
+@importorskip('googleapiclient')
+def test_googleapiclient(pyi_builder):
+    pyi_builder.test_source("""
+        from googleapiclient.discovery import build
+        # Actual access to the service requires API key...
+        #service = build('drive', 'v3')
+        #service.close()
+    """)


### PR DESCRIPTION
The `googleapiclient.model` module uses `pkg_resources` and its `get_distribution()` function to query the version of `google-api-python-client` package, therefore we need to collect its metadata.

Fixes pyinstaller/pyinstaller#5332.
Fixes #14.