### PR TITLE
tests: fix the pythonnet3 test

### DIFF
--- a/.github/workflows/oneshot-test.yml
+++ b/.github/workflows/oneshot-test.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Set up .NET Core for pythonnet tests
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.x'
+          dotnet-version: '6.x'
 
       - name: Run bash commands
         if: ${{ github.event.inputs.commands }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up .NET Core for pythonnet tests
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.x'
+          dotnet-version: '6.x'
 
       # Install MariaDB Connector/C from official MariaDB Community Server
       # repository. The version shipped with ubuntu-20.04 is too old for

--- a/news/500.update.rst
+++ b/news/500.update.rst
@@ -1,0 +1,3 @@
+In ``clr`` hook for ``pythonnet`` collect the ``Python.Runtime.dll`` as
+a data file on non-Windows OSes to prevent errors during binary dependency
+analysis.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -63,6 +63,7 @@ pyvjoy==1.0.1; sys_platform == 'win32'
 pynput==1.7.6
 pymssql==2.2.5
 pystray==0.19.4
+pythonnet==3.0.0.post1
 pytz==2022.4
 pyzmq==24.0.1
 PyQt5==5.15.7
@@ -121,10 +122,6 @@ pydivert==2.1.0; sys_platform == 'win32'
 
 # pywin32-ctypes runs on Windows
 pywin32-ctypes==0.2.0; sys_platform == 'win32'
-
-# pythonnet 3 (when released) will be cross platform
-# pythonnet 2.5.2 provides wheels only for python <= 3.8
-pythonnet==2.5.2; sys_platform == 'win32' and python_version <= '3.8'
 
 # pymediainfo on linux does not bundle mediainfo shared library, and requires system one.
 pymediainfo==5.1.0; sys_platform == 'darwin' or sys_platform == 'win32'

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-clr.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-clr.py
@@ -15,6 +15,7 @@
 # the terminal styling library (https://pypi.org/project/clr/). Therefore, we must first check if pythonnet is actually
 # available...
 from PyInstaller.utils.hooks import is_module_satisfies
+from PyInstaller.compat import is_win
 
 
 if is_module_satisfies("pythonnet"):
@@ -27,7 +28,7 @@ if is_module_satisfies("pythonnet"):
     except ImportError:
         import importlib_metadata
 
-    binaries = []
+    collected_runtime_files = []
 
     # Try finding Python.Runtime.dll via distribution's file list
     dist_files = importlib_metadata.files('pythonnet')
@@ -35,20 +36,27 @@ if is_module_satisfies("pythonnet"):
         runtime_dll_files = [f for f in dist_files if f.match('Python.Runtime.dll')]
         if len(runtime_dll_files) == 1:
             runtime_dll_file = runtime_dll_files[0]
-            binaries = [(runtime_dll_file.locate(), runtime_dll_file.parent.as_posix())]
+            collected_runtime_files = [(runtime_dll_file.locate(), runtime_dll_file.parent.as_posix())]
             logger.debug("hook-clr: Python.Runtime.dll discovered via metadata.")
         elif len(runtime_dll_files) > 1:
             logger.warning("hook-clr: multiple instances of Python.Runtime.dll listed in metadata - cannot resolve.")
 
     # Fall back to the legacy way
-    if not binaries:
+    if not collected_runtime_files:
         runtime_dll_file = ctypes.util.find_library('Python.Runtime')
         if runtime_dll_file:
-            binaries = [(runtime_dll_file, '.')]
+            collected_runtime_files = [(runtime_dll_file, '.')]
             logger.debug('hook-clr: Python.Runtime.dll discovered via legacy method.')
 
-    if not binaries:
+    if not collected_runtime_files:
         raise Exception('Python.Runtime.dll not found')
+
+    # On Windows, collect runtime DLL file(s) as binaries; on other OSes, collect them as data files, to prevent fatal
+    # errors in binary dependency analysis.
+    if is_win:
+        binaries = collected_runtime_files
+    else:
+        datas = collected_runtime_files
 
     # These modules are imported inside Python.Runtime.dll
     hiddenimports = ["platform", "warnings"]

--- a/src/_pyinstaller_hooks_contrib/tests/data/netcore5_runtime_config.json
+++ b/src/_pyinstaller_hooks_contrib/tests/data/netcore5_runtime_config.json
@@ -1,9 +1,0 @@
-{
-    "runtimeOptions": {
-        "tfm": "net5.0",
-        "framework": {
-            "name": "Microsoft.NETCore.App",
-            "version": "5.0.2"
-        }
-    }
-}

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -799,12 +799,10 @@ def test_pythonnet2(pyi_builder):
 
 @requires('pythonnet >= 3.dev')
 def test_pythonnet3(pyi_builder):
-    runtime_cfg_path = str((Path(__file__) / '../data/netcore5_runtime_config.json').resolve(strict=True).as_posix())
     pyi_builder.test_source(f"""
-        from pathlib import Path
         from clr_loader import get_coreclr
         from pythonnet import set_runtime
-        set_runtime(get_coreclr('{runtime_cfg_path}'))
+        set_runtime(get_coreclr())  # Pick up and use any installed .NET runtime.
 
         import clr
         """)


### PR DESCRIPTION
Instead of trying to load specific .NET runtime via json file, let `clr_loader.get_coreclr()` pick up any installed version it finds.

On CI, install .NET 6.x instead of EOL'd 5.x. Repin pythonnet to 3.0.0.post1, and install it on all OSes, since it should now be fully cross-platform.