### PR TITLE
Couple of CI improvements

### DIFF
--- a/.github/workflows/oneshot-test.yml
+++ b/.github/workflows/oneshot-test.yml
@@ -41,6 +41,10 @@ on:
           Use ';' to separate multiple commands.
         required: false
 
+env:
+  # Colored pytest output on CI despite not having a tty
+  FORCE_COLOR: 1
+
 jobs:
   generate-matrix:
     # Parse inputs into a json containing the matrix that will parametrize the

--- a/.github/workflows/oneshot-test.yml
+++ b/.github/workflows/oneshot-test.yml
@@ -109,6 +109,10 @@ jobs:
       # There doesn't seem to be a nice function to cast 'true' to true.
       fail-fast: ${{ github.event.inputs.fail-fast == 'true' }}
 
+    env:
+      # Rebuild bootloader when installing PyInstaller from develop branch
+      PYINSTALLER_COMPILE_BOOTLOADER: 1
+
     # Finally, the usual: setup Python, install dependencies, test.
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - requirements-test-libraries.txt
 
+env:
+  # Colored pytest output on CI despite not having a tty
+  FORCE_COLOR: 1
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -21,6 +21,11 @@ jobs:
         pyinstaller: ["https://github.com/pyinstaller/pyinstaller/archive/develop.zip"]
         os: ["macos-latest", "ubuntu-latest", "windows-latest"]
       fail-fast: false
+
+    env:
+      # Rebuild bootloader when installing PyInstaller from develop branch
+      PYINSTALLER_COMPILE_BOOTLOADER: 1
+
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -67,7 +67,7 @@ jobs:
           sudo apt-get install libxcb-xkb-dev xvfb
           Xvfb :99 & echo "DISPLAY=:99" >> $GITHUB_ENV
           # Install PyQt5 (qtmodern) dependencies.
-          sudo apt-get install -y libxcb-keysyms1 libxcb-render-util0 \
+          sudo apt-get install -y libxcb-image0 libxcb-keysyms1 libxcb-render-util0 \
             libxkbcommon-x11-0 libxcb-icccm4 libxcb1 openssl \
             libxcb-randr0-dev libxcb-xtest0-dev libxcb-xinerama0-dev \
             libxcb-shape0-dev libxcb-xkb-dev libopengl0 libegl1 \


### PR DESCRIPTION
- install `libxcb-image0` on ubuntu runners to keep PyQt5 happy
- enable colored output, like we do in the main repository
- force bootloader recompilation when installing PyInstaller from `develop` branch