### PR TITLE
macOS CI: replace python 3.5 with 3.9

### DIFF
--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         pyinstaller: [PyInstaller, "https://github.com/pyinstaller/pyinstaller/archive/develop.zip"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
         pyinstaller: [PyInstaller, "https://github.com/pyinstaller/pyinstaller/archive/develop.zip"]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Also, disable `fast-fail` so we can get the full picture about failing tests.