### PR TITLE
Update fiona hook for compatibility with fiona 1.9.0

### DIFF
--- a/news/541.update.1.rst
+++ b/news/541.update.1.rst
@@ -1,0 +1,1 @@
+Update ``fiona`` hook for compatibility with ``fiona`` 1.9.0.

--- a/news/541.update.rst
+++ b/news/541.update.rst
@@ -1,0 +1,2 @@
+Have ``fiona`` hook collect the package's data files (e.g., the
+projections database).

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -27,7 +27,7 @@ dash-uploader==0.6.0
 # We install it via apt-get and brew on ubuntu and macOS CI runners, respectively.
 discid==1.2.0; sys_platform != 'win32'
 fabric==3.0.0
-fiona==1.8.22; sys_platform != 'win32'
+fiona==1.9.0; sys_platform != 'win32'
 folium==0.14.0
 ffpyplayer==4.3.5; python_version < '3.10' # doesn't have py310 wheels
 geopandas==0.12.2; python_version >= '3.8' and sys_platform != 'win32'

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-fiona.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-fiona.py
@@ -10,8 +10,14 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
+from PyInstaller.utils.hooks import collect_data_files
+
+
 hiddenimports = [
     "fiona._shim",
     "fiona.schema",
     "json",
 ]
+
+# Collect data files that are part of the package (e.g., projections database)
+datas = collect_data_files("fiona")

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-fiona.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-fiona.py
@@ -10,14 +10,17 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import collect_data_files
-
+from PyInstaller.utils.hooks import collect_data_files, is_module_satisfies
 
 hiddenimports = [
     "fiona._shim",
     "fiona.schema",
     "json",
 ]
+
+# As of fiona 1.9.0, `fiona.enums` is also a hidden import, made in cythonized `fiona.crs`.
+if is_module_satisfies("fiona >= 1.9.0"):
+    hiddenimports.append("fiona.enums")
 
 # Collect data files that are part of the package (e.g., projections database)
 datas = collect_data_files("fiona")


### PR DESCRIPTION
Update `fiona` hook for compatibility with `fiona` 1.9.0 (add `fiona.enums` to hidden imports).

Also ensure that the package's data files are collected, and add a test that shows why they are needed.