### PR TITLE
hooks: add hook for jsonrpcserver

### DIFF
--- a/news/126.new.rst
+++ b/news/126.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``jsonrpcserver`` to collect missing ``request-schema.json`` data file.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-jsonrpcserver.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-jsonrpcserver.py
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# This is needed to bundle request-schema.json file needed by
+# jsonrpcserver package
+
+from PyInstaller.utils.hooks import collect_data_files
+datas = collect_data_files('jsonrpcserver')


### PR DESCRIPTION
Add a simple hook to include missing [request-schema.json](https://github.com/bcb/jsonrpcserver/blob/master/jsonrpcserver/request-schema.json) file required by [jsonrpcserver](https://github.com/bcb/jsonrpcserver) python package.