### PR TITLE
Add hook for "shotgun_api3"

### DIFF
--- a/news/138.new.rst
+++ b/news/138.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``shotgun_api3`` to collect data files and hidden imports.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -25,6 +25,8 @@ pylint==2.4.4
 pyusb==1.0.2
 pyzmq==22.0.3
 sentry-sdk==0.19.3
+# shotgun_api3 can only be installed from git
+git+https://github.com/shotgunsoftware/python-api.git@v3.2.6
 spacy==3.0.6
 srsly==2.4.1
 thinc==8.0.4

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-shotgun_api3.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-shotgun_api3.py
@@ -1,0 +1,23 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+# Shotgun is using "six" to import these and
+# PyInstaller does not seem to catch them correctly.
+hiddenimports = ["xmlrpc", "xmlrpc.client"]
+
+# Collect the following files:
+#   /shotgun_api3/lib/httplib2/python2/cacerts.txt
+#   /shotgun_api3/lib/httplib2/python3/cacerts.txt
+#   /shotgun_api3/lib/certifi/cacert.pem
+datas = collect_data_files("shotgun_api3")

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -613,3 +613,10 @@ def test_spacy(pyi_builder):
     pyi_builder.test_source("""
         import spacy
         """)
+
+
+@importorskip('shotgun_api3')
+def test_shotgun_api3(pyi_builder):
+    pyi_builder.test_source("""
+        import shotgun_api3
+        """)


### PR DESCRIPTION
This is a hook for the [Shotgrid python API](https://github.com/shotgunsoftware/python-api).

Let me know if there is something missing/wrong with this PR! 🙂 