### PR TITLE
Override pygraphviz' search for graphviz programs

### DIFF
--- a/news/357.update.rst
+++ b/news/357.update.rst
@@ -1,0 +1,3 @@
+Add a runtime hook for ``pygraphviz`` that modifies the search behavior
+for ``graphviz`` programs, in order to ensure that the collected programs
+in ``sys._MEIPASS`` are found and used.

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,4 +37,6 @@ where=src
 * = *.txt
 
 [flake8]
+# E265 - block comment should start with '# '
+extend-ignore = E265
 max-line-length=120

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks.dat
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks.dat
@@ -4,5 +4,6 @@
     'traitlets': ['pyi_rth_traitlets.py'],
     'usb': ['pyi_rth_usb.py'],
     'nltk': ['pyi_rth_nltk.py'],
-    'pyproj': ['pyi_rth_pyproj.py']
+    'pyproj': ['pyi_rth_pyproj.py'],
+    'pygraphviz': ['pyi_rth_pygraphviz.py'],
 }

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_pygraphviz.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_pygraphviz.py
@@ -1,0 +1,31 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2021, PyInstaller Development Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+#-----------------------------------------------------------------------------
+
+import pygraphviz
+
+# Override pygraphviz.AGraph._which method to search for graphviz executables inside sys._MEIPASS
+if hasattr(pygraphviz.AGraph, '_which'):
+    def _pygraphviz_override_which(self, name):
+        import os
+        import sys
+        import platform
+
+        program_name = name
+        if platform.system() == "Windows":
+            program_name += ".exe"
+
+        program_path = os.path.join(sys._MEIPASS, program_name)
+        if not os.path.isfile(program_path):
+            raise ValueError(f"Prog {name} not found in the PyInstaller-frozen application bundle!")
+
+        return program_path
+
+    pygraphviz.AGraph._which = _pygraphviz_override_which

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1024,3 +1024,19 @@ def test_twisted_custom_reactor(pyi_builder):
         from twisted.internet import reactor
         assert callable(reactor.listenTCP)
         """)
+
+
+@importorskip("pygraphviz")
+def test_pygraphviz_bundled_programs(pyi_builder):
+    # Test that the frozen application is using collected graphviz executables instead of system-installed ones.
+    pyi_builder.test_source("""
+        import sys
+        import os
+        import pygraphviz
+
+        bundle_dir = os.path.normpath(sys._MEIPASS)
+        dot_path = os.path.normpath(pygraphviz.AGraph()._get_prog('dot'))
+
+        assert os.path.commonprefix([dot_path, bundle_dir]) == bundle_dir, \
+            f"Invalid program path: {dot_path}!"
+        """)


### PR DESCRIPTION
Add a runtime hook that overrides `pygraphviz.AGraph._which()` method with custom implementation that searches in `sys._MEIPASS` instead of `PATH`. This allows `pygraphviz` to use collected `graphviz` programs without having to have `sys._MEIPASS` prepended to `PATH` (which it usually it not).

Fixes #357.