### PR TITLE
Add hook and test for exchnagelib

### DIFF
--- a/news/508.new.rst
+++ b/news/508.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``exchangelib``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -111,6 +111,7 @@ pyshark==0.5.3
 opencv-python==4.6.0.66
 hydra-core==1.2.0
 spiceypy==5.1.2
+exchangelib==4.8.0
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-exchangelib.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-exchangelib.py
@@ -9,7 +9,4 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-from PyInstaller.utils.hooks import collect_submodules
-
-hiddenimports = collect_submodules("tzdata")
+hiddenimports = ['tzdata']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-exchangelib.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-exchangelib.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2022 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_submodules
+
+hiddenimports = collect_submodules("tzdata")

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1403,3 +1403,10 @@ def test_discid(pyi_builder):
         assert os.path.isfile(lib_file), f"Shared library {lib_name} not collected to _MEIPASS!"
         """
     )
+
+
+@importorskip('exchangelib')
+def test_exchangelib(pyi_builder):
+    pyi_builder.test_source("""
+        import exchangelib
+    """)


### PR DESCRIPTION
In some cases `exchengelib` need to collect `tzdata`, I noticed it on `alpine` distribution that it raises this on import
```
exchangelib.errors.UnknownTimeZone: No time zone found with key UTC
```
