### PR TITLE
Add hook for minecraft-launcher-lib

### DIFF
--- a/news/536.new.rst
+++ b/news/536.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``minecraft-launcher-lib``

--- a/news/536.rst
+++ b/news/536.rst
@@ -1,1 +1,0 @@
-Add hook for ``minecraft-launcher-lib``

--- a/news/536.rst
+++ b/news/536.rst
@@ -1,0 +1,1 @@
+Add hook for ``minecraft-launcher-lib``

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -117,6 +117,7 @@ opencv-python==4.7.0.68
 hydra-core==1.3.0
 spiceypy==5.1.2
 exchangelib==4.9.0
+minecraft-launcher-lib==5.2
 
 # ------------------- Platform (OS) specifics
 

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -117,7 +117,7 @@ opencv-python==4.7.0.68
 hydra-core==1.3.0
 spiceypy==5.1.2
 exchangelib==4.9.0
-minecraft-launcher-lib==5.2
+minecraft-launcher-lib==5.2; python_version >= '3.8'
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-minecraft_launcher_lib.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-minecraft_launcher_lib.py
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------
-# Copyright (c) 2021 PyInstaller Development Team.
+# Copyright (c) 2023 PyInstaller Development Team.
 #
 # This file is distributed under the terms of the GNU General Public
 # License (version 2.0 or later).

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-minecraft_launcher_lib.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-minecraft_launcher_lib.py
@@ -1,0 +1,14 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2021 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files("minecraft_launcher_lib")

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1477,3 +1477,13 @@ def test_compliance_checker(pyi_builder):
         print("Return value:", return_value)
         print("Errors occurred:", errors)
     """, app_args=[str(input_file)])
+
+
+@importorskip('minecraft_launcher_lib')
+def test_minecraft_launcher_lib(pyi_builder):
+    pyi_builder.test_source(
+        '''
+        import minecraft_launcher_lib
+        assert isinstance(minecraft_launcher_lib.utils.get_library_version(), str)
+        '''
+    )


### PR DESCRIPTION
This adds a hook for [minecraft-launcher-lib](https://pypi.org/project/minecraft-launcher-lib/)