### PR TITLE
Add a hook for pyppeteer to collect its metadata.

### DIFF
--- a/news/329.new.rst
+++ b/news/329.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``pyppeteer``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -36,6 +36,7 @@ pycryptodome==3.10.4
 pycryptodomex==3.10.4
 pyexcelerate==0.10.0
 pylint==2.11.1
+pypeteer==0.2.6
 pyusb==1.2.1
 pyvjoy==1.0.1; sys_platform == 'win32'
 pynput==1.7.3

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyppeteer.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyppeteer.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata
+
+# pyppeteer uses importlib.metadata to query its own version.
+datas = copy_metadata("pyppeteer")

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -846,3 +846,11 @@ def test_sacremoses(pyi_builder):
     pyi_builder.test_source("""
         import sacremoses
         """)
+
+
+@importorskip("pypeteer")
+def test_pypeteer(pyi_builder):
+    pyi_builder.test_source("""
+        import pypeteer
+        print(pypeteer.version)
+        """)


### PR DESCRIPTION
Fixes #329, although as stated [here](https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/329#issuecomment-936619498), the issue is as much pyppeteers as ours.