### PR TITLE
Include markdown metadata to support entry-points

### DIFF
--- a/news/336.update.rst
+++ b/news/336.update.rst
@@ -1,0 +1,1 @@
+Update ``markdown`` hook to include package metadata, enabling the use of short names for built-in extensions, such as ``extra`` or ``toc``.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-markdown.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-markdown.py
@@ -10,7 +10,11 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import is_module_satisfies, collect_submodules
+from PyInstaller.utils.hooks import (
+    collect_submodules,
+    copy_metadata,
+    is_module_satisfies,
+)
 
 hiddenimports = collect_submodules('markdown.extensions')
 
@@ -18,3 +22,7 @@ hiddenimports = collect_submodules('markdown.extensions')
 # dependency on html.parser
 if is_module_satisfies("markdown >= 3.3"):
     hiddenimports += ['html.parser']
+
+# Extensions can be referenced by short names, e.g. "extra", through a mechanism
+# using entry-points. Thus we need to collect the package metadata as well.
+datas = copy_metadata("markdown")

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -144,10 +144,12 @@ def test_pylint(pyi_builder):
 @importorskip('markdown')
 def test_markdown(pyi_builder):
     # Markdown uses __import__ed extensions. Make sure these work by
-    # trying to use the 'toc' extension..
+    # trying to use the 'toc' extension, using both short and long format.
     pyi_builder.test_source(
         """
         import markdown
+        print(markdown.markdown('testing',
+            extensions=['toc']))
         print(markdown.markdown('testing',
             extensions=['markdown.extensions.toc']))
         """)


### PR DESCRIPTION
The markdown package uses entry-points to allow short names for built-in extensions, such as `extra` or `toc`. The hook has been updated so that the necessary package metadata is included in the build, enabling the same behavior as the unfrozen package.

This would resolve problems like https://github.com/Python-Markdown/markdown/issues/884.