### PR TITLE
hooks: add hook for pandas_flavor

### DIFF
--- a/news/455.new.rst
+++ b/news/455.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``pandas_flavor`` to handle hidden imports in version 0.3.0
+of the package.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pandas_flavor.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pandas_flavor.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2022 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# As of version 0.3.0, pandas_flavor uses lazy loader to import `register` and `xarray` sub-modules. In earlier
+# versions, these used to be imported directly.
+hiddenimports = ['pandas_flavor.register', 'pandas_flavor.xarray']


### PR DESCRIPTION
Add hook for `pandas_flavor` to handle hidden imports caused by switch to lazy loader in version 0.3.0 of the package.