### PR TITLE
Fix duplicated headers in changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         run: echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
 
       - name: Install Dependencies
-        run: python -m pip install -U towncrier twine wheel
+        run: python -m pip install --upgrade -r requirements-release.txt
 
       - name: Build & Validate Bundles
         run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,4 @@
 2022.12 (2022-11-05)
---------------------
-
-2022.12 (2022-11-05)
 ---------------------
 
 New hooks
@@ -12,9 +9,6 @@ New hooks
 * Add hook for ``exchangelib``. (`#508
   <https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/508>`_)
 
-
-2022.11 (2022-10-27)
---------------------
 
 2022.11 (2022-10-27)
 ---------------------
@@ -62,9 +56,6 @@ Updated hooks
   analysis. (`#500
   <https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/500>`_)
 
-
-2022.10 (2022-08-31)
---------------------
 
 2022.10 (2022-08-31)
 ---------------------

--- a/news/_template.rst
+++ b/news/_template.rst
@@ -1,8 +1,5 @@
 {% set pyi_url = 'https://github.com/pyinstaller/pyinstaller-hooks-contrib' %}
 {% set issue_url = pyi_url + '/issues/' %}
-
-{{ versiondata.version }} ({{ versiondata.date }})
-{{ top_underline * ((versiondata.version + versiondata.date)|length + 4)}}
 {% macro print_issue_numbers(issues) %}
 {% for issue in issues if issue.startswith('#') %}
 {% if loop.first %} ({% endif %}

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,4 +1,4 @@
-towncrier
+towncrier==22.8.0
 setuptools
 wheel
 twine


### PR DESCRIPTION
* Remove heading and top underline from the news template, to avoid duplicates when using latest version of `towncrier` (22.8.0). 
* Pin `towncrier` to 22.8.0 in `requirements-release.txt`.
* Have the Release workflow install dependencies using the `requirements-release.txt`.
* Remove duplicated headings from CHANGELOG.

Closes #513.