### PR TITLE
Add hook for pypylon

### DIFF
--- a/news/114.new.rst
+++ b/news/114.new.rst
@@ -1,0 +1,1 @@
+Add a standard hook for PyPylon.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pypylon.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pypylon.py
@@ -1,0 +1,37 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# PyPylon is a tricky library to bundle. It encapsulates the pylon C++ SDK inside
+# it with modified library references to make the module relocatable.
+# PyInstaller is able to find those libraries and preserve the linkage for almost
+# all of them. However - there is an additional linking step happening at runtime,
+# when the library is creating the transport layer for the camera. This linking
+# will fail with the library files modified by pyinstaller.
+# As the module is already relocatable, we circumvent this issue by bundling
+# pypylon as-is - for pyinstaller we treat the shared library files as just data.
+
+
+import os
+
+from PyInstaller.utils.hooks import collect_all
+from PyInstaller.utils.hooks import collect_dynamic_libs
+
+# Collect dynamic libs as data (to prevent pyinstaller from modifying them)
+datas = collect_dynamic_libs('pypylon')
+
+# Exclude the C++-extensions from automatic search, add them manually as data files
+# their dependencies were already handled with collect_dynamic_libs
+excludedimports = ['pypylon._pylon', 'pypylon._genicam']
+for filename, module in collect_all('pypylon._pylon')[0]:
+    if (os.path.basename(filename).startswith('_pylon.')
+            or os.path.basename(filename).startswith('_genicam.')):
+        datas += [(filename, module)]


### PR DESCRIPTION
Closes https://github.com/basler/pypylon/issues/118

Probably abuses pyinstaller hooks a bit, but the way pypylon handles its libraries makes it really difficult for an automated tool to perform packaging.

Tested with Linux and Windows.