### PR TITLE
pygraphviz hook: check for executables based on a list

### DIFF
--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pygraphviz.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pygraphviz.py
@@ -19,12 +19,30 @@ from PyInstaller.compat import is_win, is_darwin
 binaries = []
 datas = []
 
+# List of binaries agraph.py may invoke.
+progs = [
+    "neato",
+    "dot",
+    "twopi",
+    "circo",
+    "fdp",
+    "nop",
+    "acyclic",
+    "gvpr",
+    "gvcolor",
+    "ccomps",
+    "sccmap",
+    "tred",
+    "sfdp",
+    "unflatten",
+]
+
 if is_darwin:
     # The dot binary in PATH is typically a symlink, handle that.
     # graphviz_bindir is e.g. /usr/local/Cellar/graphviz/2.46.0/bin
     graphviz_bindir = os.path.dirname(os.path.realpath(shutil.which("dot")))
-    for binary in glob.glob(graphviz_bindir + "/*"):
-        binaries.append((binary, "."))
+    for binary in progs:
+        binaries.append((graphviz_bindir + "/" + binary, "."))
     # graphviz_bindir is e.g. /usr/local/Cellar/graphviz/2.46.0/lib/graphviz
     graphviz_libdir = os.path.realpath(graphviz_bindir + "/../lib/graphviz")
     for binary in glob.glob(graphviz_libdir + "/*.dylib"):
@@ -33,8 +51,9 @@ if is_darwin:
         datas.append((data, "graphviz"))
 
 if is_win:
-    for binary in glob.glob("c:/Program Files/Graphviz*/bin/*.exe"):
-        binaries.append((binary, "."))
+    for prog in progs:
+        for binary in glob.glob("c:/Program Files/Graphviz*/bin/" + prog + ".exe"):
+            binaries.append((binary, "."))
     for binary in glob.glob("c:/Program Files/Graphviz*/bin/*.dll"):
         binaries.append((binary, "."))
     for data in glob.glob("c:/Program Files/Graphviz*/bin/config*"):


### PR DESCRIPTION
Instead of a brute-force glob. This paves the way to get the hook
working on Linux as well, where bundling /usr/bin/* is obviously a
no-go.

See
<https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/86#issuecomment-774312818>
for more details.