### PR TITLE
 hooks: update sounddevice and soundfile hooks for PyInstaller 5.1

### DIFF
--- a/news/432.update.rst
+++ b/news/432.update.rst
@@ -1,0 +1,2 @@
+Update ``sounddevice`` and ``soundfile`` hooks for PyInstaller 5.1
+compatibility.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -91,7 +91,10 @@ altair==4.2.0; python_version >= '3.7'
 shapely==1.8.2; sys_platform != 'darwin' or python_version < '3.10'
 lark==1.1.2
 python-stdnum==1.17
-
+# On linux, sounddevice and soundfile use system-provided libportaudio
+# and libsndfile, respectively.
+sounddevice==0.4.4; sys_platform != 'linux'
+soundfile==0.10.3.post1; sys_platform != 'linux'
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sounddevice.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sounddevice.py
@@ -19,18 +19,15 @@ https://github.com/spatialaudio/python-sounddevice/
 import os
 
 from PyInstaller.compat import is_darwin, is_win
-from PyInstaller.utils.hooks import get_package_paths
+from PyInstaller.utils.hooks import get_module_file_attribute
 
-sfp = get_package_paths("sounddevice")
+module_dir = os.path.dirname(get_module_file_attribute("sounddevice"))
 
 path = None
 if is_win:
-    path = os.path.join(sfp[0], "_sounddevice_data", "portaudio-binaries")
+    path = os.path.join(module_dir, "_sounddevice_data", "portaudio-binaries")
 elif is_darwin:
-    path = os.path.join(
-        sfp[0], "_sounddevice_data", "portaudio-binaries", "libportaudio.dylib"
-    )
+    path = os.path.join(module_dir, "_sounddevice_data", "portaudio-binaries", "libportaudio.dylib")
 
 if path is not None and os.path.exists(path):
-    binaries = [(path,
-                 os.path.join("_sounddevice_data", "portaudio-binaries"))]
+    binaries = [(path, os.path.join("_sounddevice_data", "portaudio-binaries"))]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-soundfile.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-soundfile.py
@@ -18,18 +18,18 @@ https://github.com/bastibe/SoundFile
 import os
 
 from PyInstaller.compat import is_win, is_darwin
-from PyInstaller.utils.hooks import get_package_paths
+from PyInstaller.utils.hooks import get_module_file_attribute
 
 # get path of soundfile
-sfp = get_package_paths('soundfile')
+module_dir = os.path.dirname(get_module_file_attribute('soundfile'))
 
 # add binaries packaged by soundfile on OSX and Windows
 # an external dependency (libsndfile) is used on GNU/Linux
 path = None
 if is_win:
-    path = os.path.join(sfp[0], '_soundfile_data')
+    path = os.path.join(module_dir, '_soundfile_data')
 elif is_darwin:
-    path = os.path.join(sfp[0], '_soundfile_data', 'libsndfile.dylib')
+    path = os.path.join(module_dir, '_soundfile_data', 'libsndfile.dylib')
 
 if path is not None and os.path.exists(path):
     binaries = [(path, "_soundfile_data")]

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1142,3 +1142,17 @@ def test_numcodecs(pyi_builder):
         multiprocessing.freeze_support()
         from numcodecs import Blosc
     """)
+
+
+@importorskip('sounddevice')
+def test_sounddevice(pyi_builder):
+    pyi_builder.test_source("""
+        import sounddevice
+    """)
+
+
+@importorskip('soundfile')
+def test_soundfile(pyi_builder):
+    pyi_builder.test_source("""
+        import soundfile
+    """)


### PR DESCRIPTION
Update hooks for PyInstaller 5.1 compatibility. As `sounddevice` and `soundfile` are not packages but top-level modules, the hookutils `get_package_paths()` now fails due to changes made in PyInstaller 5.1. Both hooks should have been using `get_module_file_attribute()` instead.

Fixes #432.