### PR TITLE
hooks: add hooks for moviepy.audio.fx.all and moviepy.video.fx.all

### DIFF
--- a/news/559.new.rst
+++ b/news/559.new.rst
@@ -1,0 +1,3 @@
+Add hooks for ``moviepy.audio.fx.all`` and ``moviepy.video.fx.all`` that collect all
+corresponding submodules, so that importing ``moviepy.editor`` from MoviePy works
+out-of-the-box in the frozen application.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -41,6 +41,7 @@ mariadb==1.1.6; sys_platform != "darwin"
 markdown==3.4.1
 # MetPy is no longer runable with PyInstaller since matplotlib made pillow a dependency. See #395.
 # MetPy==1.2.0; python_version >= '3.7'
+moviepy==1.0.3
 mnemonic==0.20
 msoffcrypto-tool==5.0.0
 netCDF4==1.6.3; python_version >= '3.8'

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-moviepy.audio.fx.all.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-moviepy.audio.fx.all.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the Apache License 2.0
+#
+# The full license is available in LICENSE.APL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------
+
+# `moviepy.audio.fx.all` programmatically imports and forwards all submodules of `moviepy.audio.fx`, so we need to
+# collect those as hidden imports.
+from PyInstaller.utils.hooks import collect_submodules
+
+hiddenimports = collect_submodules('moviepy.audio.fx')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-moviepy.video.fx.all.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-moviepy.video.fx.all.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the Apache License 2.0
+#
+# The full license is available in LICENSE.APL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+# ------------------------------------------------------------------
+
+# `moviepy.video.fx.all` programmatically imports and forwards all submodules of `moviepy.video.fx`, so we need to
+# collect those as hidden imports.
+from PyInstaller.utils.hooks import collect_submodules
+
+hiddenimports = collect_submodules('moviepy.video.fx')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1519,3 +1519,13 @@ def test_minecraft_launcher_lib(pyi_builder):
         assert isinstance(minecraft_launcher_lib.utils.get_library_version(), str)
         '''
     )
+
+
+@importorskip('moviepy')
+def test_moviepy_editor(pyi_builder):
+    # `moviepy.editor` tries to access the `moviepy.video.fx` and `moviepy.audio.fx` plugins/modules via the
+    # `moviepy.video.fx.all` and `moviepy.video.fx.all` modules, which in turn programmatically import and
+    # forward all corresponding submodules.
+    pyi_builder.test_source("""
+        import moviepy.editor
+    """)


### PR DESCRIPTION
These hooks collect corresponding audio/video submodules (which are imported programmatically), which fixes the attribute-not-found error when importing `moviepy.editor` in the frozen application.