### PR TITLE
Per-platform imports for platformdirs

### DIFF
--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-platformdirs.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-platformdirs.py
@@ -10,7 +10,18 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.compat import is_darwin, is_win
+
+modules = ["platformdirs"]
 
 # platfromdirs contains dynamically loaded per-platform submodules.
-hiddenimports = collect_submodules("platformdirs")
+if is_darwin:
+    modules.append("platformdirs.macos")
+elif is_win:
+    modules.append("platformdirs.windows")
+else:
+    # default to unix for all other platforms
+    # this includes unix, cygwin, and msys2
+    modules.append("platformdirs.unix")
+
+hiddenimports = modules


### PR DESCRIPTION
Only import the platformdirs submodule for the platform the binary is
being built against.