### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/oneshot-test.yml
+++ b/.github/workflows/oneshot-test.yml
@@ -45,6 +45,7 @@ env:
   # Colored pytest output on CI despite not having a tty
   FORCE_COLOR: 1
 
+permissions: {}
 jobs:
   generate-matrix:
     # Parse inputs into a json containing the matrix that will parametrize the
@@ -100,6 +101,9 @@ jobs:
 
 
   test:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+
     needs: generate-matrix
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -12,6 +12,9 @@ env:
   # Colored pytest output on CI despite not having a tty
   FORCE_COLOR: 1
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,12 @@
 on: workflow_dispatch
 name: Release
 
+permissions: {}
 jobs:
   release:
+    permissions:
+      contents: write
+
     runs-on: ubuntu-latest
 
     if: contains('["Legorooj", "bwoodsend", "rokm"]', github.event.actor)

--- a/.github/workflows/validate-new-news.yml
+++ b/.github/workflows/validate-new-news.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.