### PR TITLE
Update hook for pypylon to include data files

### DIFF
--- a/news/116.update.rst
+++ b/news/116.update.rst
@@ -1,0 +1,1 @@
+Update hook for PyPylon to include data files.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pypylon.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pypylon.py
@@ -23,10 +23,14 @@
 import os
 
 from PyInstaller.utils.hooks import collect_all
+from PyInstaller.utils.hooks import collect_data_files
 from PyInstaller.utils.hooks import collect_dynamic_libs
 
 # Collect dynamic libs as data (to prevent pyinstaller from modifying them)
 datas = collect_dynamic_libs('pypylon')
+
+# Collect data files, looking for pypylon/pylonCXP/bin/ProducerCXP.cti, but other files may also be needed
+datas += collect_data_files('pypylon')
 
 # Exclude the C++-extensions from automatic search, add them manually as data files
 # their dependencies were already handled with collect_dynamic_libs


### PR DESCRIPTION
#114 missed the data files required for discovering cameras.

Tested to work on a new Windows installation.