### PR TITLE
add zstandard libraries from hdf5plugin for dclab hook

### DIFF
--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dclab.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dclab.py
@@ -15,3 +15,6 @@
 from PyInstaller.utils.hooks import collect_data_files
 
 datas = collect_data_files('dclab')
+
+# Add the Zstandard library used by dclab by default
+datas += collect_data_files("hdf5plugin", includes=["plugins/libh5zstd.*"])


### PR DESCRIPTION
The package dclab uses the Zstandard compression algorithm HDF5 plugin from the hdf5plugin package. This pull request makes sure that the corresponding dll/so/dylib files are present in the distribution. I am the author of dclab.
https://github.com/ZellMechanik-Dresden/dclab