### PR TITLE
Add email_validator to the list of pydantic optional dependencies hidden imports

### DIFF
--- a/news/576.update.rst
+++ b/news/576.update.rst
@@ -1,0 +1,1 @@
+ Update ``pydantic`` hook hidden imports to include the optional dependency ``email_validator``.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
@@ -35,6 +35,7 @@ if is_compiled:
         'uuid',
         # Optional dependencies.
         'dotenv',
+        'email_validator'
     ]
     # Older releases (prior 1.4) also import distutils.version
     if not is_module_satisfies('pydantic >= 1.4'):


### PR DESCRIPTION
This commit adds the missing email-validator package required by Pydantic when validating email.

Without it, we have to manually append the package `email_validator` on the hidden-import argument.

You can find more information about this change in the documentation at https://docs.pydantic.dev/latest/install/#optional-dependencies .