### PR TITLE
hooks: add hook for mnemonic

### DIFF
--- a/news/284.new.rst
+++ b/news/284.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``mnemonic`` to collect data files

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -12,6 +12,7 @@ humanize==3.5.0
 iminuit==2.4.0
 mariadb==1.0.7; sys_platform != "darwin"
 markdown==3.2.1
+mnemonic==0.20
 msoffcrypto-tool==4.12.0
 Office365-REST-Python-Client==2.3.4
 openpyxl==3.0.3

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-mnemonic.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-mnemonic.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('mnemonic')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -649,3 +649,11 @@ def test_cloudscraper(pyi_builder):
         import cloudscraper
         scraper = cloudscraper.create_scraper()
         """)
+
+
+@importorskip('mnemonic')
+def test_mnemonic(pyi_builder):
+    pyi_builder.test_source("""
+        import mnemonic
+        mnemonic.Mnemonic("english")
+        """)


### PR DESCRIPTION
This pull request adds a hook for mnemonic.
See: https://stackoverflow.com/questions/68624566/.
The (text) files which mnemonic needed are located [here.](https://github.com/trezor/python-mnemonic/tree/master/src/mnemonic/wordlist)
