### PR TITLE
Add hook for geopandas, which reads data files during import.

### DIFF
--- a/news/400.new.rst
+++ b/news/400.new.rst
@@ -1,0 +1,1 @@
+Add geopandas data files for ``geopandas==0.10.2``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -22,6 +22,7 @@ fabric==2.7.1
 fiona==1.8.21; sys_platform != 'win32'
 folium==0.12.1.post1
 ffpyplayer==4.3.5; python_version < '3.10' # doesn't have py310 wheels
+geopandas==0.10.2
 python-gitlab==3.9.0
 h5py==3.7.0; python_version >= '3.7'
 humanize==4.3.0

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -22,7 +22,7 @@ fabric==2.7.1
 fiona==1.8.21; sys_platform != 'win32'
 folium==0.12.1.post1
 ffpyplayer==4.3.5; python_version < '3.10' # doesn't have py310 wheels
-geopandas==0.10.2
+geopandas==0.10.2; sys_platform != 'win32'
 python-gitlab==3.9.0
 h5py==3.7.0; python_version >= '3.7'
 humanize==4.3.0

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -22,7 +22,7 @@ fabric==2.7.1
 fiona==1.8.21; sys_platform != 'win32'
 folium==0.12.1.post1
 ffpyplayer==4.3.5; python_version < '3.10' # doesn't have py310 wheels
-geopandas==0.10.2; sys_platform != 'win32'
+geopandas==0.10.2; python_version >= '3.8' and sys_platform != 'win32'
 python-gitlab==3.9.0
 h5py==3.7.0; python_version >= '3.7'
 humanize==4.3.0

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-geopandas.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-geopandas.py
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+
+from PyInstaller.utils.hooks import collect_data_files
+
+
+datas = collect_data_files("geopandas", subdir="datasets")

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -40,8 +40,8 @@ def test_jinxed(pyi_builder):
 
 
 @importorskip("geopandas")
-def test_geopandas(test):
-    test.test_source(
+def test_geopandas(pyi_builder):
+    pyi_builder.test_source(
         '''
         import geopandas
         '''

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -39,6 +39,15 @@ def test_jinxed(pyi_builder):
     )
 
 
+@importorskip("geopandas")
+def test_geopandas(test):
+    test.test_source(
+        '''
+        import geopandas
+        '''
+    )
+
+
 def tensorflow_onedir_only(test):
     def wrapped(pyi_builder):
         if pyi_builder._mode != 'onedir':


### PR DESCRIPTION
Tested for geopandas 0.10.2 and pyinstaller 4.10

See also these SO questions:
* https://stackoverflow.com/a/51957870
* https://stackoverflow.com/questions/56804095/pyinstaller-stopiteration-error-when-i-import-geopandas