### PR TITLE
ci: bump used action versions to ones that use Node 16

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,18 +11,18 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
-    
+
     - name: Get out of detached head state
       run: |
         git fetch origin ${{ github.base_ref }}
         git fetch origin ${{ github.ref }}
         git checkout FETCH_HEAD --
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
 

--- a/.github/workflows/oneshot-test.yml
+++ b/.github/workflows/oneshot-test.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
@@ -119,15 +119,15 @@ jobs:
 
     # Finally, the usual: setup Python, install dependencies, test.
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up .NET Core for pythonnet tests
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.x'
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -30,10 +30,10 @@ jobs:
       PYINSTALLER_COMPILE_BOOTLOADER: 1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -53,7 +53,7 @@ jobs:
           cat requirements-test-libraries.txt
 
       - name: Set up .NET Core for pythonnet tests
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.x'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
     if: contains('["Legorooj", "bwoodsend", "rokm"]', github.event.actor)
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.github/workflows/validate-new-news.yml
+++ b/.github/workflows/validate-new-news.yml
@@ -12,7 +12,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Validate new news items
         run: python scripts/verify-news-fragments.py


### PR DESCRIPTION
Should take care of "Node.js 12 actions are deprecated." warnings in the jobs' summary.