### PR TITLE
Include metadata for pytorch

### DIFF
--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-torch.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-torch.py
@@ -10,6 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import get_package_paths
+from PyInstaller.utils.hooks import copy_metadata, get_package_paths
 
-datas = [(get_package_paths('torch')[1],"torch"),]
+datas = copy_metadata("torch") + [(get_package_paths('torch')[1],"torch")]


### PR DESCRIPTION
Some 3rd-party packages (e.g., skorch)  requires pkg_resources.get_distribution()
of pytorch.

Example usage: https://github.com/skorch-dev/skorch/blob/9ac71e2acf8b814b65ee84ee6696e7441737e820/skorch/__init__.py#L29