### PR TITLE
hooks: future-proof the pydantic hook

### DIFF
--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
@@ -15,8 +15,11 @@ from PyInstaller.utils.hooks import is_module_satisfies
 
 # By default, pydantic from PyPi comes with all modules compiled as
 # cpython extensions, which seems to prevent pyinstaller from automatically
-# picking up the submodules
-is_compiled = get_module_attribute('pydantic', 'compiled') == 'True'
+# picking up the submodules.
+# NOTE: in PyInstaller 4.x and earlier, get_module_attribute() returns the
+# string representation of the value ('True'), while in PyInstaller 5.x
+# and later, the actual value is returned (True).
+is_compiled = get_module_attribute('pydantic', 'compiled') in {'True', True}
 if is_compiled:
     # Compiled version; we need to manually collect the submodules from
     # pydantic...


### PR DESCRIPTION
In the upcoming PyInstaller 5.x series, the `get_module_attribute()` function will return the actual value instead of its string representation. So compare the returned value for the `compiled` attribute against both `'True'` and `True` for compatibility with both PyInstaller 4.x and 5.x series.
