### PR TITLE
Run CI testing on any pull request touching the requirements file.

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,10 +1,12 @@
-name: PyUp CI
+name: Pull Request CI
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
   workflow_dispatch:
   pull_request:
+    paths:
+      - requirements-test-libraries.txt
 
 jobs:
   test:


### PR DESCRIPTION
This replaces the trigger for pull requests coming from the PyUp bot and
hopefully will remove the need to manually invoke the oneshot workflow on
incoming pull requests.