### PR TITLE
hooks: scikit-image & scikit-learn: use distribution names for version checks

### DIFF
--- a/news/276.update.rst
+++ b/news/276.update.rst
@@ -1,0 +1,3 @@
+Update ``scikit-learn`` and ``scikit-image`` hooks to perform version checks 
+based on distribution name instead of package name, to prevent failures
+when ``sklearn`` dummy distribution is installed.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.filters.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.filters.py
@@ -14,5 +14,5 @@ from PyInstaller.utils.hooks import is_module_satisfies
 
 # The following missing module prevents import of skimage.feature
 # with skimage 0.18.x.
-if is_module_satisfies("skimage >= 0.18.0"):
+if is_module_satisfies("scikit_image >= 0.18.0"):
     hiddenimports = ['skimage.filters.rank.core_cy_3d', ]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sklearn.cluster.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sklearn.cluster.py
@@ -14,5 +14,5 @@ from PyInstaller.utils.hooks import is_module_satisfies
 
 # sklearn.cluster in scikit-learn 0.23.x has a hidden import of
 # threadpoolctl
-if is_module_satisfies("sklearn >= 0.23"):
+if is_module_satisfies("scikit_learn >= 0.23"):
     hiddenimports = ['threadpoolctl', ]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sklearn.linear_model.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sklearn.linear_model.py
@@ -14,5 +14,5 @@ from PyInstaller.utils.hooks import is_module_satisfies
 
 # sklearn.linear_model in scikit-learn 0.24.x has a hidden import of
 # sklearn.utils._weight_vector
-if is_module_satisfies("sklearn >= 0.24"):
+if is_module_satisfies("scikit_learn >= 0.24"):
     hiddenimports = ['sklearn.utils._weight_vector', ]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sklearn.neighbors.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sklearn.neighbors.py
@@ -14,7 +14,7 @@ from PyInstaller.utils.hooks import is_module_satisfies
 
 hiddenimports = []
 
-if is_module_satisfies("sklearn >= 0.22"):
+if is_module_satisfies("scikit_learn >= 0.22"):
     # 0.22 and later
     hiddenimports += [
         'sklearn.neighbors._typedefs',

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -383,8 +383,8 @@ def test_pydivert(pyi_builder):
 
 
 @importorskip('skimage')
-@pytest.mark.skipif(not is_module_satisfies('skimage >= 0.16.0'),
-                    reason='The test supports only skimage 0.16.0 or newer.')
+@pytest.mark.skipif(not is_module_satisfies('scikit_image >= 0.16'),
+                    reason='The test supports only scikit-image >= 0.16.')
 @pytest.mark.parametrize('submodule', [
     'color', 'data', 'draw', 'exposure', 'feature', 'filters', 'future',
     'graph', 'io', 'measure', 'metrics', 'morphology', 'registration',
@@ -397,7 +397,7 @@ def test_skimage(pyi_builder, submodule):
 
 
 @importorskip('sklearn')
-@pytest.mark.skipif(not is_module_satisfies('sklearn >= 0.21'),
+@pytest.mark.skipif(not is_module_satisfies('scikit_learn >= 0.21'),
                     reason='The test supports only scikit-learn >= 0.21.')
 @pytest.mark.parametrize('submodule', [
     'calibration', 'cluster', 'covariance', 'cross_decomposition',


### PR DESCRIPTION
Use distribution names (`scikit_image` and `scikit_learn`) for version checks via `is_module_satisfies()` instead of package names (`skimage` and `sklearn`). It is possible to install latest `scikit-learn` by installing 'sklearn', which installs `sklearn==0.0` that ends up messing up the version checks.

Make same adjustment in `scikit-image` hooks for the sake of consistency (although trying to install `skimage` shows an error     telling user to install `scikit-image` instead).