### PR TITLE
update hook-weasyprint.py

### DIFF
--- a/news/410.update.rst
+++ b/news/410.update.rst
@@ -1,0 +1,1 @@
+Update the weasyprint hook to include GTK+ dlls on windows

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-weasyprint.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-weasyprint.py
@@ -11,8 +11,23 @@
 # ------------------------------------------------------------------
 
 # Hook for weasyprint: https://pypi.python.org/pypi/WeasyPrint
-# Tested on version weasyprint 0.24 using Windows 7 and python 2.7
+# Tested on version weasyprint 0.24 using Windows 10 and python 3.9
+
+import os
 
 from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.compat import is_win
 
-datas = collect_data_files('weasyprint')
+datas, binaries = [], []
+datas += collect_data_files('weasyprint')
+
+# the dll_directories code is equivalent to the one in weasyprint/text/ffi.py
+if is_win:
+    dll_directories = os.getenv(
+        'WEASYPRINT_DLL_DIRECTORIES',
+        'C:\\Program Files\\GTK3-Runtime Win64\\bin').split(';')
+    
+    for dll_directory in dll_directories:
+        binaries += [(os.path.join(dll_directory, '*.dll', '.')]
+        if os.path.isdir(os.path.join(os.path.dirname(dll_directory), 'etc')):
+            datas += [(os.path.join(os.path.dirname(dll_directory), 'etc'), 'etc')]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-weasyprint.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-weasyprint.py
@@ -26,8 +26,9 @@ if is_win:
     dll_directories = os.getenv(
         'WEASYPRINT_DLL_DIRECTORIES',
         'C:\\Program Files\\GTK3-Runtime Win64\\bin').split(';')
-    
+
     for dll_directory in dll_directories:
-        binaries += [(os.path.join(dll_directory, '*.dll', '.')]
+        if os.path.isdir(dll_directory):
+            binaries.append((os.path.join(dll_directory, '*.dll'), '.'))
         if os.path.isdir(os.path.join(os.path.dirname(dll_directory), 'etc')):
-            datas += [(os.path.join(os.path.dirname(dll_directory), 'etc'), 'etc')]
+            datas.append((os.path.join(os.path.dirname(dll_directory), 'etc'), 'etc'))


### PR DESCRIPTION
weasyprint tries to `ffi.dlopen()` some GTK+ libraries. With the update, these are added to binaries array at least on windows (I don't know how to find the files on the various linux distributions)

See https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#windows and https://github.com/Kozea/WeasyPrint/blob/master/weasyprint/text/ffi.py#L388-L413 for reference.

