### PR TITLE
Add hook-cloudscraper.py

### DIFF
--- a/news/281.new.rst
+++ b/news/281.new.rst
@@ -1,0 +1,1 @@
+Add a hook for `cloudscraper` to collect data files

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -4,6 +4,7 @@ av==8.0.3
 boto==2.49.0
 boto3==1.12.33
 botocore==1.15.33
+cloudscraper==1.2.58
 dash==1.19.0
 dash-bootstrap-components==0.12.0
 dash-uploader==0.5.0

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cloudscraper.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cloudscraper.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('cloudscraper')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -641,3 +641,11 @@ def test_dash_uploader(pyi_builder):
     pyi_builder.test_source("""
         import dash_uploader
         """)
+
+
+@importorskip('cloudscraper')
+def test_cloudscraper(pyi_builder):
+    pyi_builder.test_source("""
+        import cloudscraper
+        scraper = cloudscraper.create_scraper()
+        """)


### PR DESCRIPTION
Add a hook for `cloudscraper` to collect data files.
Data is located at [cloudscraper\user_agent\browsers.json](https://github.com/VeNoMouS/cloudscraper/blob/master/cloudscraper/user_agent/browsers.json).
[ci](https://github.com/eric15342335/pyinstaller-hooks-contrib/actions/runs/1084697166)