### PR TITLE
CI/CD: Prevent the scheduled workflow from running on forks.

### DIFF
--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 18 * * FRI'
+      if: github.repository == 'pyinstaller/pyinstaller-hooks-contrib'
   pull_request:
 
 jobs:


### PR DESCRIPTION
I noticed that the CRON workflow is also running on all our forks instead of just this master repo. Fix this.