### PR TITLE
hooks: mariadb: always collect decimal module as hidden import

### DIFF
--- a/news/426.update.rst
+++ b/news/426.update.rst
@@ -1,0 +1,3 @@
+Update ``mariadb`` hook to always include the ``decimal`` module as a
+hidden import, instead of implicitly relying on it being picked up due
+to import in some other, unrelated module.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-mariadb.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-mariadb.py
@@ -10,11 +10,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
-from PyInstaller.compat import is_py38
-
-
-# The MariaDB uses a .pyd file and uses import within its __init__.py
-# The decimal import seems to be hidden in Python version 3.7 and older
-if not is_py38:
-    hiddenimports = ['decimal']
+# The MariaDB uses a .pyd file that imports ``decimal`` module within its
+# module initialization function. On recent python versions (> 3.8), the decimal
+# module seems to be picked up nevertheless (presumably due to import in some
+# other module), but it is better not to rely on that, and ensure it is always
+# collected as a hidden import.
+hiddenimports = ['decimal']


### PR DESCRIPTION
Always collect the `decimal` module as a hidden import, even if it seems to be automatically picked up on recent python versions.
That likely happens due to import in some other module (e.g., from standard library), but may be subject to change in the future,
so we should not be relying on it. Besides, the hidden import does no harm, even if it is redundant.