### PR TITLE
Added hook for pdfminer.six library.

### DIFF
--- a/news/83.new.rst
+++ b/news/83.new.rst
@@ -1,0 +1,1 @@
+Added a hook for 'pdfminer.six' library

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pdfminer.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pdfminer.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('pdfminer')


### PR DESCRIPTION
Pdfminer.six library was not extracting some Japanese texts from a
PDF file after being bundled with Pyinstaller.
Fixes #5509