### PR TITLE
hooks: add hook for tableauhyperapi

### DIFF
--- a/news/316.new.rst
+++ b/news/316.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``tableauhyperapi`` to collect dynamic libraries.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -47,6 +47,7 @@ srsly==2.4.1
 swagger-spec-validator==2.7.3
 thinc==8.0.9
 timezonefinder==5.2.0
+tableauhyperapi==0.0.13394
 Unidecode==1.2.0
 web3==5.23.1
 websockets==9.1

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tableauhyperapi.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tableauhyperapi.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_dynamic_libs
+
+binaries = collect_dynamic_libs("tableauhyperapi")

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -780,3 +780,10 @@ def test_platformdirs(pyi_builder):
 @importorskip("websockets")
 def test_websockets(pyi_builder):
     pyi_builder.test_source("import websockets")
+
+
+@importorskip("tableauhyperapi")
+def test_tableauhyperapi(pyi_builder):
+    pyi_builder.test_source("""
+        import tableauhyperapi
+        """)


### PR DESCRIPTION
<details>
<summary>
wheel
</summary>

```
tableauhyperapi
│   catalog.py
│   connection.py
│   databasename.py
│   date.py
│   endpoint.py
│   hyperexception.py
│   hyperprocess.py
│   hyperserviceversion.py
│   inserter.py
│   interval.py
│   name.py
│   result.py
│   resultschema.py
│   schemaname.py
│   sql.py
│   sqltype.py
│   tabledefinition.py
│   tablename.py
│   timestamp.py
│   warning.py
│   __init__.py
│
├───bin
│   │   tableauhyperapi.dll
│   │
│   └───hyper
│           crashdumper.exe
│           hyperd.exe
│
└───impl
        cdef.py
        cdef_compiled.py
        converter.py
        dll.py
        dllutil.py
        hapi.py
        immutablelistwrapper.py
        lib_h.py
        schemaconverter.py
        util.py
        version.py
        __init__.py
```
</details>

https://stackoverflow.com/questions/69041243/few-packages-in-pyinstaller-is-not-packaged