### PR TITLE
Hooks skimage fix

### DIFF
--- a/news/565.new.rst
+++ b/news/565.new.rst
@@ -1,0 +1,1 @@
+Added hook file for scikit-image (skimage). There were existing hooks for individual submodules of skimage, but since v0.2 it needs more.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.py
@@ -1,0 +1,20 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+
+# This hook was tested with scikit-image (skimage) 0.14.1:
+# https://scikit-image.org
+
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+hiddenimports = [x for x in collect_submodules("skimage") if "tests" not in x]
+datas =collect_data_files("skimage")
+

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.py
@@ -16,5 +16,4 @@
 
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 hiddenimports = [x for x in collect_submodules("skimage") if "tests" not in x]
-datas =collect_data_files("skimage")
-
+datas = collect_data_files("skimage")


### PR DESCRIPTION
starting skimage 0.20, I believe, many things are lazy-loaded. To get my project with skimage to work with pyinstaller, I had to upgrade lazy_loader -> 0.2 and include this hook file. hook file created by reading https://github.com/scikit-image/scikit-image/issues/6772#issuecomment-1449671566 and guessing.

Tests did not run for me. There is already a test_skimage in the suite, but `pytest -k 'test_skimage'` would either deselect all tests or (if I removed some decorators in front of test_skimage) run the function with a bunch of parameters that are not listed in the parametrize mark. I haven't used pytest before, so maybe someone else can figure it out.