### PR TITLE
Add hooks for dash and related packages (#102)

### DIFF
--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -34,7 +34,7 @@ jobs:
 
           # Install hooks-contrib
           pip install -e .
-          pip install -r requirements-test-libraries.txt
+          pip install --prefer-binary -r requirements-test-libraries.txt
 
           # Install PyInstaller
           pip install ${{ matrix.pyinstaller }}

--- a/news/103.new.rst
+++ b/news/103.new.rst
@@ -1,2 +1,3 @@
 Add hook for ``plotly`` to collect data files and hidden `pandas`, `cmath`, and `plotly.validator` imports
 Add hooks for ``dash`` and related packages to collect data files and hook for meta-data from ``flask-compress``
+Add hook for ``dash_bootstrap_components`` to collect data files

--- a/news/103.new.rst
+++ b/news/103.new.rst
@@ -1,3 +1,5 @@
 Add hook for ``plotly`` to collect data files and hidden `pandas`, `cmath`, and `plotly.validator` imports
+
 Add hooks for ``dash`` and related packages to collect data files and hook for meta-data from ``flask-compress``
+
 Add hook for ``dash_bootstrap_components`` to collect data files

--- a/news/103.new.rst
+++ b/news/103.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``plotly`` to collect data files and hidden `pandas`, `cmath`, and `plotly.validator` imports

--- a/news/103.new.rst
+++ b/news/103.new.rst
@@ -1,1 +1,2 @@
 Add hook for ``plotly`` to collect data files and hidden `pandas`, `cmath`, and `plotly.validator` imports
+Add hooks for ``dash`` and related packages to collect data files and hook for meta-data from ``flask-compress``

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -7,6 +7,7 @@ iminuit==1.4.0
 markdown==3.2.1
 pendulum==2.0.5
 phonenumbers==8.12.1
+plotly==4.14.3
 pinyin==0.4.0
 pycparser==2.20
 pycryptodome==3.9.7
@@ -26,6 +27,10 @@ publicsuffix2==2.20191221
 # Prebuilt wheels for Python 3.9 were introduced in h5py > 3
 h5py==2.10.0; python_version < '3.9'
 h5py==3.2.1; python_version >= '3.9'
+
+# Pandas dropped support for Python 3.6 in 1.2 releases
+pandas==1.1.5; python_version < '3.7'
+pandas==1.2.3; python_version >= '3.7'
 
 # These libraries only support python above 3.5
 openpyxl==3.0.3; python_version > '3.5'

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -3,7 +3,6 @@
 boto==2.49.0
 boto3==1.12.33
 botocore==1.15.33
-h5py==2.10.0
 iminuit==1.4.0
 markdown==3.2.1
 pendulum==2.0.5
@@ -19,11 +18,15 @@ pyzmq==19.0.0
 Unidecode==1.1.1
 zeep==3.4.0
 sentry-sdk==0.19.3
-av==8.0.2
+av==8.0.3
 passlib==1.7.2
 publicsuffix2==2.20191221
 
 # ------------------- Python Version/Platform (OS) specifics
+# Prebuilt wheels for Python 3.9 were introduced in h5py > 3
+h5py==2.10.0; python_version < '3.9'
+h5py==3.2.1; python_version >= '3.9'
+
 # These libraries only support python above 3.5
 openpyxl==3.0.3; python_version > '3.5'
 web3==5.7.0; python_version > '3.5'

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -4,6 +4,7 @@ boto==2.49.0
 boto3==1.12.33
 botocore==1.15.33
 dash==1.19.0
+dash-bootstrap-components==0.12.0
 iminuit==1.4.0
 markdown==3.2.1
 pendulum==2.0.5

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -3,6 +3,7 @@
 boto==2.49.0
 boto3==1.12.33
 botocore==1.15.33
+dash==1.19.0
 iminuit==1.4.0
 markdown==3.2.1
 pendulum==2.0.5

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dash_bootstrap_components.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dash_bootstrap_components.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('dash_bootstrap_components')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dash_core_components.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dash_core_components.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('dash_core_components')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dash_html_components.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dash_html_components.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('dash_html_components')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dash_renderer.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dash_renderer.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('dash_renderer')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dash_table.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dash_table.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('dash_table')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-flask_compress.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-flask_compress.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata
+
+datas = copy_metadata('flask_compress')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-plotly.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-plotly.py
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_submodules
+
+datas = collect_data_files('plotly', includes=['package_data/**/*.*'])
+hiddenimports = collect_submodules('plotly.validators') + ['pandas', 'cmath']

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -498,3 +498,44 @@ def test_plotly(pyi_builder):
         df = pd.DataFrame.from_records(data, columns=['col_1', 'col_2'])
         fig = px.scatter(df, x='col_1', y='col_2')
         """)
+
+
+@pytest.mark.timeout(300)
+@importorskip('dash')
+def test_dash(pyi_builder):
+    pyi_builder.test_source("""
+        import dash
+        import dash_core_components as dcc
+        import dash_html_components as html
+        from dash.dependencies import Input, Output
+
+        app = dash.Dash(__name__)
+        app.layout = html.Div(
+            [
+                dcc.Input(id='input_text', type='text', placeholder='input type text'),
+                html.Div(id='out-all-types'),
+            ]
+        )
+
+        @app.callback(
+            Output('out-all-types', 'children'),
+            [Input('input_text', 'value')],
+        )
+        def cb_render(val):
+            return val
+        """)
+
+
+@importorskip('dash_table')
+def test_dash_table(pyi_builder):
+    pyi_builder.test_source("""
+        import dash
+        import dash_table
+
+        app = dash.Dash(__name__)
+        app.layout = dash_table.DataTable(
+            id='table',
+            columns=[{'name': 'a', 'id': 'a'}, {'name': 'b', 'id': 'b'}],
+            data=[{'a': 1, 'b': 2}, {'a': 3, 'b': 4}],
+        )
+        """)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -486,3 +486,15 @@ def test_googleapiclient(pyi_builder):
     pyi_builder.test_source("""
         from googleapiclient.discovery import build
         """)
+
+
+@importorskip('plotly')
+def test_plotly(pyi_builder):
+    pyi_builder.test_source("""
+        import pandas as pd
+        import plotly.express as px
+
+        data = [(1, 1), (2, 1), (3, 5), (4, -3)]
+        df = pd.DataFrame.from_records(data, columns=['col_1', 'col_2'])
+        fig = px.scatter(df, x='col_1', y='col_2')
+        """)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -539,3 +539,15 @@ def test_dash_table(pyi_builder):
             data=[{'a': 1, 'b': 2}, {'a': 3, 'b': 4}],
         )
         """)
+
+
+@importorskip('dash_bootstrap_components')
+def test_dash_bootstrap_components(pyi_builder):
+    pyi_builder.test_source("""
+        import dash
+        import dash_bootstrap_components as dbc
+        import dash_html_components as html
+
+        app = dash.Dash(external_stylesheets=[dbc.themes.BOOTSTRAP])
+        alert = dbc.Alert([html.H4('Well done!', className='alert-heading')])
+        """)


### PR DESCRIPTION
Fixes #102

So I started with `dash_html_components` which was my initial use case, but since getting positive feedback, I did some additional research to see what users were struggling with ([here](https://stackoverflow.com/questions/59914106/pyinstaller-error-when-executing-plotly-dash-exec-file), [here](https://stackoverflow.com/questions/60049673/how-to-pack-a-plotly-dash-application-with-pyinstaller-into-a-single-exe-file-fo), etc.). I also did a deeper dive using a standalone project to test out the hooks and make sure they covered the most common use cases: https://github.com/KyleKing/Poetry-EdgeCaseTesting

There is also an issue with `dash` which calls `pkg_resources.get_distribution` on `flask-compress` so there needs be a `copy_metadata` in the flask compress hook

I would be happy to incorporate any feedback. I think I manually tested all of the changes, but I could have overlooked something since PyInstaller is fairly complex

> Side note: What happens if someone needs to override one of these hooks? Does the hook from this package get called first and the user overrides it? I see a warning for `win32ctypes.core` (`311 WARNING: Several hooks defined for module 'win32ctypes.core'. Please take care they do not conflict.`)
>
> *Update*: [From the docs](https://pyinstaller.readthedocs.io/en/stable/hooks.html#providing-pyinstaller-hooks-with-your-package) "If both PyInstaller and your package provide hooks for some module, your package’s hooks take precedence, but can still be overridden by the command line option --additional-hooks-dir." (i.e. pyinstaller > package > user)