### PR TITLE
Msoffcrypto

### DIFF
--- a/news/139.new.rst
+++ b/news/139.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``msoffcrypto`` to collect metadata.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -9,6 +9,7 @@ dash-bootstrap-components==0.12.0
 humanize==3.5.0
 iminuit==2.4.0
 markdown==3.2.1
+msoffcrypto-tool==4.12.0
 Office365-REST-Python-Client==2.3.4
 openpyxl==3.0.3
 passlib==1.7.2

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-msoffcrypto.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-msoffcrypto.py
@@ -1,0 +1,18 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the Apache License 2.0
+#
+# The full license is available in LICENSE.APL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------
+
+"""
+msoffcrypto contains hidden metadata as of v4.12.0
+"""
+
+from PyInstaller.utils.hooks import copy_metadata
+
+datas = copy_metadata('msoffcrypto-tool')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -620,3 +620,10 @@ def test_shotgun_api3(pyi_builder):
     pyi_builder.test_source("""
         import shotgun_api3
         """)
+
+
+@importorskip('msoffcrypto')
+def test_msoffcrypto(pyi_builder):
+    pyi_builder.test_source("""
+        import msoffcrypto
+        """)


### PR DESCRIPTION
I'm having trouble figuring out how to handle this one and was hoping I could get some advice. The offending line from the package seems to be `__version__ = pkg_resources.get_distribution("msoffcrypto-tool").version`. The version was a hardcoded string in the prior release and everything worked fine then, here's the commit that broke it: https://github.com/nolze/msoffcrypto-tool/commit/161b182a029ced7597c2c5240ed8348467ffeeb9#diff-589d1c7aac0cfc6ed2f443b43655fcaad7fee63a261631470e74e01de91d2e24

My draft hook doesn't help at all, I just left it in the draft PR to show that I had already tried the kitchen sink approach.