### PR TITLE
hooks: update pydantic hook for compatibility with v.1.8.0 and later

### DIFF
--- a/news/90.update.rst
+++ b/news/90.update.rst
@@ -1,0 +1,1 @@
+Update ``pydantic`` hook for compatibility with v.1.8.0 and later.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
@@ -34,3 +34,6 @@ if is_compiled:
     # Older releases (prior 1.4) also import distutils.version
     if not is_module_satisfies('pydantic >= 1.4'):
         hiddenimports += ['distutils.version']
+    # Version 1.8.0 introduced additional dependency on typing_extensions
+    if is_module_satisfies('pydantic >= 1.8'):
+        hiddenimports += ['typing_extensions']


### PR DESCRIPTION
Pydantic 1.8.0 introduced additional dependency on `typing_extensions` module, which needs to be added to `hiddenimports` for the compiled version of pydantic.

Fixes pyinstaller/pyinstaller#5603.