### PR TITLE
hooks: add hook for pystray

### DIFF
--- a/news/288.new.rst
+++ b/news/288.new.rst
@@ -1,0 +1,1 @@
+Add a hook for `pystray` to collect hidden imports.

--- a/news/288.new.rst
+++ b/news/288.new.rst
@@ -1,1 +1,1 @@
-Add a hook for `pystray` to collect hidden imports.
+Add a hook for ``pystray`` to collect hidden imports.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -29,6 +29,7 @@ pyexcelerate==0.8.0
 pylint==2.4.4
 pyusb==1.0.2
 pynput==1.7.3
+pystray==0.17.3
 pyzmq==22.0.3
 sentry-sdk==0.19.3
 # shotgun_api3 can only be installed from git

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pystray.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pystray.py
@@ -11,4 +11,6 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import collect_submodules
+# https://github.com/moses-palmer/pystray/tree/feature-explicit-backends
+# if this get merged then we don't need this hook
 hiddenimports = collect_submodules("pystray")

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pystray.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pystray.py
@@ -1,0 +1,14 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_submodules
+hiddenimports = collect_submodules("pystray")

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -664,3 +664,10 @@ def test_pynput(pyi_builder):
     pyi_builder.test_source("""
         import pynput
         """)
+
+
+@importorskip('pystray')
+def test_pystray(pyi_builder):
+    pyi_builder.test_source("""
+        import pystray
+        """)


### PR DESCRIPTION
Pystray [chooses](https://github.com/moses-palmer/pystray/blob/master/lib/pystray/__init__.py#L22) different backends for different platforms. Note that if [this branch](https://github.com/moses-palmer/pystray/tree/feature-explicit-backends) get merged then we don't need this.
(This is the same)

[**CI**](https://github.com/eric15342335/pyinstaller-hooks-contrib/actions/runs/1107971245)