### PR TITLE
Fix hook-pyqtgraph for PyInstaller 5.2

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -37,6 +37,7 @@ jobs:
           > requirements-test-libraries.txt
           set -e
           echo '-r requirements-test.txt' >> requirements-test-libraries.txt
+          if grep -q pyqtgraph requirements-test-libraries.txt ; then echo PyQt5 >> requirements-test-libraries.txt ;fi
           cat requirements-test-libraries.txt
 
       - name: Set up .NET Core for pythonnet tests

--- a/news/465.bugfix.rst
+++ b/news/465.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``pyqtgraph`` hook for PyInstaller 5.2.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -55,6 +55,7 @@ pylint==2.14.4
 pypemicro==0.1.9
 pyphen==0.12.0
 pyppeteer==1.0.2
+pyqtgraph==0.12.4
 pyusb==1.2.1
 pyviz-comms==2.2.0
 pyvjoy==1.0.1; sys_platform == 'win32'

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyqtgraph.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyqtgraph.py
@@ -28,8 +28,9 @@ datas = collect_data_files("pyqtgraph",
 # - pyqtgraph.graphicsItems.PlotItem.plotConfigTemplate_pyside2
 # - pyqtgraph.graphicsItems.PlotItem.plotConfigTemplate_pyside6
 #
-# To be future-proof, we include all of them via a filter in
-# collect-submodules.
+# To be future-proof, we collect all modules by
+# using collect-submodules, and filtering the modules
+# which appear to be templates.
 # Tested with pyqtgraph master branch (commit c1900aa).
-hiddenimports = collect_submodules(
-    "pyqtgraph", filter=lambda name: "Template" in name)
+all_imports = collect_submodules("pyqtgraph")
+hiddenimports = [name for name in all_imports if "Template" in name]

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1238,6 +1238,7 @@ def test_pyshark(pyi_builder):
 
 
 @importorskip('pyqtgraph')
+@importorskip('PyQt5')
 def test_pyqtgraph(pyi_builder):
     pyi_builder.test_source(
         """

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1235,3 +1235,14 @@ def test_pyshark(pyi_builder):
         #print(data)
         """
     )
+
+
+@importorskip('pyqtgraph')
+def test_pyqtgraph(pyi_builder):
+    pyi_builder.test_source(
+        """
+        import pyqtgraph.graphicsItems.PlotItem
+        import pyqtgraph.graphicsItems.ViewBox.ViewBoxMenu
+        import pyqtgraph.imageview.ImageView
+        """
+    )


### PR DESCRIPTION
In 5.2 the collect_submodules function no longer recurses into
filtered packages (introduced in https://github.com/pyinstaller/pyinstaller/commit/17aa452741f71b9ac4bab0b3cbe566d68a0bdf5f), which broke the pyqtgraph hooks which relied on that behavior.

This fixes the hook by collecting all modules with `collect_submodules`, and filtering
for the hidden modules manually.

Took the opportunity to add tests for `pyqtgraph`.

Fixes #465