### PR TITLE
Add hook for the pygraphviz library

### DIFF
--- a/news/86.new.rst
+++ b/news/86.new.rst
@@ -1,0 +1,1 @@
+Added a hook for the 'pygraphviz' library

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pygraphviz.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pygraphviz.py
@@ -1,0 +1,41 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+import glob
+import os
+import shutil
+
+from PyInstaller.compat import is_win, is_darwin
+
+binaries = []
+datas = []
+
+if is_darwin:
+    # The dot binary in PATH is typically a symlink, handle that.
+    # graphviz_bindir is e.g. /usr/local/Cellar/graphviz/2.46.0/bin
+    graphviz_bindir = os.path.dirname(os.path.realpath(shutil.which("dot")))
+    for binary in glob.glob(graphviz_bindir + "/*"):
+        binaries.append((binary, "."))
+    # graphviz_bindir is e.g. /usr/local/Cellar/graphviz/2.46.0/lib/graphviz
+    graphviz_libdir = os.path.realpath(graphviz_bindir + "/../lib/graphviz")
+    for binary in glob.glob(graphviz_libdir + "/*.dylib"):
+        binaries.append((binary, "graphviz"))
+    for data in glob.glob(graphviz_libdir + "/config*"):
+        datas.append((data, "graphviz"))
+
+if is_win:
+    for binary in glob.glob("c:/Program Files/Graphviz*/bin/*.exe"):
+        binaries.append((binary, "."))
+    for binary in glob.glob("c:/Program Files/Graphviz*/bin/*.dll"):
+        binaries.append((binary, "."))
+    for data in glob.glob("c:/Program Files/Graphviz*/bin/config*"):
+        datas.append((data, "."))


### PR DESCRIPTION
pygraphviz assumes a working graphviz installation.
https://graphviz.org/download/ recommends `brew install graphviz` on
macOS and `choco install graphviz` on Windows, so look for the graphviz
binaries / configs where those tools install by default.