### PR TITLE
Add work-around for tensorflow < 2.3.0 trying to use site.USER_SITE

### DIFF
--- a/news/546.update.rst
+++ b/news/546.update.rst
@@ -1,0 +1,3 @@
+Add work-around for ``tensorflow`` < 2.3.0 trying to use
+``site.USER_SITE``, which is ``None`` in  PyInstaller 5.5 and later
+due to removal of PyInstaller's fake ``site`` module.

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks.dat
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks.dat
@@ -9,4 +9,5 @@
     'pythoncom': ['pyi_rth_pythoncom.py'],
     'pyqtgraph': ['pyi_rth_pyqtgraph_multiprocess.py'],
     'pywintypes': ['pyi_rth_pywintypes.py'],
+    'tensorflow': ['pyi_rth_tensorflow.py'],
 }

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_tensorflow.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_tensorflow.py
@@ -1,0 +1,19 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2023, PyInstaller Development Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+#-----------------------------------------------------------------------------
+
+# `tensorflow` versions prior to 2.3.0 attempt to use `site.USER_SITE` in path/string manipulation functions.
+# As frozen application runs with disabled `site`, the value of this variable is `None`, and causes path/string
+# manipulation functions to raise an error. As a work-around, we set `site.USER_SITE` to an empty string, which is
+# also what the fake `site` module available in PyInstaller prior to v5.5 did.
+import site
+
+if site.USER_SITE is None:
+    site.USER_SITE = ''


### PR DESCRIPTION
Add a run-time hook for `tensorflow` that sets site.USER_SITE to an empty string, in order to prevent run-time errors caused by `tensorflow` < 2.3.0 blindly passing `site.USER_SITE` to `str.startswith`.

Due to `site` being disabled in PyInstaller-frozen application, `site.USER_SITE` is `None`. In PyInstaller versions prior to v5.5, this was mitigated by PyInstaller's own fake `site` module, which also set `site.USER_SITE` to an empty string.

Fixes #529.