### PR TITLE
ci: conditionally enable slow tests for scikit-image and scikit-learn

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -114,3 +114,26 @@ jobs:
 
       - name: Run tests
         run: pytest -v
+
+      # Conditionally enable slow tests, so that they are ran only if
+      # their corresponding packages are explicitly installed but not
+      # if they are installed as dependencies of some other package.
+      - name: Check if slow tests are required (scikit-learn)
+        id: check-scikit-learn
+        shell: bash
+        run: |
+          grep -E "scikit-learn" requirements-test-libraries.txt && echo "AVAILABLE=yes" >> $GITHUB_OUTPUT || echo "AVAILABLE=no" >> $GITHUB_OUTPUT
+
+      - name: Run slow tests (scikit-learn)
+        if: ${{ steps.check-scikit-learn.outputs.AVAILABLE == 'yes' }}
+        run: pytest -v -m slow -k sklearn
+
+      - name: Check if slow tests are required (scikit-image)
+        id: check-scikit-image
+        shell: bash
+        run: |
+          grep -E "scikit-image" requirements-test-libraries.txt && echo "AVAILABLE=yes" >> $GITHUB_OUTPUT || echo "AVAILABLE=no" >> $GITHUB_OUTPUT
+
+      - name: Run slow tests (scikit-image)
+        if: ${{ steps.check-scikit-image.outputs.AVAILABLE == 'yes' }}
+        run: pytest -v -m slow -k skimage

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -119,6 +119,8 @@ spiceypy==5.1.2
 exchangelib==4.9.0
 NBT==1.5.1
 minecraft-launcher-lib==5.3; python_version >= '3.8'
+scikit-learn==1.2.2; python_version >= '3.8'
+
 
 # ------------------- Platform (OS) specifics
 


### PR DESCRIPTION
Add steps that run slow tests for scikit-image and/or scikit-learn when the corresponding package versions are explicitly updated in `requirements-tests-libraries`.