### PR TITLE
hooks: add hook for adbutils

### DIFF
--- a/news/323.new.rst
+++ b/news/323.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``adbutils`` to collect dynamic libraries.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -1,6 +1,7 @@
 # ------------------ LIBRARIES ------------------ #
 # TODO: Add most of the libraries we have hooks for, and write tests
 av==8.0.3
+adbutils==0.11.0; sys_platform == 'darwin' or sys_platform == 'win32'
 boto==2.49.0
 boto3==1.18.44
 botocore==1.21.44

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-adbutils.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-adbutils.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+# adb.exe is not automatically collected by collect_dynamic_libs()
+datas = collect_data_files("adbutils", subdir="binaries", includes=["adb*"])

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -824,3 +824,10 @@ def test_pyvjoy(pyi_builder):
     pyi_builder.test_source("""
         import pyvjoy
         """)
+
+
+@importorskip("adbutils")
+def test_adbutils(pyi_builder):
+    pyi_builder.test_source("""
+        from adbutils._utils import get_adb_exe; get_adb_exe()
+        """)


### PR DESCRIPTION
adbutils bundles [adb binaries](https://github.com/openatx/adbutils/tree/master/adbutils/binaries) for windows/macos as the fallback adb:

https://github.com/openatx/adbutils/blob/dccec86376ab3fd741cfedb62c0c9b71a58b4877/adbutils/_utils.py#L29-L41

[CI](https://github.com/eric15342335/pyinstaller-hooks-contrib/actions/runs/1265028870)