### PR TITLE
Oneshot CI: Support appending custom pytest flags

### DIFF
--- a/.github/workflows/oneshot-test.yml
+++ b/.github/workflows/oneshot-test.yml
@@ -40,6 +40,9 @@ on:
           Ran from bash irregardless of OS.
           Use ';' to separate multiple commands.
         required: false
+      pytest_args:
+        description: |
+          Additional arguments to be passed to pytest.
 
 env:
   # Colored pytest output on CI despite not having a tty
@@ -150,4 +153,4 @@ jobs:
           pip install https://github.com/pyinstaller/pyinstaller/archive/develop.zip
 
       - name: Run tests
-        run: python -m PyInstaller.utils.run_tests -c pytest.ini -v
+        run: pytest -v ${{ inputs.pytest_args }}

--- a/.github/workflows/oneshot-test.yml
+++ b/.github/workflows/oneshot-test.yml
@@ -29,7 +29,7 @@ on:
       python-version:
         description: 'Version(s) of Python'
         required: true
-        default: '3.7,'
+        default: '3.11,'
       fail-fast:
         description: 'Terminate all tests if one fails (true/false).'
         required: true
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
 
       # Actually parse the configuration.
       - id: set-matrix

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
         pyinstaller: ["https://github.com/pyinstaller/pyinstaller/archive/develop.zip"]
         os: ["macos-latest", "ubuntu-latest", "windows-latest"]
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Its fields are as follows:
     * Set to `ubuntu, macos, windows` (order is unimportant) to test all three OSs.
 4.  Which Python version(s) to run on
     * Set to `3.9` to test only Python 3.9,
-    * Set to `3.6, 3.7, 3.8, 3.9` to test all currently supported version of Python.
+    * Set to `3.8, 3.9, 3.10, 3.11` to test all currently supported version of Python.
 5.  The final two options can generally be left alone.
 
 Hit the green **Run workflow** button at the bottom of the dialog, wait a few seconds then refresh the page.

--- a/scripts/cloud-test.py
+++ b/scripts/cloud-test.py
@@ -103,6 +103,7 @@ OSs = ["ubuntu", "windows", "macos"]
 @click.option("--os", multiple=True, default=["ubuntu"], type=click.Choice(OSs + ["all"], case_sensitive=False),
               help="Which OSs to test on. Use 'all' to specify all three. Defaults to 'ubuntu'.")
 @click.option("--fail-fast", default=False, is_flag=True, help="Cancel all other builds if any one of them fails.")
+@click.option("--pytest-args", default="", help="Additional arguments to be passed to pytest.")
 @click.option("--fork", default=None,
               help="Which fork of pyinstaller-hooks-contrib to use. Defaults to the fork of the authenticated user.")
 @click.option("--branch", default=None,
@@ -113,7 +114,7 @@ OSs = ["ubuntu", "windows", "macos"]
 @click.option("--browser", default=False, is_flag=True,
               help="Open the live build on Github in a browser window.")
 @click.option("--dry-run", is_flag=True, help="Don't launch a build. Just parse and print the parameters.")
-def main(package, py, os, fork, branch, fail_fast, commands, browser, dry_run):
+def main(package, py, os, fork, branch, pytest_args, fail_fast, commands, browser, dry_run):
     """Launch CI testing of a given package against multiple package or Python versions and OSs.
 
     The **package** specifies only those to install. Which tests should be ran is inferred implicitly by
@@ -160,6 +161,7 @@ def main(package, py, os, fork, branch, fail_fast, commands, browser, dry_run):
         "python-version": _norm_comma_space(",".join(py)),
         "package": _norm_comma_space(package),
         "os": _norm_comma_space(",".join(os).lower()),
+        "pytest_args": pytest_args,
         "fail-fast": str(fail_fast).lower(),
         "commands": "; ".join(commands),
     }

--- a/scripts/cloud-test.py
+++ b/scripts/cloud-test.py
@@ -89,17 +89,17 @@ def _norm_comma_space(x):
     return re.sub(", *", ", ", x)
 
 
-PYTHONS = ["3.7", "3.8", "3.9", "3.10"]
+PYTHONS = ["3.8", "3.9", "3.10", "3.11"]
 OSs = ["ubuntu", "windows", "macos"]
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.argument("package", nargs=-1)
-@click.option("--py", multiple=True, default=["3.7"],
+@click.option("--py", multiple=True, default=["3.11"],
               help="Python version(s) to test on. Separate multiple versions with a comma or use this parameter "
-                   "multiple times to test multiple versions. You may specify micro versions such as 3.7.9 although "
+                   "multiple times to test multiple versions. You may specify micro versions such as 3.10.9 although "
                    "this is discouraged as they are not guaranteed to be available. Use 'all' to select {}. "
-                   "Defaults to '3.7'.".format(PYTHONS))
+                   "Defaults to '3.11'.".format(PYTHONS))
 @click.option("--os", multiple=True, default=["ubuntu"], type=click.Choice(OSs + ["all"], case_sensitive=False),
               help="Which OSs to test on. Use 'all' to specify all three. Defaults to 'ubuntu'.")
 @click.option("--fail-fast", default=False, is_flag=True, help="Cancel all other builds if any one of them fails.")
@@ -119,10 +119,10 @@ def main(package, py, os, fork, branch, fail_fast, commands, browser, dry_run):
     The **package** specifies only those to install. Which tests should be ran is inferred implicitly by
     ``@pytest.importorskip``.
 
-    Basic usage: Launch two jobs to test the ``pycparser`` hooks on linux, Pythons 3.6 and 3.7, using the latest
+    Basic usage: Launch two jobs to test the ``pycparser`` hooks on linux, Pythons 3.10 and 3.11, using the latest
     version of ``pycparser``. And open the build in a browser window.
 
-        python cloud-test.py --py=3.6,3.7 --os=ubuntu --browser pycparser
+        python cloud-test.py --py=3.10,3.11 --os=ubuntu --browser pycparser
 
     The **package** can be anything you'd put on the right hand side of `pip install`. Multiple packages to install can
     be separated by a space: Launch one job which installs and tests two libraries.


### PR DESCRIPTION
Custom flags are likely to be `-m slow` or `-k some_test`.

Also bump the default Python versions.