### PR TITLE
Fix scheduled-test CI

### DIFF
--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -53,6 +53,12 @@ jobs:
           Xvfb :99 & echo "DISPLAY=:99" >> $GITHUB_ENV
           # Install mariadb dependencies.
           sudo apt-get install -y libmariadbclient-dev
+          # Install PyQt5 (qtmodern) dependencies.
+          sudo apt-get install -y libxcb-keysyms1 libxcb-render-util0 \
+            libxkbcommon-x11-0 libxcb-icccm4 libxcb1 openssl \
+            libxcb-randr0-dev libxcb-xtest0-dev libxcb-xinerama0-dev \
+            libxcb-shape0-dev libxcb-xkb-dev libopengl0 libegl1 \
+            libpulse0 libpulse-mainloop-glib0
 
       - name: Install dependencies
         run: |

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -16,7 +16,7 @@ iminuit==2.8.3
 langdetect==1.0.9
 mariadb==1.0.7; sys_platform != "darwin"
 markdown==3.3.4
-MetPy==1.1.0
+MetPy==1.1.0; python_version >= '3.7'
 mnemonic==0.20
 msoffcrypto-tool==4.12.0
 Office365-REST-Python-Client==2.3.8


### PR DESCRIPTION
An attempt at fixing [yesterday's failed scheduled test](https://github.com/pyinstaller/pyinstaller-hooks-contrib/runs/3570109442?check_suite_focus=true).

Python 3.6 pipelines are failing due to latest version of MetPy having dropped support for 3.6.

`qtmodern` tests are failing on linux due to missing system dependencies of `PyQt5`.