### PR TITLE
hooks: update scikit-image hooks for compatibility with 0.18.x series

### DIFF
--- a/news/107.update.rst
+++ b/news/107.update.rst
@@ -1,0 +1,1 @@
+Update ``scikit-image`` hooks for compatibility with 0.18.x series.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.filters.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.filters.py
@@ -1,0 +1,18 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import is_module_satisfies
+
+# The following missing module prevents import of skimage.feature
+# with skimage 0.18.x.
+if is_module_satisfies("skimage >= 0.18.0"):
+    hiddenimports = ['skimage.filters.rank.core_cy_3d', ]


### PR DESCRIPTION
Add missing `skimage.filters.rank.core_cy_3d` hidden import.

Fixes pyinstaller/pyinstaller#5721.