### PR TITLE
bugfix: Unable to find "/usr/sbin/neato" when adding binary and data …

### DIFF
--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pygraphviz.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pygraphviz.py
@@ -49,7 +49,7 @@ if is_win:
 else:
     # The dot binary in PATH is typically a symlink, handle that.
     # graphviz_bindir is e.g. /usr/local/Cellar/graphviz/2.46.0/bin
-    graphviz_bindir = os.path.dirname(os.path.realpath(shutil.which("dot")))
+    graphviz_bindir = os.path.dirname(shutil.which("dot"))
     for binary in progs:
         binaries.append((graphviz_bindir + "/" + binary, "."))
     if is_darwin:


### PR DESCRIPTION
…files.

Problem on Debian GNU/Linux 11 (bullseye) and Ubuntu 22.04.1 LTS:

    In : os.path.realpath(shutil.which("dot"))
    Out: '/usr/sbin/libgvc6-config-update'

    In : os.path.dirname(os.path.realpath(shutil.which("dot")))
    Out: '/usr/sbin'

Solution:

    In : os.path.dirname(shutil.which("dot"))
    Out: '/usr/bin'