### PR TITLE
hooks: pyproj: collect metadata for pyproj >= 3.4.0

### DIFF
--- a/news/505.update.rst
+++ b/news/505.update.rst
@@ -1,0 +1,1 @@
+Update ``pyproj`` hook for compatibility with ``pyproj`` v3.4.0.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -25,7 +25,7 @@ fabric==2.7.1
 fiona==1.8.22; sys_platform != 'win32'
 folium==0.13.0
 ffpyplayer==4.3.5; python_version < '3.10' # doesn't have py310 wheels
-geopandas==0.11.1; python_version >= '3.8' and sys_platform != 'win32'
+geopandas==0.12.1; python_version >= '3.8' and sys_platform != 'win32'
 python-gitlab==3.11.0
 h5py==3.7.0; python_version >= '3.7'
 humanize==4.4.0

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyproj.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyproj.py
@@ -12,7 +12,7 @@
 
 import os
 import sys
-from PyInstaller.utils.hooks import collect_data_files, is_module_satisfies
+from PyInstaller.utils.hooks import collect_data_files, is_module_satisfies, copy_metadata
 from PyInstaller.compat import is_win
 
 
@@ -56,3 +56,8 @@ if is_conda:
         from PyInstaller.utils.hooks import logger
         logger.warning("Datas for pyproj not found at:\n{}".format(src_proj_data))
     # A runtime hook defines the path for `PROJ_LIB`
+
+# With pyproj 3.4.0, we need to collect package's metadata due to `importlib.metadata.version(__package__)` call in
+# `__init__.py`. This change was reverted in subsequent releases of pyproj, so we collect metadata only for 3.4.0.
+if is_module_satisfies("pyproj == 3.4.0"):
+    datas += copy_metadata("pyproj")


### PR DESCRIPTION
As of version 3.4.0, pyproj's `__init__.py` queries its own version via `importlib.metadata.version(__package__)`, which requires the package metadata to be collected.