### PR TITLE
CI: replace python 3.5 with 3.9 on AppVeyor and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
   include:
     - &test
       stage: PyInstaller stable release
-      python: 3.8
+      python: 3.9
       install:
         # Upgrade to the latest pip.
         - python -m pip install -U pip setuptools wheel
@@ -48,21 +48,21 @@ jobs:
         - pip install https://github.com/pyinstaller/pyinstaller/archive/develop.tar.gz
      
     - <<: *test
+      python: 3.8
+    - <<: *test
       python: 3.7
     - <<: *test
       python: 3.6
-    - <<: *test
-      python: 3.5
     
     - <<: *test
       stage: PyInstaller development version
+      python: 3.8
+      install: *install-develop
+    - <<: *test
+      stage: PyInstaller development version
       python: 3.7
       install: *install-develop
     - <<: *test
       stage: PyInstaller development version
       python: 3.6
-      install: *install-develop
-    - <<: *test
-      stage: PyInstaller development version
-      python: 3.5
       install: *install-develop

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,11 @@ environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
   matrix:
+    - PYTHON: C:\Python39
+      PYTHON_VERSION: "3.9"
+      INSTALL_URL: pyinstaller  # INSTALL_URL is passed straight to pip with `pip install INSTALL_URL`.
+      USE_DEV: "False"
+
     - PYTHON: C:\Python38
       PYTHON_VERSION: "3.8"
       INSTALL_URL: pyinstaller  # INSTALL_URL is passed straight to pip with `pip install INSTALL_URL`.
@@ -23,12 +28,12 @@ environment:
       PYTHON_VERSION: "3.6"
       INSTALL_URL: pyinstaller
       USE_DEV: "False"
-
-    - PYTHON: C:\Python35
-      PYTHON_VERSION: "3.5"
-      INSTALL_URL: pyinstaller
-      USE_DEV: "False"
     
+    - PYTHON: C:\Python39
+      PYTHON_VERSION: "3.9"
+      INSTALL_URL: "https://github.com/pyinstaller/pyinstaller/archive/develop.tar.gz"
+      USE_DEV: "True"
+
     - PYTHON: C:\Python38
       PYTHON_VERSION: "3.8"
       INSTALL_URL: "https://github.com/pyinstaller/pyinstaller/archive/develop.tar.gz"
@@ -41,11 +46,6 @@ environment:
 
     - PYTHON: C:\Python36
       PYTHON_VERSION: "3.6"
-      INSTALL_URL: "https://github.com/pyinstaller/pyinstaller/archive/develop.tar.gz"
-      USE_DEV: "True"
-
-    - PYTHON: C:\Python35
-      PYTHON_VERSION: "3.5"
       INSTALL_URL: "https://github.com/pyinstaller/pyinstaller/archive/develop.tar.gz"
       USE_DEV: "True"
 


### PR DESCRIPTION
Missed these two in the previous PR...