### PR TITLE
Add hook for python-stdnum

### DIFF
--- a/news/412.new.rst
+++ b/news/412.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``python-stdnum``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -89,6 +89,7 @@ altair==4.2.0; python_version >= '3.7'
 # For some reason, shapely provides only arm64 py310 macOS wheel.
 shapely==1.8.1post1; sys_platform != 'darwin' or python_version < '3.10'
 lark==1.1.2
+python-stdnum==1.17
 
 
 # ------------------- Platform (OS) specifics

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-stdnum.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-stdnum.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2022 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# Collect data files that are required by some of the stdnum's sub-modules
+from PyInstaller.utils.hooks import collect_data_files
+datas = collect_data_files("stdnum")

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1119,3 +1119,10 @@ def test_lark(pyi_builder):
             %import common.SIGNED_NUMBER''',
             start='value')
     """)
+
+
+@importorskip('stdnum')
+def test_stdnum_iban(pyi_builder):
+    pyi_builder.test_source("""
+        import stdnum.iban
+    """)


### PR DESCRIPTION
Collect data files required by some of the stdnum's sub-modules.

Closes pyinstaller/pyinstaller#6770.