### PR TITLE
hooks: prevent pyqtgraph hook from recursing into pyqtgraph.examples

### DIFF
--- a/news/551.update.rst
+++ b/news/551.update.rst
@@ -1,0 +1,2 @@
+Prevent ``pyqtgraph`` hook from recursing into ``pyqgraph.examples``
+while scanning for submodules.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyqtgraph.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyqtgraph.py
@@ -30,8 +30,11 @@ datas = collect_data_files('pyqtgraph', excludes=['**/examples/*'])
 # To be future-proof, we collect all modules by
 # using collect-submodules, and filtering the modules
 # which appear to be templates.
+# We need to avoid recursing into `pyqtgraph.examples`, because that
+# triggers instantiation of `QApplication` (which requires X/Wayland
+# session on linux).
 # Tested with pyqtgraph master branch (commit c1900aa).
-all_imports = collect_submodules("pyqtgraph")
+all_imports = collect_submodules("pyqtgraph", filter=lambda name: name != "pyqtgraph.examples")
 hiddenimports = [name for name in all_imports if "Template" in name]
 
 # Collect the pyqtgraph/multiprocess/bootstrap.py as a module; this is required by our pyqtgraph.multiprocess runtime


### PR DESCRIPTION
Prevent `pyqtgraph` hook from recursing into `pyqtgraph.examples` while scanning for submodules. While the obtained list of submodules is subsequently filtered to include only templates, import of `pyqtgraph.examples` during scan triggers instantiation of `QtWidgets.QApplication`. This, in turn, requires a valid X/Wayland session on linux and and lack thereof results in an error that crashes the python subprocess in which we scan for submodules.

Fixes the second (linux-specific) part of the issue reported in pyinstaller/pyinstaller#7452.