### PR TITLE
hooks: pylint: fix filter function passed to collect_submodules

### DIFF
--- a/news/435.update.rst
+++ b/news/435.update.rst
@@ -1,0 +1,2 @@
+Fix the filter function used with ``collect_submodules`` in the ``pylint``
+hook to properly exclude ``pylint.testutils``.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pylint.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pylint.py
@@ -60,7 +60,15 @@ datas = (
          collect_data_files('pylint.reporters', True)
          )
 
-# Add imports from dynamically loaded modules excluding tests and testutils
-hiddenimports = collect_submodules('pylint',
-                                   lambda name: (not is_module_or_submodule(name, 'pylint.test')) and
-                                   (not name == 'testutils'))
+
+# Add imports from dynamically loaded modules, excluding pylint.test
+# subpackage (pylint <= 2.3) and pylint.testutils submodule (pylint < 2.7)
+# or subpackage (pylint >= 2.7)
+def _filter_func(name):
+    return (
+        not is_module_or_submodule(name, 'pylint.test') and
+        not is_module_or_submodule(name, 'pylint.testutils')
+    )
+
+
+hiddenimports = collect_submodules('pylint', _filter_func)


### PR DESCRIPTION
Fix filter function passed to `collect_submodules` to correctly exclude both `pylint.test` sub-package (available in `pylint` <= 2.3) and `pylint.testutils submodule` (`pylint` < 2.7) or subpackage (>= `2.7`).

Previously, `pylint.testutils` and its contents were not excluded.

Closes #435.