### PR TITLE
Add a hook for altair

### DIFF
--- a/news/387.new.rst
+++ b/news/387.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``altair``, which has data files.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -80,6 +80,7 @@ zeep==4.1.0
 pypsexec==0.3.0
 mimesis==5.3.0; python_version >= '3.8'
 orjson==3.6.7
+altair==4.2.0; python_version >= '3.7'
 
 
 # ------------------- Platform (OS) specifics

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-altair.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-altair.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files("altair")

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1063,3 +1063,10 @@ def test_orjson(pyi_builder):
     pyi_builder.test_source("""
         import orjson
         """)
+
+
+@importorskip('altair')
+def test_altair(pyi_builder):
+    pyi_builder.test_source("""
+        import altair
+        """)


### PR DESCRIPTION
Added a hook for altair that collects some required JSON schema files. Successful test: https://github.com/cascade256/pyinstaller-hooks-contrib/actions/runs/1885014947


By the way, really helpful instructions for contributing!