### PR TITLE
hooks: update pywintypes and pythoncom hooks

### DIFF
--- a/news/474.update.rst
+++ b/news/474.update.rst
@@ -1,0 +1,2 @@
+Update ``pywintypes`` and ``pythoncom`` hooks for compatibility with upcoming
+changes in PyInstaller's attempt at preserving DLL parent directory structure.

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks.dat
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks.dat
@@ -6,4 +6,6 @@
     'nltk': ['pyi_rth_nltk.py'],
     'pyproj': ['pyi_rth_pyproj.py'],
     'pygraphviz': ['pyi_rth_pygraphviz.py'],
+    'pythoncom': ['pyi_rth_pythoncom.py'],
+    'pywintypes': ['pyi_rth_pywintypes.py'],
 }

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_pythoncom.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_pythoncom.py
@@ -1,0 +1,24 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2022, PyInstaller Development Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+#-----------------------------------------------------------------------------
+
+# Unfortunately, __import_pywin32_system_module__ from pywintypes module assumes that in a frozen application, the
+# pythoncom3X.dll and pywintypes3X.dll that are normally found in site-packages/pywin32_system32, are located
+# directly in the sys.path, without bothering to check first if they are actually available in the standard location.
+# This obviously runs afoul of our attempts at preserving the directory layout and placing them in the pywin32_system32
+# sub-directory instead of the top-level application directory. So as a work-around, add the sub-directory to sys.path
+# to keep pywintypes happy...
+import sys
+import os
+
+pywin32_system32_path = os.path.join(sys._MEIPASS, 'pywin32_system32')
+if os.path.isdir(pywin32_system32_path) and pywin32_system32_path not in sys.path:
+    sys.path.append(pywin32_system32_path)
+del pywin32_system32_path

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_pywintypes.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_pywintypes.py
@@ -1,0 +1,24 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2022, PyInstaller Development Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+#-----------------------------------------------------------------------------
+
+# Unfortunately, __import_pywin32_system_module__ from pywintypes module assumes that in a frozen application, the
+# pythoncom3X.dll and pywintypes3X.dll that are normally found in site-packages/pywin32_system32, are located
+# directly in the sys.path, without bothering to check first if they are actually available in the standard location.
+# This obviously runs afoul of our attempts at preserving the directory layout and placing them in the pywin32_system32
+# sub-directory instead of the top-level application directory. So as a work-around, add the sub-directory to sys.path
+# to keep pywintypes happy...
+import sys
+import os
+
+pywin32_system32_path = os.path.join(sys._MEIPASS, 'pywin32_system32')
+if os.path.isdir(pywin32_system32_path) and pywin32_system32_path not in sys.path:
+    sys.path.append(pywin32_system32_path)
+del pywin32_system32_path

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pywintypes.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pywintypes.py
@@ -10,15 +10,22 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
+# pywin32 supports frozen mode; in that mode, it is looking at sys.path for pywintypesXY.dll. However, as of
+# PyInstaller 5.4, we may collect that DLL into its original pywin32_system32 sub-directory as part of the
+# binary dependency analysis (and add it to sys.path by means of a runtime hook).
 
-"""
-pywin32 module supports frozen mode. In frozen mode it is looking
-in sys.path for file pywintypesXX.dll. Include the pywintypesXX.dll
-as a data file. The path to this dll is contained in __file__
-attribute.
-"""
+import pathlib
 
-from PyInstaller.utils.hooks import get_pywin32_module_file_attribute
+from PyInstaller.utils.hooks import is_module_satisfies, get_pywin32_module_file_attribute
 
-_pth = get_pywin32_module_file_attribute('pywintypes')
-binaries = [(_pth, '.')]
+dll_filename = get_pywin32_module_file_attribute('pywintypes')
+dst_dir = '.'  # Top-level application directory
+
+if is_module_satisfies('PyInstaller >= 5.4'):
+    # Try preserving the original pywin32_system directory, if applicable (it is not applicable in Anaconda,
+    # where the DLL is located in Library/bin).
+    dll_path = pathlib.Path(dll_filename)
+    if dll_path.parent.name == 'pywin32_system32':
+        dst_dir = 'pywin32_system32'
+
+binaries = [(dll_filename, dst_dir)]

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1305,3 +1305,17 @@ def test_hydra(pyi_builder, tmpdir):
         """,
         pyi_args=['--add-data', os.pathsep.join((config_file, 'conf'))]
     )
+
+
+@importorskip('pywintypes')
+def test_pywintypes(pyi_builder):
+    pyi_builder.test_source("""
+        import pywintypes
+        """)
+
+
+@importorskip('pythoncom')
+def test_pythoncom(pyi_builder):
+    pyi_builder.test_source("""
+        import pythoncom
+        """)


### PR DESCRIPTION
Have `pywintypes` and `pythoncom` hook collect their corresponding DLLs into `pywin32_system32` sub-directory if the DLLs originally came from `site-packages/pywin32_system32` directory (which is the case with PyPI wheel, but not with Anaconda package). This prevents duplication of `pywintypesXY.dll` when the latter is also collected as a part of link-time binary dependency analysis, which starting with PyInstaller 5.4 attempts to preserve the parent directory structure (https://github.com/pyinstaller/pyinstaller/pull/7028).