### PR TITLE
Create hook for Azurerm which is using pkg_resources internally

### DIFF
--- a/news/123.new.rst
+++ b/news/123.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``Azurerm`` which is using pkg_resources internally.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-azurerm.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-azurerm.py
@@ -9,11 +9,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
 # Azurerm is a lite api to microsoft azure.
 # Azurerm is using pkg_resources internally which is not supported by py-installer.
 # This hook will collect the module metadata.
 # Tested with Azurerm 0.10.0
+
 from PyInstaller.utils.hooks import copy_metadata
 
 datas = copy_metadata("azurerm")

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-azurerm.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-azurerm.py
@@ -1,3 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
 # Azurerm is a lite api to microsoft azure.
 # Azurerm is using pkg_resources internally which is not supported by py-installer.
 # This hook will collect the module metadata.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-azurerm.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-azurerm.py
@@ -1,0 +1,7 @@
+# Azurerm is a lite api to microsoft azure.
+# Azurerm is using pkg_resources internally which is not supported by py-installer.
+# This hook will collect the module metadata.
+# Tested with Azurerm 0.10.0
+from PyInstaller.utils.hooks import copy_metadata
+
+datas = copy_metadata("azurerm")


### PR DESCRIPTION
Azurerm is a lite api to microsoft azure.
Azurerm is using pkg_resources internally which is not supported by py-installer.
This hook will collect the module metadata.
Tested with Azurerm 0.10.0