### PR TITLE
hooks: update tensorflow hook to support tensorflow 2.6 and later

### DIFF
--- a/news/371.update.rst
+++ b/news/371.update.rst
@@ -1,0 +1,1 @@
+Update ``tensorflow``  hook to add support for ``tensorflow`` 2.6.x and later.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tensorflow.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tensorflow.py
@@ -67,4 +67,9 @@ else:
                                        filter=_submodules_filter)
     datas = collect_data_files('tensorflow', excludes=data_excludes)
 
+    # From 2.6.0 on, we also need to explicitly collect keras (due to
+    # lazy mapping of tensorflow.keras.xyz -> keras.xyz)
+    if is_module_satisfies("tensorflow >= 2.6.0"):
+        hiddenimports += collect_submodules('keras')
+
 excludedimports = excluded_submodules


### PR DESCRIPTION
We need to explicitly collect keras package and its submodules due to lazy mapping of `tensorflow.keras.xyz` -> `keras.xyz`.

Fixes pyinstaller/pyinstaller#6519. Fixes pyinstaller/pyinstaller#6538.