### PR TITLE
Update ``pyshark`` hook to be compatible with versions ``>=0.5``.

### DIFF
--- a/news/477.update.rst
+++ b/news/477.update.rst
@@ -1,0 +1,1 @@
+Update ``pyshark`` hook to be compatible with versions ``>=0.5.2``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -102,7 +102,7 @@ yt-dlp==2022.7.18
 limits==2.7.0
 great-expectations==0.15.17
 tensorflow==2.9.1
-pyshark==0.4.6
+pyshark==0.5.2
 opencv-python==4.6.0.66
 hydra-core==1.2.0
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyshark.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyshark.py
@@ -14,8 +14,11 @@
 # Tested with version 0.4.5
 
 
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, is_module_satisfies
 
 hiddenimports = ['pyshark', 'py._path.local', 'py._vendored_packages.iniconfig', 'pyshark.config']
+
+if is_module_satisfies("pyshark >= 0.5"):
+    hiddenimports += ["py._io.terminalwriter", "py._builtin"]
 
 datas = collect_data_files('pyshark')


### PR DESCRIPTION
Let's put `pyshark` out of its misery...