### PR TITLE
Add hook for numcodecs

### DIFF
--- a/news/420.new.rst
+++ b/news/420.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``numcodecs``, which has a hidden import.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -34,6 +34,7 @@ markdown==3.3.6
 # MetPy==1.2.0; python_version >= '3.7'
 mnemonic==0.20
 msoffcrypto-tool==5.0.0
+numcodecs==0.9.1; python_version < '3.10' # doesn't have python 3.10 wheels yet
 Office365-REST-Python-Client==2.3.11
 openpyxl==3.0.9
 pandas==1.4.1; python_version >= '3.8'

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-numcodecs.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-numcodecs.py
@@ -1,0 +1,14 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2022 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# compat_ext is only imported from pyx files, so it is missed
+hiddenimports = ['numcodecs.compat_ext']

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1131,5 +1131,8 @@ def test_stdnum_iban(pyi_builder):
 @importorskip('numcodecs')
 def test_numcodecs(pyi_builder):
     pyi_builder.test_source("""
+        # numcodecs uses multiprocessing
+        import multiprocessing
+        multiprocessing.freeze_support()
         from numcodecs import Blosc
     """)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1126,3 +1126,10 @@ def test_stdnum_iban(pyi_builder):
     pyi_builder.test_source("""
         import stdnum.iban
     """)
+
+
+@importorskip('numcodecs')
+def test_numcodecs(pyi_builder):
+    pyi_builder.test_source("""
+        from numcodecs import Blosc
+    """)


### PR DESCRIPTION
numcodecs.compat_ext is only imported from pyx files, so it is missed.

Fixes: zarr-developers/numcodecs#291