### PR TITLE
hooks: add pre-safe-import hook for tensorflow >= 2.8.0

### DIFF
--- a/news/451.update.rst
+++ b/news/451.update.rst
@@ -1,0 +1,2 @@
+Fix ``tensorflow`` not being collected at all when using ``tensorflow``
+2.8.0 or newer and importing only from the ``tensorflow.keras`` subpackage.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -100,6 +100,7 @@ soundfile==0.10.3.post1; sys_platform != 'linux'
 yt-dlp==2022.5.18
 limits==2.6.3
 great-expectations==0.15.9
+tensorflow==2.9.1
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/pre_safe_import_module/hook-tensorflow.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/pre_safe_import_module/hook-tensorflow.py
@@ -1,0 +1,23 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import is_module_satisfies
+
+
+def pre_safe_import_module(api):
+    # As of tensorflow 2.8.0, the `tensorflow.keras` is entirely gone, replaced by a lazy-loaded alias for
+    # `keras.api._v2.keras`. Without us registering the alias here, a program that imports only from
+    # `tensorflow.keras` fails to collect `tensorflow`.
+    # See: https://github.com/pyinstaller/pyinstaller/discussions/6890
+    # The alias was already present in earlier releases, but it does not seem to be causing problems there,
+    # so keep this specific to tensorflow >= 2.8.0 to avoid accidentally breaking something else.
+    if is_module_satisfies("tensorflow >= 2.8.0"):
+        api.add_alias_module('keras.api._v2.keras', 'tensorflow.keras')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -55,6 +55,20 @@ def test_tensorflow(pyi_builder):
     )
 
 
+# Test if tensorflow.keras imports properly result in tensorflow being collected.
+# See https://github.com/pyinstaller/pyinstaller/discussions/6890
+@importorskip('tensorflow')
+@tensorflow_onedir_only
+def test_tensorflow_keras_import(pyi_builder):
+    pyi_builder.test_source(
+        """
+        from tensorflow.keras.models import Sequential
+        from tensorflow.keras.layers import Dense, LSTM, Dropout
+        from tensorflow.keras.optimizers import Adam
+        """
+    )
+
+
 @importorskip('tensorflow')
 @tensorflow_onedir_only
 def test_tensorflow_layer(pyi_builder):


### PR DESCRIPTION
Register the alias `tensorflow.keras` = `keras.api._v2.keras`, which is required as of `tensorflow >= 2.8.0` for programs that import
only from `tensorflow.keras`.

Add a new import test for `tensorflow.keras` that demonstrates the issue. 

See https://github.com/pyinstaller/pyinstaller/discussions/6890