### PR TITLE
hooks: add hook for pymediainfo

### DIFF
--- a/news/324.new.rst
+++ b/news/324.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``pymediainfo``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -76,5 +76,8 @@ pywin32-ctypes==0.2.0; sys_platform == 'win32'
 # pythonnet 3 (when released) will be cross platform
 pythonnet==2.5.2; sys_platform == 'win32'
 
+# pymediainfo on linux does not bundle mediainfo shared library, and requires system one.
+pymediainfo==5.1.0; sys_platform == 'darwin' or sys_platform == 'win32'
+
 # Include the requirements for testing
 -r requirements-test.txt

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pymediainfo.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pymediainfo.py
@@ -1,0 +1,43 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.compat import is_win, is_darwin
+from PyInstaller.utils.hooks import collect_dynamic_libs, logger
+
+# Collect bundled mediainfo shared library (available in Windows and macOS wheels on PyPI).
+binaries = collect_dynamic_libs("pymediainfo")
+
+# On linux, no wheels are available, and pymediainfo uses system shared library.
+if not binaries and not (is_win or is_darwin):
+    def _find_system_mediainfo_library():
+        import os
+        import ctypes.util
+        from PyInstaller.depend.utils import _resolveCtypesImports
+
+        libname = ctypes.util.find_library("mediainfo")
+        if libname is not None:
+            resolved_binary = _resolveCtypesImports([os.path.basename(libname)])
+            if resolved_binary:
+                return resolved_binary[0][1]
+
+    try:
+        mediainfo_lib = _find_system_mediainfo_library()
+    except Exception as e:
+        logger.warning("Error while trying to find system-installed MediaInfo library: %s", e)
+        mediainfo_lib = None
+
+    if mediainfo_lib:
+        # Put the library into pymediainfo sub-directory, to keep layout consistent with that of wheels.
+        binaries += [(mediainfo_lib, 'pymediainfo')]
+
+if not binaries:
+    logger.warning("MediaInfo shared library not found - pymediainfo will likely fail to work!")

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -831,3 +831,11 @@ def test_adbutils(pyi_builder):
     pyi_builder.test_source("""
         from adbutils._utils import get_adb_exe; get_adb_exe()
         """)
+
+
+@importorskip("pymediainfo")
+def test_pymediainfo(pyi_builder):
+    pyi_builder.test_source("""
+        from pymediainfo import MediaInfo
+        MediaInfo._get_library()  # Trigger search for shared library.
+        """)


### PR DESCRIPTION
Collects bundled `MediaInfo` shared library that is available in macOS and Windows wheels. On other OSes, it attempts to collect
the system-installed `MediaInfo` shared library.

The tests are currently enabled only for macOS and Windows, where we want to check if bundled shared library is properly collected. If we wanted the test to run on Linux, we'd need to install `libmediainfo0v5` via `apt`, but that would be self-defeating, because once system copy is available, the frozen test would pass if the library was collected or not.