### PR TITLE
Add copy_metadata to pycountry hook

### DIFF
--- a/news/113.update.rst
+++ b/news/113.update.rst
@@ -1,0 +1,1 @@
+Update the hook for ``pycountry`` to copy metadata, in addition to collecting data files.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pycountry.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pycountry.py
@@ -10,9 +10,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 
 # pycountry requires the ISO databases for country data.
 # Tested v1.15 on Linux/Ubuntu.
 # https://pypi.python.org/pypi/pycountry
-datas = collect_data_files('pycountry')
+datas = copy_metadata('pycountry') + collect_data_files('pycountry')


### PR DESCRIPTION
Based off this thread: http://pyinstaller.47505.x6.nabble.com/PyInstaller-not-working-with-module-pycountry-td3064.html
I faced this same issue, used this modified hook, and it worked.