### PR TITLE
hooks: fix hook-pypylon for PyInstaller 5.1

### DIFF
--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pypylon.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pypylon.py
@@ -22,7 +22,6 @@
 
 import os
 
-from PyInstaller.utils.hooks import collect_all
 from PyInstaller.utils.hooks import collect_data_files
 from PyInstaller.utils.hooks import collect_dynamic_libs
 
@@ -35,7 +34,7 @@ datas += collect_data_files('pypylon')
 # Exclude the C++-extensions from automatic search, add them manually as data files
 # their dependencies were already handled with collect_dynamic_libs
 excludedimports = ['pypylon._pylon', 'pypylon._genicam']
-for filename, module in collect_all('pypylon')[0]:
+for filename, module in collect_data_files('pypylon', include_py_files=True):
     if (os.path.basename(filename).startswith('_pylon.')
             or os.path.basename(filename).startswith('_genicam.')):
         datas += [(filename, module)]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pypylon.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pypylon.py
@@ -35,7 +35,7 @@ datas += collect_data_files('pypylon')
 # Exclude the C++-extensions from automatic search, add them manually as data files
 # their dependencies were already handled with collect_dynamic_libs
 excludedimports = ['pypylon._pylon', 'pypylon._genicam']
-for filename, module in collect_all('pypylon._pylon')[0]:
+for filename, module in collect_all('pypylon')[0]:
     if (os.path.basename(filename).startswith('_pylon.')
             or os.path.basename(filename).startswith('_genicam.')):
         datas += [(filename, module)]


### PR DESCRIPTION
The hook was broken in Pyinstaller commit:
https://github.com/pyinstaller/pyinstaller/commit/20f922cdac0207e943395bcae4a23d597558c5f7

Before that, the hook worked "by accident".