### PR TITLE
ci: install MariaDB connector from official MariaDB CS repository

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -44,6 +44,20 @@ jobs:
         with:
           dotnet-version: '5.x'
 
+      # Install MariaDB Connector/C from official MariaDB Community Server
+      # repository. The version shipped with ubuntu-20.04 is too old for
+      # the "mariadb" python package.
+      - name: Install MariaDB Connector/C
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install wget curl
+          wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+          echo "d4e4635eeb79b0e96483bd70703209c63da55a236eadd7397f769ee434d92ca8  mariadb_repo_setup" | sha256sum -c -
+          chmod +x mariadb_repo_setup
+          sudo ./mariadb_repo_setup --mariadb-server-version="mariadb-10.6"
+          sudo apt-get install libmariadb3 libmariadb-dev
+
       - name: Install apt dependencies
         if: startsWith(matrix.os, 'ubuntu')
         run: |
@@ -51,8 +65,6 @@ jobs:
           # Set up a virtual screen (for GUI libraries and pynput).
           sudo apt-get install libxcb-xkb-dev xvfb
           Xvfb :99 & echo "DISPLAY=:99" >> $GITHUB_ENV
-          # Install mariadb dependencies.
-          sudo apt-get install -y libmariadbclient-dev
           # Install PyQt5 (qtmodern) dependencies.
           sudo apt-get install -y libxcb-keysyms1 libxcb-render-util0 \
             libxkbcommon-x11-0 libxcb-icccm4 libxcb1 openssl \

--- a/news/463.update.rst
+++ b/news/463.update.rst
@@ -1,0 +1,1 @@
+Update ``mariadb`` hook for compatibility with 1.1.x series.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -28,7 +28,7 @@ humanize==4.2.1
 iminuit==2.12.0
 kaleido==0.2.1  # pyup: != 0.2.1.post1  # Contains only an invalid armv7l wheel.
 langdetect==1.0.9
-mariadb==1.0.11; sys_platform != "darwin"
+mariadb==1.1.3; sys_platform != "darwin"
 markdown==3.3.7
 # MetPy is no longer runable with PyInstaller since matplotlib made pillow a dependency. See #395.
 # MetPy==1.2.0; python_version >= '3.7'

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-mariadb.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-mariadb.py
@@ -10,9 +10,17 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
+from PyInstaller.utils.hooks import is_module_satisfies, collect_submodules
+
 # The MariaDB uses a .pyd file that imports ``decimal`` module within its
 # module initialization function. On recent python versions (> 3.8), the decimal
 # module seems to be picked up nevertheless (presumably due to import in some
 # other module), but it is better not to rely on that, and ensure it is always
 # collected as a hidden import.
 hiddenimports = ['decimal']
+
+
+# mariadb >= 1.1.0 requires several hidden imports from mariadb.constants.
+# Collect them all, just to be on the safe side...
+if is_module_satisfies("mariadb >= 1.1.0"):
+    hiddenimports += collect_submodules("mariadb.constants")


### PR DESCRIPTION
Install MariaDB Connector/C from official MariaDB Community Server repository. The version shipped with Ubuntu 20.04 is too old and is not supported by `mariadb` >= 1.1.3.