### PR TITLE
hooks: update scikit-learn hooks for compatibility with 0.24.x series

### DIFF
--- a/news/108.update.rst
+++ b/news/108.update.rst
@@ -1,0 +1,1 @@
+Update ``scikit-learn`` hooks for compatibility with 0.24.x series.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sklearn.linear_model.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sklearn.linear_model.py
@@ -1,0 +1,18 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import is_module_satisfies
+
+# sklearn.linear_model in scikit-learn 0.24.x has a hidden import of
+# sklearn.utils._weight_vector
+if is_module_satisfies("sklearn >= 0.24"):
+    hiddenimports = ['sklearn.utils._weight_vector', ]


### PR DESCRIPTION
Add missing `sklearn.utils._weight_vector` hidden import.