### PR TITLE
hooks: clr: guard against potential sources of errors

### DIFF
--- a/news/486.update.1.rst
+++ b/news/486.update.1.rst
@@ -1,0 +1,5 @@
+Have ``clr`` hook check for availability of the ``pythonnet`` before
+trying to query its metadata. Fixes an ``importlib.metadata.PackageNotFoundError``
+raised by the ``clr`` hook when the hook is triggered by a module or
+a package named ``clr`` other than the ``clr`` extension module from
+``pythonnet``.

--- a/news/486.update.rst
+++ b/news/486.update.rst
@@ -1,0 +1,2 @@
+Fix a ``TypeError`` raised by the ``clr`` hook when ``pythonnet`` dist
+lacks the file list metadata.


### PR DESCRIPTION
Guard against potential sources of errors in the `clr` hook:
- the absence of `pythonnet`, when the hook is triggered by some other module/package named `clr`. (Presumably) fixes https://github.com/pyinstaller/pyinstaller/issues/6283.
- the absence of file list metadata in `pythonnet`. Fixes #485.