### PR TITLE
Update hooks for pyqtgraph

### DIFF
--- a/news/501.update.1.rst
+++ b/news/501.update.1.rst
@@ -1,0 +1,7 @@
+Implement preliminary support for handling subprocesses used by
+``pyqtgraph.multiprocess``, for example in ``pyqtgraph``
+``RemoteGraphicsView`` widget. The user is still required to ensure that
+stdlib's ``multiprocessing.freeze_support`` is called in the entry-point
+script before using ``pyqtgraph``. In addition, with ``onefile`` builds,
+the user must set the ``_MEIPASS2`` environment variable to the value
+of ``sys._MEIPASS`` before using ``pyqtgraph``.

--- a/news/501.update.rst
+++ b/news/501.update.rst
@@ -1,0 +1,2 @@
+Have the ``pyqtgraph`` hook collect the colormap files and their
+license files from the package.

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks.dat
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks.dat
@@ -7,5 +7,6 @@
     'pyproj': ['pyi_rth_pyproj.py'],
     'pygraphviz': ['pyi_rth_pygraphviz.py'],
     'pythoncom': ['pyi_rth_pythoncom.py'],
+    'pyqtgraph': ['pyi_rth_pyqtgraph_multiprocess.py'],
     'pywintypes': ['pyi_rth_pywintypes.py'],
 }

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_pyqtgraph_multiprocess.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_pyqtgraph_multiprocess.py
@@ -1,0 +1,51 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2022, PyInstaller Development Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+#-----------------------------------------------------------------------------
+
+import sys
+import os
+
+
+def _setup_pyqtgraph_multiprocess_hook():
+    # NOTE: pyqtgraph.multiprocess spawns the sub-process using subprocess.Popen (or equivalent). This means that in
+    # onefile builds, the executable in subprocess will unpack itself again, into different sys._MEIPASS, because
+    # the _MEIPASS2 environment variable is not set (bootloader / bootstrap script cleans it up). This will make the
+    # argv[1] check below fail, due to different sys._MEIPASS value in the subprocess.
+    #
+    # To work around this, at the time of writing (PyInstaller 5.5), the user needs to set _MEIPASS2 environment
+    # variable to sys._MEIPASS before using `pyqtgraph.multiprocess` in onefile builds. And stlib's
+    # `multiprocessing.freeze_support` needs to be called in the entry-point program, due to `pyqtgraph.multiprocess`
+    # internally using stdlib's `multiprocessing` primitives.
+    if len(sys.argv) == 2 and sys.argv[1] == os.path.join(sys._MEIPASS, 'pyqtgraph', 'multiprocess', 'bootstrap.py'):
+        # Load as module; this requires --hiddenimport pyqtgraph.multiprocess.bootstrap
+        try:
+            mod_name = 'pyqtgraph.multiprocess.bootstrap'
+            mod = __import__(mod_name)
+            bootstrap_co = mod.__loader__.get_code(mod_name)
+        except Exception:
+            bootstrap_co = None
+
+        if bootstrap_co:
+            exec(bootstrap_co)
+            sys.exit(0)
+
+        # Load from file; requires pyqtgraph/multiprocess/bootstrap.py collected as data file
+        bootstrap_file = os.path.join(sys._MEIPASS, 'pyqtgraph', 'multiprocess', 'bootstrap.py')
+        if os.path.isfile(bootstrap_file):
+            with open(bootstrap_file, 'r') as fp:
+                bootstrap_code = fp.read()
+            exec(bootstrap_code)
+            sys.exit(0)
+
+        raise RuntimeError("Could not find pyqtgraph.multiprocess bootstrap code or script!")
+
+
+_setup_pyqtgraph_multiprocess_hook()
+del _setup_pyqtgraph_multiprocess_hook

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyqtgraph.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyqtgraph.py
@@ -12,9 +12,8 @@
 
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
-# include all .ui and image files
-datas = collect_data_files("pyqtgraph",
-                           includes=["**/*.ui", "**/*.png", "**/*.svg"])
+# Collect all data files, excluding the examples' data
+datas = collect_data_files('pyqtgraph', excludes=['**/examples/*'])
 
 # pyqtgraph uses Qt-version-specific templates for the UI elements.
 # There are templates for different versions of PySide and PyQt, e.g.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyqtgraph.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyqtgraph.py
@@ -33,3 +33,8 @@ datas = collect_data_files('pyqtgraph', excludes=['**/examples/*'])
 # Tested with pyqtgraph master branch (commit c1900aa).
 all_imports = collect_submodules("pyqtgraph")
 hiddenimports = [name for name in all_imports if "Template" in name]
+
+# Collect the pyqtgraph/multiprocess/bootstrap.py as a module; this is required by our pyqtgraph.multiprocess runtime
+# hook to handle the pyqtgraph's multiprocessing implementation. The pyqtgraph.multiprocess seems to be imported
+# automatically on the import of pyqtgraph itself, so there is no point in creating a separate hook for this.
+hiddenimports += ['pyqtgraph.multiprocess.bootstrap']

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1289,6 +1289,16 @@ def test_pyqtgraph(pyi_builder):
     )
 
 
+@importorskip('pyqtgraph')
+def test_pyqtgraph_colormap(pyi_builder):
+    pyi_builder.test_source(
+        """
+        import pyqtgraph.colormap
+        assert pyqtgraph.colormap.listMaps()
+        """
+    )
+
+
 @importorskip('hydra')
 def test_hydra(pyi_builder, tmpdir):
     config_file = str((Path(__file__) / '../data/test_hydra/config.yaml').resolve(strict=True).as_posix())

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1285,7 +1285,8 @@ def test_pyqtgraph(pyi_builder):
         import pyqtgraph.graphicsItems.PlotItem
         import pyqtgraph.graphicsItems.ViewBox.ViewBoxMenu
         import pyqtgraph.imageview.ImageView
-        """
+        """,
+        pyi_args=['--exclude', 'PySide2', '--exclude', 'PySide6', '--exclude', 'PyQt6']
     )
 
 
@@ -1296,6 +1297,47 @@ def test_pyqtgraph_colormap(pyi_builder):
         import pyqtgraph.colormap
         assert pyqtgraph.colormap.listMaps()
         """
+    )
+
+
+@importorskip('pyqtgraph')
+@importorskip('PyQt5')
+def test_pyqtgraph_remote_graphics_view(pyi_builder):
+    pyi_builder.test_source(
+        """
+        import sys
+        import os
+        import signal
+
+        from PyQt5 import QtCore, QtWidgets
+        import pyqtgraph
+
+        # Multiprocessing is used internally by pyqtgraph.multiprocess
+        import multiprocessing
+        multiprocessing.freeze_support()
+
+        # pyqtgraph.multiprocess also uses a subprocess.Popen() to spawn its
+        # sub-process, so we need to restore _MEIPASS2 to prevent the executable
+        # to unpacking itself again in the subprocess.
+        os.environ['_MEIPASS2'] = sys._MEIPASS
+
+        # Create a window with remote graphics view
+        app = QtWidgets.QApplication(sys.argv)
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+        window = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(window)
+        remote_view = pyqtgraph.widgets.RemoteGraphicsView.RemoteGraphicsView()
+        layout.addWidget(remote_view)
+
+        window.show()
+
+        # Quit after a second
+        QtCore.QTimer.singleShot(1000, app.exit)
+
+        sys.exit(app.exec_())
+        """,
+        pyi_args=['--exclude', 'PySide2', '--exclude', 'PySide6', '--exclude', 'PyQt6']
     )
 
 


### PR DESCRIPTION
Update `pyqtgraph` standard hook to collect all data from the package, including the colormaps and their associated license files, as per https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/490#issuecomment-1258173167.

Create a new runtime hook that attempts to handle subprocess spawned by `pyqtgraph.multiprocess`. The caveat is that the user still needs to call stdlib `multiprocess.freeze_support` in their entry-point script (which is something I hope to get around to addressing in PyInstaller's `multiprocess` hook). And for onefile builds, they also need to set `_MEIPASS2` environment variable to prevent the executable from unpacking itself again in the subprocess (using different `sys._MEIPASS`, and thus breaking the path check in the runtime hook). This is because `pyqtgraph.multiprocess` uses `subprocess.Popen` to spawn the process; perhaps we could extend our `subprocess`  runtime hook to detect when `sys.executable` is spawned and automatically restore `_MEIPASS2` in the subprocess' environment?

Replaces and closes #490.