### PR TITLE
Added googleapiclient.discovery

### DIFF
--- a/news/97.update.rst
+++ b/news/97.update.rst
@@ -1,0 +1,2 @@
+Add ```googleapiclient.discovery``` json files to work with services
+like Blogger v3 on the ```build()``` method.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-googleapiclient.model.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-googleapiclient.model.py
@@ -11,8 +11,10 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import copy_metadata
+from PyInstaller.utils.hooks import collect_data_files
 
 # googleapiclient.model queries the library version via
 # pkg_resources.get_distribution("google-api-python-client").version,
 # so we need to collect that package's metadata
 datas = copy_metadata('google_api_python_client')
+datas += collect_data_files('googleapiclient.discovery', include_py_files=True, excludes=['*.txt', '**/__pycache__'])

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-googleapiclient.model.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-googleapiclient.model.py
@@ -17,4 +17,4 @@ from PyInstaller.utils.hooks import collect_data_files
 # pkg_resources.get_distribution("google-api-python-client").version,
 # so we need to collect that package's metadata
 datas = copy_metadata('google_api_python_client')
-datas += collect_data_files('googleapiclient.discovery', include_py_files=True, excludes=['*.txt', '**/__pycache__'])
+datas += collect_data_files('googleapiclient.discovery', excludes=['*.txt', '**/__pycache__'])


### PR DESCRIPTION
Implements the fix commented [here](https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/82#issuecomment-796438598) on #82.
TL;DR: Using google-api-python-client for Blogger API causes `build()` method to raise error and None value due to missing `googleapiclient.discovery` files.