### PR TITLE
Add hook for pylsl

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -99,7 +99,7 @@ jobs:
           # Install libdiscid (dependency of discid python package).
           brew install libdiscid
           # Install lsl library for pylsl
-          brew install lsl
+          brew install brew install labstreaminglayer/tap/lsl
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -98,6 +98,8 @@ jobs:
           brew install pango
           # Install libdiscid (dependency of discid python package).
           brew install libdiscid
+          # Install lsl library for pylsl
+          brew install lsl
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -99,7 +99,7 @@ jobs:
           # Install libdiscid (dependency of discid python package).
           brew install libdiscid
           # Install lsl library for pylsl
-          brew install brew install labstreaminglayer/tap/lsl
+          brew install labstreaminglayer/tap/lsl
 
       - name: Install dependencies
         shell: bash

--- a/news/573.new.rst
+++ b/news/573.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``pylsl``

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -122,7 +122,6 @@ minecraft-launcher-lib==5.3; python_version >= '3.8'
 scikit-learn==1.2.2; python_version >= '3.8'
 scikit-image==0.20.0; python_version >= '3.8'
 
-
 # ------------------- Platform (OS) specifics
 
 # PyEnchant only pre-builds macOS and Windows
@@ -139,6 +138,9 @@ pywin32-ctypes==0.2.0; sys_platform == 'win32'
 
 # pymediainfo on linux does not bundle mediainfo shared library, and requires system one.
 pymediainfo==6.0.1; sys_platform == 'darwin' or sys_platform == 'win32'
+
+# the required library can be installed with "brew install lsl" on macOS, or with "conda install liblsl" on any platform
+pylsl==1.16.1; sys_platform == "darwin"
 
 # Include the requirements for testing
 -r requirements-test.txt

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -139,7 +139,7 @@ pywin32-ctypes==0.2.0; sys_platform == 'win32'
 # pymediainfo on linux does not bundle mediainfo shared library, and requires system one.
 pymediainfo==6.0.1; sys_platform == 'darwin' or sys_platform == 'win32'
 
-# the required library can be installed with "brew install lsl" on macOS, or with "conda install liblsl" on any platform
+# the required library can be installed with "brew install labstreaminglayer/tap/lsl" on macOS, or with "conda install liblsl" on any platform
 pylsl==1.16.1; sys_platform == "darwin"
 
 # Include the requirements for testing

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pylsl.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pylsl.py
@@ -75,7 +75,3 @@ if libfile:
 else:
     logger.warning("liblsl shared library not found - pylsl will likely fail to work!")
     binaries = []
-
-
-if __name__ == '__main__':
-    print(binaries)

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pylsl.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pylsl.py
@@ -1,72 +1,29 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
 import os
-import platform
-import struct
-import pathlib
-from ctypes import util
-from PyInstaller.utils.hooks import get_module_file_attribute, logger
+from PyInstaller.utils.hooks import logger
 
-"""
-Hook for pylsl, i.e., the Python wrapper around labstreaminglayer (aka LSL).
-The pylsl package loads the C++ liblsl library using CDLL. The logic for
-locating liblsl is replicated here; subsequently it is added to the binaries
-and packaged in the compiled version such that pylsl will be able to find it
-there as well.
-
-See also
--  https://labstreaminglayer.readthedocs.io
--  https://github.com/labstreaminglayer/pylsl
--  https://github.com/sccn/liblsl
-"""
-
-
-def find_liblsl_library():
-    """finds the binary lsl library.
-
-    Search order is to first try to use the path stored in the environment
-    variable PYLSL_LIB (if available), then search through the package
-    directory, and finally search the whole system.
-    """
-
-    # first try the environment variable PYLSL_LIB
-    if "PYLSL_LIB" in os.environ:
-        libfile = os.environ["PYLSL_LIB"]
-        if libfile and os.path.isfile(libfile):
-            return libfile
-
-    # this will only run if PYLSL_LIB did not resolve the library
-    os_name = platform.system()
-    if os_name in ["Windows", "Microsoft"]:
-        libsuffix = ".dll"
-    elif os_name == "Darwin":
-        libsuffix = ".dylib"
-    elif os_name == "Linux":
-        libsuffix = ".so"
-    else:
-        raise RuntimeError("unrecognized operating system:", os_name)
-
-    for scope in ["package", "system"]:
-        for libprefix in ["", "lib"]:
-            for debugsuffix in ["", "-debug"]:
-                for bitness in ["", str(8 * struct.calcsize("P"))]:
-                    if scope == "package":
-                        # try in the package directory at pylsl/lib
-                        module_dir = pathlib.Path(get_module_file_attribute('pylsl')).parent
-                        libfile = os.path.join(module_dir, libprefix + "lsl" + bitness + debugsuffix + libsuffix)
-                        if libfile and os.path.isfile(libfile):
-                            return libfile
-                    elif (scope == "system") and os_name not in ["Windows", "Microsoft"]:
-                        # try on the system library path, this includes the conda library path
-                        libfile = util.find_library(libprefix + "lsl" + bitness + debugsuffix)
-                        if libfile and os.path.isfile(libfile):
-                            return libfile
-                    elif (scope == "system") and os_name == "Darwin":
-                        # try on the homebrew library path
-                        libfile = util.find_library('/opt/homebrew/lib/' + libprefix + "lsl" + bitness + debugsuffix)
-                        if libfile and os.path.isfile(libfile):
-                            return libfile
+try:
+    # the import will fail it the library cannot be found
+    from pylsl import pylsl
     
+    # the find_liblsl_libraries() is a generator function that yields multiple possibilities
+    for libfile in pylsl.find_liblsl_libraries():
+        if libfile:
+            break
+except:
+    libfile = None
 
-libfile = find_liblsl_library()
 
 if libfile:
     # add the liblsl library to the binaries

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pylsl.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pylsl.py
@@ -39,4 +39,3 @@ if libfile:
 else:
     logger.warning("liblsl shared library not found - pylsl will likely fail to work!")
     binaries = []
-    

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pylsl.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pylsl.py
@@ -1,0 +1,81 @@
+import os
+import platform
+import struct
+import pathlib
+from ctypes import util
+from PyInstaller.utils.hooks import get_module_file_attribute, logger
+
+"""
+Hook for pylsl, i.e., the Python wrapper around labstreaminglayer (aka LSL).
+The pylsl package loads the C++ liblsl library using CDLL. The logic for
+locating liblsl is replicated here; subsequently it is added to the binaries
+and packaged in the compiled version such that pylsl will be able to find it
+there as well.
+
+See also
+-  https://labstreaminglayer.readthedocs.io
+-  https://github.com/labstreaminglayer/pylsl
+-  https://github.com/sccn/liblsl
+"""
+
+
+def find_liblsl_library():
+    """finds the binary lsl library.
+
+    Search order is to first try to use the path stored in the environment
+    variable PYLSL_LIB (if available), then search through the package
+    directory, and finally search the whole system.
+    """
+
+    # first try the environment variable PYLSL_LIB
+    if "PYLSL_LIB" in os.environ:
+        libfile = os.environ["PYLSL_LIB"]
+        if libfile and os.path.isfile(libfile):
+            return libfile
+
+    # this will only run if PYLSL_LIB did not resolve the library
+    os_name = platform.system()
+    if os_name in ["Windows", "Microsoft"]:
+        libsuffix = ".dll"
+    elif os_name == "Darwin":
+        libsuffix = ".dylib"
+    elif os_name == "Linux":
+        libsuffix = ".so"
+    else:
+        raise RuntimeError("unrecognized operating system:", os_name)
+
+    for scope in ["package", "system"]:
+        for libprefix in ["", "lib"]:
+            for debugsuffix in ["", "-debug"]:
+                for bitness in ["", str(8 * struct.calcsize("P"))]:
+                    if scope == "package":
+                        # try in the package directory at pylsl/lib
+                        module_dir = pathlib.Path(get_module_file_attribute('pylsl')).parent
+                        libfile = os.path.join(module_dir, libprefix + "lsl" + bitness + debugsuffix + libsuffix)
+                        if libfile and os.path.isfile(libfile):
+                            return libfile
+                    elif (scope == "system") and os_name not in ["Windows", "Microsoft"]:
+                        # try on the system library path, this includes the conda library path
+                        libfile = util.find_library(libprefix + "lsl" + bitness + debugsuffix)
+                        if libfile and os.path.isfile(libfile):
+                            return libfile
+                    elif (scope == "system") and os_name == "Darwin":
+                        # try on the homebrew library path
+                        libfile = util.find_library('/opt/homebrew/lib/' + libprefix + "lsl" + bitness + debugsuffix)
+                        if libfile and os.path.isfile(libfile):
+                            return libfile
+    
+
+libfile = find_liblsl_library()
+
+if libfile:
+    # add the liblsl library to the binaries
+    # it gets packaged in pylsl/lib, which is where pylsl will look first
+    binaries = [(libfile, os.path.join('pylsl', 'lib'))]
+else:
+    logger.warning("liblsl shared library not found - pylsl will likely fail to work!")
+    binaries = []
+
+
+if __name__ == '__main__':
+    print(binaries)

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pylsl.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pylsl.py
@@ -11,19 +11,23 @@
 # ------------------------------------------------------------------
 
 import os
-from PyInstaller.utils.hooks import logger
+from PyInstaller.utils.hooks import logger, isolated 
 
-try:
-    # the import will fail it the library cannot be found
-    from pylsl import pylsl
-    
-    # the find_liblsl_libraries() is a generator function that yields multiple possibilities
-    for libfile in pylsl.find_liblsl_libraries():
-        if libfile:
-            break
-except:
-    libfile = None
+def find_library():
+    try:
+        # the import will fail it the library cannot be found
+        from pylsl import pylsl
+        
+        # the find_liblsl_libraries() is a generator function that yields multiple possibilities
+        for libfile in pylsl.find_liblsl_libraries():
+            if libfile:
+                break
+    except:
+        libfile = None
+    return libfile
 
+# whenever a hook needs to load a 3rd party library, it needs to be done in an isolated subprocess
+libfile = isolated.call(find_library)
 
 if libfile:
     # add the liblsl library to the binaries

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pylsl.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pylsl.py
@@ -11,20 +11,23 @@
 # ------------------------------------------------------------------
 
 import os
-from PyInstaller.utils.hooks import logger, isolated 
+from PyInstaller.utils.hooks import logger, isolated
+
 
 def find_library():
     try:
         # the import will fail it the library cannot be found
         from pylsl import pylsl
-        
+
         # the find_liblsl_libraries() is a generator function that yields multiple possibilities
         for libfile in pylsl.find_liblsl_libraries():
             if libfile:
                 break
-    except:
+    except (ImportError, ModuleNotFoundError, RuntimeError) as error:
+        print(error)
         libfile = None
     return libfile
+
 
 # whenever a hook needs to load a 3rd party library, it needs to be done in an isolated subprocess
 libfile = isolated.call(find_library)
@@ -36,3 +39,4 @@ if libfile:
 else:
     logger.warning("liblsl shared library not found - pylsl will likely fail to work!")
     binaries = []
+    

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -251,6 +251,15 @@ def test_markdown(pyi_builder):
         """)
 
 
+@importorskip('pylsl')
+def test_lxml_isoschematron(pyi_builder):
+    pyi_builder.test_source(
+        """
+        import pylsl
+        print(pylsl.version.__version__)
+        """)
+
+
 @importorskip('lxml')
 def test_lxml_isoschematron(pyi_builder):
     pyi_builder.test_source(

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -252,7 +252,7 @@ def test_markdown(pyi_builder):
 
 
 @importorskip('pylsl')
-def test_lxml_isoschematron(pyi_builder):
+def test_pylsl(pyi_builder):
     pyi_builder.test_source(
         """
         import pylsl


### PR DESCRIPTION
This adds a hook for pylsl, i.e., the Python wrapper around labstreaminglayer,  which is also known as LSL.

The pylsl package loads the C++ liblsl library using CDLL. The logic for locating liblsl is replicated here; subsequently it is added to the binaries and packaged in the compiled version in `pylsl/lib` which ensures that  pylsl will be able to find it.

See also
-  https://labstreaminglayer.readthedocs.io
-  https://github.com/labstreaminglayer/pylsl
-  https://github.com/sccn/liblsl

I tested it successfully on macOS and Windows, using a few methods to install liblsl (using conda, using homebrew, and using a local copy and the PYLSL_LIB variable).