### PR TITLE
hooks: IPython: remove use of compat.modname_tkinter

### DIFF
--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-IPython.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-IPython.py
@@ -13,7 +13,7 @@
 
 # Tested with IPython 4.0.0.
 
-from PyInstaller.compat import modname_tkinter, is_win, is_darwin
+from PyInstaller.compat import is_win, is_darwin
 from PyInstaller.utils.hooks import collect_data_files
 
 # Ignore 'matplotlib'. IPython contains support for matplotlib.
@@ -24,7 +24,7 @@ excludedimports = ['gtk', 'matplotlib', 'PyQt4', 'PyQt5', 'PySide']
 
 # IPython uses 'tkinter' for clipboard access on Linux/Unix. Exclude it on Windows and OS X.
 if is_win or is_darwin:
-    excludedimports.append(modname_tkinter)
+    excludedimports.append('tkinter')
 
 datas = collect_data_files('IPython')
 


### PR DESCRIPTION
Use 'tkinter' instead.