### PR TITLE
Remove py hidden imports for pyshark >= 0.6.

### DIFF
--- a/news/575.update.rst
+++ b/news/575.update.rst
@@ -1,0 +1,1 @@
+ Remove no longer needed ``py`` hidden imports for ``pyshark >= 0.6``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -112,7 +112,7 @@ soundfile==0.12.1; sys_platform != 'linux'
 limits==3.4.0
 great-expectations==0.16.7
 tensorflow==2.12.0; python_version >= '3.8'
-pyshark==0.5.3
+pyshark==0.6.0
 opencv-python==4.7.0.72
 hydra-core==1.3.2
 spiceypy==5.1.2

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyshark.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyshark.py
@@ -16,9 +16,11 @@
 
 from PyInstaller.utils.hooks import collect_data_files, is_module_satisfies
 
-hiddenimports = ['pyshark', 'py._path.local', 'py._vendored_packages.iniconfig', 'pyshark.config']
+hiddenimports = ['pyshark.config']
 
-if is_module_satisfies("pyshark >= 0.5"):
-    hiddenimports += ["py._io.terminalwriter", "py._builtin"]
+if is_module_satisfies("pyshark < 0.6"):
+    hiddenimports += ['py._path.local', 'py._vendored_packages.iniconfig']
+    if is_module_satisfies("pyshark >= 0.5"):
+        hiddenimports += ["py._io.terminalwriter", "py._builtin"]
 
 datas = collect_data_files('pyshark')


### PR DESCRIPTION
`pyshark` now uses `termcolor` instead of `py._io.terminalwriter` for writing colored text to terminals.
