### PR TITLE
CI/CD: Prevent Windows from skipping over a failed pip install.

### DIFF
--- a/.github/workflows/oneshot-test.yml
+++ b/.github/workflows/oneshot-test.yml
@@ -124,6 +124,7 @@ jobs:
         run: ${{ github.event.inputs.commands }}
 
       - name: Install dependencies
+        shell: bash
         run: |
           # Upgrade to the latest pip.
           python -m pip install -U pip setuptools wheel

--- a/.github/workflows/pyup-test.yml
+++ b/.github/workflows/pyup-test.yml
@@ -68,6 +68,7 @@ jobs:
           brew install cairo
 
       - name: Install dependencies
+        shell: bash
         run: |
           # Upgrade to the latest pip.
           python -m pip install -U pip setuptools wheel


### PR DESCRIPTION
Multi-command run statements on Windows CI are executed via powershell without any equivalent to bash's `-e` option so that a failed pip install will not set an error exit code for the step and proceed onto running the tests (and most likely passing when it shouldn't).

CI run: https://github.com/bwoodsend/pyinstaller-hooks-contrib/actions/runs/2082924736