### PR TITLE
Add hook for lark

### DIFF
--- a/news/409.new.rst
+++ b/news/409.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``lark`` (used by ``commentjson`` and others) that loads the needed grammar files.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -88,7 +88,7 @@ orjson==3.6.7
 altair==4.2.0; python_version >= '3.7'
 # For some reason, shapely provides only arm64 py310 macOS wheel.
 shapely==1.8.1post1; sys_platform != 'darwin' or python_version < '3.10'
-
+lark==1.1.2
 
 # ------------------- Platform (OS) specifics
 

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -90,6 +90,7 @@ altair==4.2.0; python_version >= '3.7'
 shapely==1.8.1post1; sys_platform != 'darwin' or python_version < '3.10'
 lark==1.1.2
 
+
 # ------------------- Platform (OS) specifics
 
 # PyEnchant only pre-builds macOS and Windows

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-lark.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-lark.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2022 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files("lark")

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1108,3 +1108,14 @@ def test_shapely(pyi_builder):
         patch = Point(0.0, 0.0).buffer(10.0)
         print(patch.area)
         """)
+
+
+@importorskip('lark')
+def test_lark(pyi_builder):
+    pyi_builder.test_source("""
+        import lark
+        parser = lark.Lark('''
+            value: "true"
+            %import common.SIGNED_NUMBER''',
+            start='value')
+    """)


### PR DESCRIPTION
I came across this issue when using [`commentjson`](https://pypi.org/project/commentjson/). Some Lark `.grammar` files that are needed were not being included when any sort of Lark `%import` was used. This should fix the issue for both the https://pypi.org/project/lark/ and older https://pypi.org/project/lark-parser/ packages (both install to `lark` inside `site-packages`).

Here are the CI results: https://github.com/NathanVaughn/pyinstaller-hooks-contrib/actions/runs/2157919610
Python 3.6 failed as it was unavailable, but I see that that the `setup.cfg` lists `>=3.7`.

I think I got everything, but let me know if I missed something!