### PR TITLE
hooks: sounddevice and soundfile: collect system-installed shared lib

### DIFF
--- a/news/487.update.rst
+++ b/news/487.update.rst
@@ -1,0 +1,4 @@
+Extend the ``sounddevice`` and ``soundfile`` hooks to collect 
+system-installed shared libraries in cases when the libraries are
+not bundled with the package (i.e., linux PyPI wheels, Anaconda on
+all OSes).

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sounddevice.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sounddevice.py
@@ -9,25 +9,55 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-# -----------------------------------------------------------------------------
 
 """
 sounddevice:
 https://github.com/spatialaudio/python-sounddevice/
 """
 
-import os
+import pathlib
 
-from PyInstaller.compat import is_darwin, is_win
-from PyInstaller.utils.hooks import get_module_file_attribute
+from PyInstaller.utils.hooks import get_module_file_attribute, logger
 
-module_dir = os.path.dirname(get_module_file_attribute("sounddevice"))
+binaries = []
+datas = []
 
-path = None
-if is_win:
-    path = os.path.join(module_dir, "_sounddevice_data", "portaudio-binaries")
-elif is_darwin:
-    path = os.path.join(module_dir, "_sounddevice_data", "portaudio-binaries", "libportaudio.dylib")
+# PyPI wheels for Windows and macOS ship the sndfile shared library in _sounddevice_data directory,
+# located next to the sounddevice.py module file (i.e., in the site-packages directory).
+module_dir = pathlib.Path(get_module_file_attribute('sounddevice')).parent
+data_dir = module_dir / '_sounddevice_data' / 'portaudio-binaries'
+if data_dir.is_dir():
+    destdir = str(data_dir.relative_to(module_dir))
 
-if path is not None and os.path.exists(path):
-    binaries = [(path, os.path.join("_sounddevice_data", "portaudio-binaries"))]
+    # Collect the shared library (known variants: libportaudio64bit.dll, libportaudio32bit.dll, libportaudio.dylib)
+    for lib_file in data_dir.glob("libportaudio*.*"):
+        binaries += [(str(lib_file), destdir)]
+
+    # Collect the README.md file
+    readme_file = data_dir / "README.md"
+    if readme_file.is_file():
+        datas += [(str(readme_file), destdir)]
+else:
+    # On linux and in Anaconda in all OSes, the system-installed portaudio library needs to be collected.
+    def _find_system_portaudio_library():
+        import os
+        import ctypes.util
+        from PyInstaller.depend.utils import _resolveCtypesImports
+
+        libname = ctypes.util.find_library("portaudio")
+        if libname is not None:
+            resolved_binary = _resolveCtypesImports([os.path.basename(libname)])
+            if resolved_binary:
+                return resolved_binary[0][1]
+
+    try:
+        lib_file = _find_system_portaudio_library()
+    except Exception as e:
+        logger.warning("Error while trying to find system-installed portaudio library: %s", e)
+        lib_file = None
+
+    if lib_file:
+        binaries += [(lib_file, '.')]
+
+if not binaries:
+    logger.warning("portaudio shared library not found - sounddevice will likely fail to work!")

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-soundfile.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-soundfile.py
@@ -15,21 +15,49 @@ pysoundfile:
 https://github.com/bastibe/SoundFile
 """
 
-import os
+import pathlib
 
-from PyInstaller.compat import is_win, is_darwin
-from PyInstaller.utils.hooks import get_module_file_attribute
+from PyInstaller.utils.hooks import get_module_file_attribute, logger
 
-# get path of soundfile
-module_dir = os.path.dirname(get_module_file_attribute('soundfile'))
+binaries = []
+datas = []
 
-# add binaries packaged by soundfile on OSX and Windows
-# an external dependency (libsndfile) is used on GNU/Linux
-path = None
-if is_win:
-    path = os.path.join(module_dir, '_soundfile_data')
-elif is_darwin:
-    path = os.path.join(module_dir, '_soundfile_data', 'libsndfile.dylib')
+# PyPI wheels for Windows and macOS ship the sndfile shared library in _soundfile_data directory,
+# located next to the soundfile.py module file (i.e., in the site-packages directory).
+module_dir = pathlib.Path(get_module_file_attribute('soundfile')).parent
+data_dir = module_dir / '_soundfile_data'
+if data_dir.is_dir():
+    destdir = str(data_dir.relative_to(module_dir))
 
-if path is not None and os.path.exists(path):
-    binaries = [(path, "_soundfile_data")]
+    # Collect the shared library (known variants: libsndfile64bit.dll, libsndfile32bit.dll, libsndfile.dylib)
+    for lib_file in data_dir.glob("libsndfile*.*"):
+        binaries += [(str(lib_file), destdir)]
+
+    # Collect the COPYING file
+    copying_file = data_dir / "COPYING"
+    if copying_file.is_file():
+        datas += [(str(copying_file), destdir)]
+else:
+    # On linux and in Anaconda in all OSes, the system-installed sndfile library needs to be collected.
+    def _find_system_sndfile_library():
+        import os
+        import ctypes.util
+        from PyInstaller.depend.utils import _resolveCtypesImports
+
+        libname = ctypes.util.find_library("sndfile")
+        if libname is not None:
+            resolved_binary = _resolveCtypesImports([os.path.basename(libname)])
+            if resolved_binary:
+                return resolved_binary[0][1]
+
+    try:
+        lib_file = _find_system_sndfile_library()
+    except Exception as e:
+        logger.warning("Error while trying to find system-installed sndfile library: %s", e)
+        lib_file = None
+
+    if lib_file:
+        binaries += [(lib_file, '.')]
+
+if not binaries:
+    logger.warning("sndfile shared library not found - soundfile will likely fail to work!")


### PR DESCRIPTION
Extend the `sounddevice` and `soundfile` hooks to collect system-installed `sndfile` and `portaudio` shared libraries in cases when the libraries are not bundled with the package (i.e., linux PyPI wheels and Anaconda-provided packages on all OSes).

Fixes the collection part of pyinstaller/pyinstaller#7065.