### PR TITLE
hooks: update shapely hook for compatibility with shapely >= 2.0.0

### DIFF
--- a/news/133.update.rst
+++ b/news/133.update.rst
@@ -1,0 +1,1 @@
+Update ``shapely`` hook for compatibility with ``shapely >= 2.0.0``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -100,8 +100,7 @@ pypsexec==0.3.0
 mimesis==6.1.1; python_version >= '3.8'
 orjson==3.8.3
 altair==4.2.0; python_version >= '3.7'
-# For some reason, shapely provides only arm64 py310 macOS wheel.
-shapely==1.8.5.post1; sys_platform != 'darwin' or python_version < '3.10'
+shapely==2.0.0
 lark==1.1.4
 python-stdnum==1.18
 # On linux, sounddevice and soundfile use system-provided libportaudio

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-shapely.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-shapely.py
@@ -20,8 +20,13 @@ from PyInstaller import compat
 # Necessary when using the vectorized subpackage
 hiddenimports = ['shapely.prepared']
 
-pkg_base, pkg_dir = get_package_paths('shapely')
+if is_module_satisfies('shapely >= 2.0.0'):
+    # An import made in the `shapely.geometry_helpers` extension; both `shapely.geometry_helpers` and `shapely._geos`
+    # extensions were introduced in v2.0.0.
+    hiddenimports += ['shapely._geos']
 
+
+pkg_base, pkg_dir = get_package_paths('shapely')
 
 binaries = []
 datas = []


### PR DESCRIPTION
Add a hidden import of shapely._geos extension, which is made from shapely.geometry_helpers extension; both were added in the shapely v2.0.0 release.