### PR TITLE
Add hook for py to fix frozen pytest runner.

### DIFF
--- a/news/376.new.rst
+++ b/news/376.new.rst
@@ -1,0 +1,2 @@
+Add a hook for ``py`` which has dynamically loaded vendored submodules.
+This fixes compatibility with ``pytest >= 7.0.0``.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-py.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-py.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2022 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_submodules
+
+hiddenimports = collect_submodules("py._path")


### PR DESCRIPTION
This fixes [the failing pytest-runner test](https://github.com/pyinstaller/pyinstaller-hooks-contrib/actions/runs/1803605477). [CI/CD](https://github.com/bwoodsend/pyinstaller-hooks-contrib/actions/runs/1808937412)