### PR TITLE
Add hooks to get spacy working

### DIFF
--- a/LICENSE.APL.txt
+++ b/LICENSE.APL.txt
@@ -1,15 +1,15 @@
 ==========================================================
-Licensing Terms for he PyInstaller community runtime hooks
+Licensing Terms for PyInstaller community runtime hooks
 ==========================================================
 
 The PyInstaller community **runtime** hooks are licensed under the terms of the
 Apache 2.0 Software License as published by the Apache Software Foundation.
 
 These generally reside in "src/_pyinstaller_hooks_contrib/hooks/rthooks",
-though please note that this license only applies to files which state in in the header, like:
+though please note that this license only applies to files which state so in the header, like:
 
 # ------------------------------------------------------------------
-# Copyright (c) 2020 PyInstaller Development Team.
+# Copyright (c) 2021 PyInstaller Development Team.
 #
 # This file is distributed under the terms of the Apache License 2.0
 #
@@ -23,7 +23,7 @@ though please note that this license only applies to files which state in in the
 Apache License 2.0
 ++++++++++++++++++
 
-   Copyright 2020 PyInstaller Development Team
+   Copyright 2020-2021 PyInstaller Development Team
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE.GPL.txt
+++ b/LICENSE.GPL.txt
@@ -12,7 +12,7 @@ that do not specifically state otherwise.
 Please add the following header to files which aren't runtime hooks (LICENSE.APL.txt):
 
 # ------------------------------------------------------------------
-# Copyright (c) 2020 PyInstaller Development Team.
+# Copyright (c) 2021 PyInstaller Development Team.
 #
 # This file is distributed under the terms of the GNU General Public
 # License (version 2.0 or later).

--- a/news/128.1.new.rst
+++ b/news/128.1.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``spacy`` which contains hidden imports and data files

--- a/news/128.2.new.rst
+++ b/news/128.2.new.rst
@@ -1,0 +1,1 @@
+Add hooks for ``thinc`` and ``thinc.banckends.numpy_ops`` which contain data files and hidden imports

--- a/news/128.3.new.rst
+++ b/news/128.3.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``srsly.msgpack._packer`` which contains a hidden import

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -1,5 +1,6 @@
 # ------------------ LIBRARIES ------------------ #
 # TODO: Add most of the libraries we have hooks for, and write tests
+av==8.0.3
 boto==2.49.0
 boto3==1.12.33
 botocore==1.15.33
@@ -10,10 +11,12 @@ iminuit==2.4.0
 markdown==3.2.1
 Office365-REST-Python-Client==2.3.4
 openpyxl==3.0.3
+passlib==1.7.2
 pendulum==2.0.5
 phonenumbers==8.12.1
-plotly==4.14.3
 pinyin==0.4.0
+plotly==4.14.3
+publicsuffix2==2.20191221
 pycparser==2.20
 pycryptodome==3.9.7
 pycryptodomex==3.9.7
@@ -21,13 +24,10 @@ pyexcelerate==0.8.0
 pylint==2.4.4
 pyusb==1.0.2
 pyzmq==22.0.3
-Unidecode==1.1.1
-zeep==3.4.0
 sentry-sdk==0.19.3
-av==8.0.3
-passlib==1.7.2
-publicsuffix2==2.20191221
+Unidecode==1.1.1
 web3==5.7.0
+zeep==3.4.0
 
 # ------------------- Python Version/Platform (OS) specifics
 # Last release with prebuilt wheels for Python 3.6 is 3.1.0

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -25,6 +25,7 @@ pylint==2.4.4
 pyusb==1.0.2
 pyzmq==22.0.3
 sentry-sdk==0.19.3
+srsly==2.4.1
 thinc==8.0.4
 Unidecode==1.1.1
 web3==5.7.0

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -25,6 +25,7 @@ pylint==2.4.4
 pyusb==1.0.2
 pyzmq==22.0.3
 sentry-sdk==0.19.3
+thinc==8.0.4
 Unidecode==1.1.1
 web3==5.7.0
 zeep==3.4.0

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -25,6 +25,7 @@ pylint==2.4.4
 pyusb==1.0.2
 pyzmq==22.0.3
 sentry-sdk==0.19.3
+spacy==3.0.6
 srsly==2.4.1
 thinc==8.0.4
 Unidecode==1.1.1

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-spacy.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-spacy.py
@@ -1,0 +1,19 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the Apache License 2.0
+#
+# The full license is available in LICENSE.APL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------
+
+"""
+Spacy contains hidden imports and data files which are needed to import it
+"""
+
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+datas = collect_data_files("spacy")
+hiddenimports = collect_submodules("spacy")

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-srsly.msgpack._packer.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-srsly.msgpack._packer.py
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the Apache License 2.0
+#
+# The full license is available in LICENSE.APL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------
+
+"""
+srsly.msgpack._packer contains hidden imports which are needed to import it
+This hook was created to make spacy work correctly.
+"""
+
+hiddenimports = ['srsly.msgpack.util']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-thinc.backends.numpy_ops.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-thinc.backends.numpy_ops.py
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the Apache License 2.0
+#
+# The full license is available in LICENSE.APL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------
+
+"""
+thinc.banckends.numpy_ops contains hidden imports which are needed to import it
+This hook was created to make spacy work correctly.
+"""
+
+hiddenimports = ['cymem.cymem', 'preshed.maps', 'blis.py']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-thinc.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-thinc.py
@@ -1,0 +1,18 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the Apache License 2.0
+#
+# The full license is available in LICENSE.APL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------
+
+"""
+Thinc contains data files and hidden imports. This hook was created to make spacy work correctly.
+"""
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+datas = collect_data_files("thinc")
+hiddenimports = collect_submodules("thinc")

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -592,3 +592,10 @@ def test_office365(pyi_builder):
         SamlTokenProvider._prepare_request_from_template('RST2.xml', {})
         SamlTokenProvider._prepare_request_from_template('SAML.xml', {})
         """)
+
+
+@importorskip('thinc')
+def test_thinc(pyi_builder):
+    pyi_builder.test_source("""
+        from thinc.backends import numpy_ops
+        """)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -599,3 +599,10 @@ def test_thinc(pyi_builder):
     pyi_builder.test_source("""
         from thinc.backends import numpy_ops
         """)
+
+
+@importorskip('srsly')
+def test_srsly(pyi_builder):
+    pyi_builder.test_source("""
+        import srsly
+        """)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -606,3 +606,10 @@ def test_srsly(pyi_builder):
     pyi_builder.test_source("""
         import srsly
         """)
+
+
+@importorskip('spacy')
+def test_spacy(pyi_builder):
+    pyi_builder.test_source("""
+        import spacy
+        """)


### PR DESCRIPTION
The [issue](https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/38) refers to preshed, but it seems like spacy is actually the root of the problem. I also reviewed [pyinstaller/pyinstaller#4696](https://github.com/pyinstaller/pyinstaller/issues/4696), [pyinstaller/pyinstaller#4053](https://github.com/pyinstaller/pyinstaller/issues/4053), and https://stackoverflow.com/questions/59645155/spacy-2-2-3-filenotfounderror-errno-2-no-such-file-or-directory-thinc-neur. Oddly enough I could find no code to use for testing in any of those places so the test case is just an import. If anybody knows these packages and can suggest a better test case please let me know.

I'm not familiar with any of these packages so I did a trial-and-error approach to figure out the minimum necessary logic for the hooks.

Closes #38 