### PR TITLE
hooks: force cv2 collection in source mode

### DIFF
--- a/news/468.update.rst
+++ b/news/468.update.rst
@@ -1,0 +1,6 @@
+Update ``cv2`` hook to add support for versions that attempt to perform module
+substitution via ``sys.path`` manipulation (== 4.5.4.58, >= 4.6.0.66) when used
+in combination with PyInstaller that supports setting module collection mode
+in hooks (> 5.2). The  contents of the ``cv2`` package are now collected in 
+source form to bypass PYZ archive and avoid compatibility issues with 
+PyInstaller's  ``FrozenImporter``

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -103,8 +103,7 @@ limits==2.7.0
 great-expectations==0.15.13
 tensorflow==2.9.1
 pyshark==0.4.6
-# We do not support loader in newer OpenCV versions yet...
-opencv-python==4.5.5.64  # pyup: ignore
+opencv-python==4.6.0.66
 
 # ------------------- Platform (OS) specifics
 


### PR DESCRIPTION
Collect the `cv2` package contents in pure source mode to bypass the PYZ archive and prevent compatibility issues between PyInstaller's `FrozenImporter` and `cv2` trying to perform module substitution by manipulating `sys.path`. This fixes problems with `opencv-python` and `opencv-python-headless` version 4.5.4.58 and >= 4.6.0.66, but requires PyInstaller with https://github.com/pyinstaller/pyinstaller/pull/6945 merged (i.e., PyInstaller > 5.2). On older PyInstaller versions, this change is no-op and the affected `cv2` versions remain defunct.

Closes pyinstaller/pyinstaller#6889.
Closes pyinstaller/pyinstaller#6964.

This fixes issues with cv2 loader script(s), so it should also fix the problems with loader that comes with OpenCV compiled from source (#110). However, if I recall correctly, in those cases the `cv2` extension that is found at `cv2/cv2.abi3.so` in PyPI wheels is placed in additional arch/compiler specific sub-directiories. Updating the hook to account for that is out of scope of this PR, though.