### PR TITLE
Create hook-grpc.py

### DIFF
--- a/news/419.new.rst
+++ b/news/419.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``grpc`` roots.pem file which is used by grpc.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-grpc.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-grpc.py
@@ -1,0 +1,2 @@
+from PyInstaller.utils.hooks import collect_data_files
+datas = collect_data_files('grpc')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-grpc.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-grpc.py
@@ -1,2 +1,14 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2022 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
 from PyInstaller.utils.hooks import collect_data_files
 datas = collect_data_files('grpc')


### PR DESCRIPTION
relates to common issue when packaging google cloud api via pyinstaller
https://github.com/googleapis/google-cloud-python/issues/5774#issuecomment-480509426

thanks to @cbenhagen