### PR TITLE
 hooks: cv2: collect Qt fonts data and plugins from linux PyPI wheels

### DIFF
--- a/news/453.update.rst
+++ b/news/453.update.rst
@@ -1,0 +1,2 @@
+(Linux) Ensure that OpenCV hook collects Qt plugins and font files that
+are bundled with linux versions of ``opencv-python`` PyPI wheels.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -102,6 +102,8 @@ limits==2.6.3
 great-expectations==0.15.10
 tensorflow==2.9.1
 pyshark==0.4.6
+# We do not support loader in newer OpenCV versions yet...
+opencv-python==4.5.5.64  # pyup: ignore
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cv2.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cv2.py
@@ -12,8 +12,9 @@
 
 import glob
 import os
+import pathlib
 
-from PyInstaller.utils.hooks import collect_dynamic_libs, collect_data_files
+from PyInstaller.utils.hooks import collect_dynamic_libs, collect_data_files, get_module_file_attribute
 from PyInstaller import compat
 
 hiddenimports = ['numpy']
@@ -34,3 +35,24 @@ if compat.is_win:
 
 # OpenCV loader from 4.5.4.60 requires extra config files and modules
 datas = collect_data_files('cv2', include_py_files=True, includes=['**/*.py'])
+
+# In linux PyPI opencv-python wheels, the cv2 extension is linked against Qt, and the wheel bundles a basic subset of Qt
+# shared libraries, plugins, and font files. This is not the case on other OSes (presumably native UI APIs are used by
+# OpenCV HighGUI module), nor in the headless PyPI wheels (opencv-python-headless).
+# The bundled Qt shared libraries should be picked up automatically due to binary dependency analysis, but we need to
+# collect plugins and font files from the `qt` subdirectory.
+if compat.is_linux:
+    pkg_path = pathlib.Path(get_module_file_attribute('cv2')).parent
+    # Collect .ttf files fron fonts directory.
+    # NOTE: since we are using glob, we can skip checks for (sub)directories' existence.
+    qt_fonts_dir = pkg_path / 'qt' / 'fonts'
+    datas += [
+        (str(font_file), str(font_file.parent.relative_to(pkg_path.parent)))
+        for font_file in qt_fonts_dir.rglob('*.ttf')
+    ]
+    # Collect .so files from plugins directory.
+    qt_plugins_dir = pkg_path / 'qt' / 'plugins'
+    binaries += [
+        (str(plugin_file), str(plugin_file.parent.relative_to(pkg_path.parent)))
+        for plugin_file in qt_plugins_dir.rglob('*.so')
+    ]

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1032,6 +1032,19 @@ def test_cv2(pyi_builder):
         """)
 
 
+# Requires OpenCV with enabled HighGUI
+@importorskip("cv2")
+def test_cv2_highgui(pyi_builder):
+    pyi_builder.test_source("""
+        import cv2
+        import numpy as np
+
+        img = np.zeros((64, 64), dtype='uint8')
+        cv2.imshow("Test", img)
+        cv2.waitKey(1000)  # Wait a second
+        """)
+
+
 @importorskip("twisted")
 def test_twisted_default_reactor(pyi_builder):
     pyi_builder.test_source("""


### PR DESCRIPTION
In linux PyPI `opencv-python` wheels, the `cv2` extension is linked against Qt, and the wheel bundles a basic subset of Qt shared libraries, plugins, and font files. This is not the case on other OSes (presumably native UI APIs are used by the OpenCV HighGUI
module), nor in the headless PyPI wheels (`opencv-python-headless`).

The bundled Qt shared libraries should be picked up automatically due to binary dependency analysis, but we need to collect  plugins and font files from the `qt` subdirectory.