### PR TITLE
pygraphviz hook: add Linux support

### DIFF
--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pygraphviz.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pygraphviz.py
@@ -15,6 +15,7 @@ import os
 import shutil
 
 from PyInstaller.compat import is_win, is_darwin
+from PyInstaller.depend.bindepend import findLibrary
 
 binaries = []
 datas = []
@@ -37,19 +38,6 @@ progs = [
     "unflatten",
 ]
 
-if is_darwin:
-    # The dot binary in PATH is typically a symlink, handle that.
-    # graphviz_bindir is e.g. /usr/local/Cellar/graphviz/2.46.0/bin
-    graphviz_bindir = os.path.dirname(os.path.realpath(shutil.which("dot")))
-    for binary in progs:
-        binaries.append((graphviz_bindir + "/" + binary, "."))
-    # graphviz_bindir is e.g. /usr/local/Cellar/graphviz/2.46.0/lib/graphviz
-    graphviz_libdir = os.path.realpath(graphviz_bindir + "/../lib/graphviz")
-    for binary in glob.glob(graphviz_libdir + "/*.dylib"):
-        binaries.append((binary, "graphviz"))
-    for data in glob.glob(graphviz_libdir + "/config*"):
-        datas.append((data, "graphviz"))
-
 if is_win:
     for prog in progs:
         for binary in glob.glob("c:/Program Files/Graphviz*/bin/" + prog + ".exe"):
@@ -58,3 +46,21 @@ if is_win:
         binaries.append((binary, "."))
     for data in glob.glob("c:/Program Files/Graphviz*/bin/config*"):
         datas.append((data, "."))
+else:
+    # The dot binary in PATH is typically a symlink, handle that.
+    # graphviz_bindir is e.g. /usr/local/Cellar/graphviz/2.46.0/bin
+    graphviz_bindir = os.path.dirname(os.path.realpath(shutil.which("dot")))
+    for binary in progs:
+        binaries.append((graphviz_bindir + "/" + binary, "."))
+    if is_darwin:
+        suffix = "dylib"
+        # graphviz_libdir is e.g. /usr/local/Cellar/graphviz/2.46.0/lib/graphviz
+        graphviz_libdir = os.path.realpath(graphviz_bindir + "/../lib/graphviz")
+    else:
+        suffix = "so"
+        # graphviz_libdir is e.g. /usr/lib64/graphviz
+        graphviz_libdir = os.path.join(os.path.dirname(findLibrary('libcdt')), 'graphviz')
+    for binary in glob.glob(graphviz_libdir + "/*." + suffix):
+        binaries.append((binary, "graphviz"))
+    for data in glob.glob(graphviz_libdir + "/config*"):
+        datas.append((data, "graphviz"))


### PR DESCRIPTION
See
<https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/86#pullrequestreview-584684190>,
this was not done before due to an implicit list of executables, which
is no longer a problem.

Keep the logic as "if windows, else if macos, else", so it can cover not
only Linux, but other similar cases (BSD, etc).