### PR TITLE
Add hook for pyttsx3.

### DIFF
--- a/.github/workflows/oneshot-test.yml
+++ b/.github/workflows/oneshot-test.yml
@@ -34,6 +34,12 @@ on:
         description: 'Terminate all tests if one fails (true/false).'
         required: true
         default: 'false'
+      commands:
+        description: |
+          Additional installation commands to run from terminal.
+          Ran from bash irregardless of OS.
+          Use ';' to separate multiple commands.
+        required: false
 
 jobs:
   generate-matrix:
@@ -97,6 +103,10 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Run bash commands
+        if: ${{ github.event.inputs.commands }}
+        run: ${{ github.event.inputs.commands }}
 
       - name: Install dependencies
         run: |

--- a/news/101.new.rst
+++ b/news/101.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``pyttsx3`` whose drivers are hidden imports.

--- a/scripts/cloud-test.py
+++ b/scripts/cloud-test.py
@@ -88,7 +88,7 @@ def _norm_comma_space(x):
     return re.sub(", *", ", ", x)
 
 
-PYTHONS = ["3.5", "3.6", "3.7", "3.8"]
+PYTHONS = ["3.6", "3.7", "3.8", "3.9"]
 OSs = ["ubuntu", "windows", "macos"]
 
 

--- a/scripts/cloud-test.py
+++ b/scripts/cloud-test.py
@@ -106,10 +106,13 @@ OSs = ["ubuntu", "windows", "macos"]
               help="Which fork of pyinstaller-hooks-contrib to use. Defaults to the fork of the authenticated user.")
 @click.option("--branch", default=None,
               help="The branch to test. Defaults to using git to get your currently active branch.")
+@click.option("--commands", multiple=True,
+              help="Additional bash installation commands to run. Ran after setting up Python but before pip-installing"
+                   "dependencies.")
 @click.option("--browser", default=False, is_flag=True,
               help="Open the live build on Github in a browser window.")
 @click.option("--dry-run", is_flag=True, help="Don't launch a build. Just parse and print the parameters.")
-def main(package, py, os, fork, branch, fail_fast, browser, dry_run):
+def main(package, py, os, fork, branch, fail_fast, commands, browser, dry_run):
     """Launch CI testing of a given package against multiple package or Python versions and OSs.
 
     The **package** specifies only those to install. Which tests should be ran is inferred implicitly by
@@ -156,7 +159,8 @@ def main(package, py, os, fork, branch, fail_fast, browser, dry_run):
         "python-version": _norm_comma_space(",".join(py)),
         "package": _norm_comma_space(package),
         "os": _norm_comma_space(",".join(os).lower()),
-        "fail-fast": str(fail_fast).lower()
+        "fail-fast": str(fail_fast).lower(),
+        "commands": "; ".join(commands),
     }
 
     print("Configuration options to be passed to CI:")

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyttsx3.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyttsx3.py
@@ -1,0 +1,30 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# pyttsx3 conditionally imports drivers module based on specific platform.
+# https://github.com/nateshmbhat/pyttsx3/blob/5a19376a94fdef6bfaef8795539e755b1f363fbf/pyttsx3/driver.py#L40-L50
+
+import sys
+
+hiddenimports = ["pyttsx3.drivers", "pyttsx3.drivers.dummy"]
+
+# Take directly from the link above.
+if sys.platform == 'darwin':
+    driverName = 'nsss'
+elif sys.platform == 'win32':
+    driverName = 'sapi5'
+else:
+    driverName = 'espeak'
+# import driver module
+name = 'pyttsx3.drivers.%s' % driverName
+
+hiddenimports.append(name)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -197,6 +197,14 @@ def test_pyttsx(pyi_builder):
         """)
 
 
+@importorskip('pyttsx3')
+def test_pyttsx3(pyi_builder):
+    pyi_builder.test_source("""
+        import pyttsx3
+        engine = pyttsx3.init()
+    """)
+
+
 @importorskip('pycparser')
 def test_pycparser(pyi_builder):
     pyi_builder.test_script('pyi_lib_pycparser.py')


### PR DESCRIPTION
Add hook for `pyttxs3`. Fixes pyinstaller/pyinstaller#3268 and a rather long [nabble thread](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/pyinstaller/IJXFdvIs--0/D85e6cD7AQAJ).

We do have a hook and test already for `pyttxs` (without the `3`) which is handled similarly but I'd prefer to keep them separate.

There's also a couple of extra commits tucked under here which I can't be bothered to separate into their own PRs. I'll merge this manually to keep the git history.

- 112f500 CI/CD: Oneshot: Allow custom bash install commands. This is so I can run any `sudo apt install [dependencies]` when needed.
- a7fedf0 CI/CD: Oneshot: Remove Python 3.5, add 3.9.

I've done oneshot testing in bits:

- [scripts/cloud-test.py --os=windows --os=macos pyttsx3==2.90, pyttsx3==2.71](https://github.com/bwoodsend/pyinstaller-hooks-contrib/runs/2156860672)
- [scripts/cloud-test.py --os=windows --os=macos --py=all pyttsx3](https://github.com/bwoodsend/pyinstaller-hooks-contrib/actions/runs/671614327)
- [scripts/cloud-test.py --commands="sudo apt install espeak ffmpeg libespeak1" pyttsx3==2.90, pyttsx3==2.71](https://github.com/bwoodsend/pyinstaller-hooks-contrib/actions/runs/671623657)
- [scripts/cloud-test.py --commands="sudo apt install espeak ffmpeg libespeak1" --py=all pyttsx3](https://github.com/bwoodsend/pyinstaller-hooks-contrib/actions/runs/671621133)

They all pass.



