### PR TITLE
hooks: torch: Only include shared libraries

### DIFF
--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-torch.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-torch.py
@@ -10,6 +10,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import get_package_paths
+from PyInstaller.utils.hooks import collect_dynamic_libs
 
-datas = [(get_package_paths('torch')[1],"torch"),]
+# include versioned .so files as well
+binaries = collect_dynamic_libs('torch', py_dylib_patterns=['*.dll', '*.dylib', 'lib*.so', 'lib*.so.*'])


### PR DESCRIPTION
Existing hook is way too simplistic and literally takes every single file in the package (headers, cpp, pyi, __pycache__ and so on)...
Fix this by only bundling shared libraries from `lib` dir.

This depends on pyinstaller/pyinstaller#7357.
Please advise how we can specify dependency on main repository (if we should).

P.S. Need to test this one more time (it was some time ago I've implemented this).