### PR TITLE
Update hook-tensorflow.py

### DIFF
--- a/news/564.update.rst
+++ b/news/564.update.rst
@@ -1,0 +1,1 @@
+Update the hook for ``tensorflow`` to be compatible with TensorFlow 2.12.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tensorflow.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tensorflow.py
@@ -18,6 +18,7 @@ tf_post_1_15_0 = is_module_satisfies("tensorflow >= 1.15.0")
 tf_pre_2_0_0 = is_module_satisfies("tensorflow < 2.0.0")
 tf_pre_2_2_0 = is_module_satisfies("tensorflow < 2.2.0")
 
+
 # Exclude from data collection:
 #  - development headers in include subdirectory
 #  - XLA AOT runtime sources

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tensorflow.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tensorflow.py
@@ -18,16 +18,16 @@ tf_post_1_15_0 = is_module_satisfies("tensorflow >= 1.15.0")
 tf_pre_2_0_0 = is_module_satisfies("tensorflow < 2.0.0")
 tf_pre_2_2_0 = is_module_satisfies("tensorflow < 2.2.0")
 
-
 # Exclude from data collection:
 #  - development headers in include subdirectory
 #  - XLA AOT runtime sources
-#  - libtensorflow_framework shared library (to avoid duplication)
+#  - libtensorflow_framework and libtensorflow_cc (since TF 2.12) shared libraries (to avoid duplication)
 #  - import library (.lib) files (Windows-only)
 data_excludes = [
     "include",
     "xla_aot_runtime_src",
     "libtensorflow_framework.*",
+    "libtensorflow_cc.*",
     "**/*.lib",
 ]
 


### PR DESCRIPTION
In the recent TF 2.12 release, there is a new file `libtensorflow_cc.so.2` which now appears twice in the final output: once correctly in the root directory (as 'binary') and once incorrectly in the `tensorflow` subdirectory (as 'data' file). This new file is where they moved the majority of the code, it's over 500 MB, so this duplication causes a lot of overhead.

To reproduce the issue, install `tensorflow==2.12` or `tensorflow-cpu==2.12` and package a file with only `import tensorflow`. With these changes the file only appears once in the final output and the package still works as expected.

I have tested this change on Linux only.