### PR TITLE
hooks: update scikit-image hooks for compatibility with 0.19.x and 0.20.0

### DIFF
--- a/news/565.update.1.rst
+++ b/news/565.update.1.rst
@@ -1,0 +1,4 @@
+Update ``scikit-image`` hooks for compatibility with the 0.20.x series;
+account for switch to ``lazy_module`` in ``skimage.data`` and
+``skimage.filters`` as well as in main package. Collect new data files
+that are now required by ``skimage.morphology``.

--- a/news/565.update.rst
+++ b/news/565.update.rst
@@ -1,0 +1,2 @@
+Update ``scikit-image`` hooks for compatibility with the 0.19.x series;
+account for lazy module loading in ``skimage.filters``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -120,6 +120,7 @@ exchangelib==4.9.0
 NBT==1.5.1
 minecraft-launcher-lib==5.3; python_version >= '3.8'
 scikit-learn==1.2.2; python_version >= '3.8'
+scikit-image==0.20.0; python_version >= '3.8'
 
 
 # ------------------- Platform (OS) specifics

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.data.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.data.py
@@ -1,0 +1,19 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import is_module_satisfies, collect_data_files, collect_submodules
+
+# As of scikit-image 0.20.0, we need to collect the __init__.pyi file for `lazy_loader`, as well as collect submodules
+# due to lazy loading.
+if is_module_satisfies('scikit-image >= 0.20.0'):
+    datas = collect_data_files("skimage.data", includes=["*.pyi"])
+    hiddenimports = collect_submodules('skimage.data', filter=lambda name: name != 'skimage.data.tests')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.filters.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.filters.py
@@ -10,11 +10,15 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import is_module_satisfies, collect_submodules
+from PyInstaller.utils.hooks import is_module_satisfies, collect_data_files, collect_submodules
 
-if is_module_satisfies("scikit_image >= 0.19.0"):
-    # In scikit-image 0.19.0, `skimage.filters` switched to lazy module loading, so we need to collect all submodules.
+if is_module_satisfies("scikit-image >= 0.19.0"):
+    # In scikit-image 0.19.x, `skimage.filters` switched to lazy module loading, so we need to collect all submodules.
     hiddenimports = collect_submodules('skimage.filters', filter=lambda name: name != 'skimage.filters.tests')
-elif is_module_satisfies("scikit_image >= 0.18.0"):
+
+    # In scikit-image 0.20.0, `lazy_loader` is used, so we need to collect `__init__.pyi` file.
+    if is_module_satisfies("scikit-image >= 0.20.0"):
+        datas = collect_data_files("skimage.filters", includes=["*.pyi"])
+elif is_module_satisfies("scikit-image >= 0.18.0"):
     # The following missing module prevents import of skimage.feature with skimage 0.18.x.
     hiddenimports = ['skimage.filters.rank.core_cy_3d', ]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.filters.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.filters.py
@@ -10,9 +10,11 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import is_module_satisfies
+from PyInstaller.utils.hooks import is_module_satisfies, collect_submodules
 
-# The following missing module prevents import of skimage.feature
-# with skimage 0.18.x.
-if is_module_satisfies("scikit_image >= 0.18.0"):
+if is_module_satisfies("scikit_image >= 0.19.0"):
+    # In scikit-image 0.19.0, `skimage.filters` switched to lazy module loading, so we need to collect all submodules.
+    hiddenimports = collect_submodules('skimage.filters', filter=lambda name: name != 'skimage.filters.tests')
+elif is_module_satisfies("scikit_image >= 0.18.0"):
+    # The following missing module prevents import of skimage.feature with skimage 0.18.x.
     hiddenimports = ['skimage.filters.rank.core_cy_3d', ]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.morphology.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.morphology.py
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files, is_module_satisfies
+
+# As of scikit-image 0.20.0, we need to collect .npy data files for `skimage.morphology`
+if is_module_satisfies('scikit-image >= 0.20'):
+    datas = collect_data_files("skimage.morphology", includes=["*.npy"])

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.py
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files, is_module_satisfies
+
+# As of scikit-image 0.20.0, we need to collect the __init__.pyi file for `lazy_loader`.
+if is_module_satisfies('scikit-image >= 0.20.0'):
+    datas = collect_data_files("skimage", includes=["*.pyi"])

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -487,7 +487,7 @@ def test_pydivert(pyi_builder):
 @pytest.mark.parametrize('submodule', [
     'color', 'data', 'draw', 'exposure', 'feature', 'filters', 'future',
     'graph', 'io', 'measure', 'metrics', 'morphology', 'registration',
-    'restoration', 'segmentation', 'transform', 'util', 'viewer'
+    'restoration', 'segmentation', 'transform', 'util'
 ])
 def test_skimage(pyi_builder, submodule):
     pyi_builder.test_source("""


### PR DESCRIPTION
Update scikit-image hooks for compatibility with 0.19.x and 0.20.0. The 0.19.x series introduced custom lazy module loader, which in our case affects `skimage.filters`. In 0.20.0, they switched to `lazy_loader`, which requires us to collect `__init__.pyi` files. In addition `skimage.morphology` introduced two mandatory .npy data files that it tries to load at import.

Supersedes and closes #565.