### PR TITLE
Add work-around for ffpyplayer trying to use site.USER_BASE

### DIFF
--- a/news/545.update.rst
+++ b/news/545.update.rst
@@ -1,0 +1,3 @@
+Add work-around for ``ffpyplayer`` 4.3.5 and 4.4.0 trying to use
+``site.USER_BASE``, which is ``None`` in  PyInstaller 5.5 and later
+due to removal of PyInstaller's fake ``site`` module.

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks.dat
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks.dat
@@ -1,5 +1,6 @@
 {
     'enchant': ['pyi_rth_enchant.py'],
+    'ffpyplayer': ['pyi_rth_ffpyplayer.py'],
     'osgeo': ['pyi_rth_osgeo.py'],
     'traitlets': ['pyi_rth_traitlets.py'],
     'usb': ['pyi_rth_usb.py'],

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_ffpyplayer.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_ffpyplayer.py
@@ -1,0 +1,19 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2023, PyInstaller Development Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+#-----------------------------------------------------------------------------
+
+# Starting with v4.3.5, the `ffpyplayer` package attempts to use `site.USER_BASE` in path manipulation functions.
+# As frozen application runs with disabled `site`, the value of this variable is `None`, and causes path manipulation
+# functions to raise an error. As a work-around, we set `site.USER_BASE` to an empty string, which is also what the
+# fake `site` module available in PyInstaller prior to v5.5 did.
+import site
+
+if site.USER_BASE is None:
+    site.USER_BASE = ''


### PR DESCRIPTION
Add a run-time hook for `ffpyplayer` that sets site.USER_BASE to an empty string, in order to prevent run-time errors caused by `ffpyplayer` blindly passing `site.USER_BASE` to `os.path.join`.

Due to `site` being disabled in PyInstaller-frozen application, `site.USER_BASE` is `None`. In PyInstaller versions prior to v5.5, this was mitigated by PyInstaller's own fake `site` module, which also set `site.USER_BASE` to an empty string.