### PR TITLE
hooks: add hook for yt_dlp

### DIFF
--- a/news/438.new.rst
+++ b/news/438.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``yt_dlp`` to handle indirect import in ``yt-dlp v2022.05.18``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -95,6 +95,7 @@ python-stdnum==1.17
 # and libsndfile, respectively.
 sounddevice==0.4.4; sys_platform != 'linux'
 soundfile==0.10.3.post1; sys_platform != 'linux'
+yt-dlp==2022.5.18
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-yt_dlp.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-yt_dlp.py
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2022 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import is_module_satisfies
+
+# As of v2022.05.18, yt_dlp requires a hidden import of yt_dlp.compat._legacy due to indirect import
+if is_module_satisfies("yt_dlp >= 2022.05.18"):
+    hiddenimports = ['yt_dlp.compat._legacy']

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1156,3 +1156,10 @@ def test_soundfile(pyi_builder):
     pyi_builder.test_source("""
         import soundfile
     """)
+
+
+@importorskip('yt_dlp')
+def test_yt_dlp(pyi_builder):
+    pyi_builder.test_source("""
+        import yt_dlp
+    """)


### PR DESCRIPTION
Add hook for yt_dlp to handle indirect import in yt-dlp v2022.05.18.

Fixes #438.