### PR TITLE
CI/CD: Oneshot: Implicitly wrap each requirement in double quotes.

### DIFF
--- a/.github/workflows/oneshot-test.yml
+++ b/.github/workflows/oneshot-test.yml
@@ -19,7 +19,7 @@ on:
         description: |
           Package names and versions to test. Jobs are split by comma.
         required: true
-        default: '"numpy==1.19", "numpy<1.18"'
+        default: 'numpy==1.19, numpy<1.18'
       os:
         description: |
           OS(s) to run on. Can be any combinations of ubuntu, windows, macos.
@@ -73,11 +73,21 @@ jobs:
           # Split by comma, ignore trailing comma, remove whitespace.
           parse_list = lambda x: [i.strip() for i in x.strip(", ").split(",")]
 
+          # Wrap a word in quotes, escaping any literal quotes already there.
+          quote = lambda x: '"{}"'.format(x.replace('"', r'\"'))
+
           matrix = {
               "os": [i + "-latest" for i in parse_list(inputs["os"])],
               "python-version": parse_list(inputs["python-version"]),
               "requirements": parse_list(inputs["package"]),
           }
+
+          # Wrap each word in " " quotes to force bash to interpret special
+          # characters such as > as literals.
+          matrix["requirements"] = [
+              " ".join(map(quote, i.split(" ")))
+              for i in matrix["requirements"]
+          ]
 
           pprint.pprint(matrix)
 


### PR DESCRIPTION
When given a requirement like `humanize>3` bash will interpret the `>` as the *stream to file* operator so that `pip install humanize>3` will really run `pip install humanize` and pipe the output to a file called `3`. Wrapping with quotes (`pip install "humanize>3"`) fixes this but it complicates the CI launching UI because, unless you know why the quotes are needed, you're guessing where/when to use them (see [here](https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/130#discussion_r654872063) for an example).

Now each requirement given is internally quoted automatically so that there is never any need to manually quote parameters. Input syntax now mostly mirrors that of PEP 508 requirements files with the differences
being that `,` splits jobs and therefore can't be used anywhere else and that single requirements like `'requests >= 2'` must be written without spaces.

I'm really not convinced that this is the best answer which is why I'm marking this as a draft. But nothing better springs to mind. Possibly we could try `\` escaping known special characters?
