### PR TITLE
hooks: update scikit-learn for compatibility with 1.0.x and 1.1.x series

### DIFF
--- a/news/456.update.rst
+++ b/news/456.update.rst
@@ -1,0 +1,1 @@
+Update ``scikit-learn`` hooks for compatibility with 1.0.x and 1.1.x series.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sklearn.metrics.pairwise.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sklearn.metrics.pairwise.py
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2022 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# Required by scikit-learn 1.1.0
+from PyInstaller.utils.hooks import is_module_satisfies
+
+if is_module_satisfies("scikit-learn >= 1.1.0"):
+    hiddenimports = [
+        'sklearn.utils._heap',
+        'sklearn.utils._sorting',
+        'sklearn.utils._vector_sentinel',
+    ]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sklearn.metrics.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sklearn.metrics.py
@@ -1,0 +1,19 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2022 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# Required by scikit-learn 1.0.0
+from PyInstaller.utils.hooks import is_module_satisfies
+
+if is_module_satisfies("scikit-learn >= 1.0.0"):
+    hiddenimports = [
+        'sklearn.utils._typedefs',
+    ]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sklearn.neighbors.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sklearn.neighbors.py
@@ -30,3 +30,7 @@ else:
 # The following hidden import must be added here
 # (as opposed to sklearn.tree)
 hiddenimports += ['sklearn.tree._criterion']
+
+# Additional hidden imports introduced in v1.0.0
+if is_module_satisfies("scikit_learn >= 1.0.0"):
+    hiddenimports += ["sklearn.neighbors._partition_nodes"]


### PR DESCRIPTION
A year has gone by, and we have happily forgotten that `scikit-learn` exists. In the meantime, 1.0.x and 1.1.x series have been released, which bring more compiled extensions, and thus more hidden imports that we need to handle.

Fixes #456.