### PR TITLE
hooks: update zmq hook for compatibility with version 22.0.0+ on Windows

### DIFF
--- a/news/98.update.rst
+++ b/news/98.update.rst
@@ -1,0 +1,2 @@
+(Windows) Update ``zmq`` hook for compatibility with new shared libraries 
+location in Windows build of ``pyzmq`` 22.0.0 and later.


### PR DESCRIPTION
Windows wheel of `pyzmq` 22.0.0 introduced separate shared library directory in `site-packages/pyzmq.libs` which is dynamically added to the path and hence eludes our binary analysis.

There's also a `.load_order` file in there that needs to be collected for python versions older than 3.8 (and is also needed on newer
versions to ensure that `pyzmq.libs` directory is created).