### PR TITLE
Add hook for fastparquet

### DIFF
--- a/news/583.new.rst
+++ b/news/583.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``fastparquet``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -126,6 +126,7 @@ minecraft-launcher-lib==5.3; python_version >= '3.8'
 scikit-learn==1.2.2; python_version >= '3.8'
 scikit-image==0.20.0; python_version >= '3.8'
 customtkinter==5.1.3
+fastparquet==2023.4.0; python_version >= '3.8'
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-fastparquet.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-fastparquet.py
@@ -1,0 +1,32 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+import os
+
+from PyInstaller.compat import is_win
+from PyInstaller.utils.hooks import get_package_paths
+
+# In all versions for which fastparquet provides Windows wheels (>= 0.7.0), delvewheel is used,
+# so we need to collect the external site-packages/fastparquet.libs directory.
+if is_win:
+    pkg_base, pkg_dir = get_package_paths("fastparquet")
+    lib_dir = os.path.join(pkg_base, "fastparquet.libs")
+    if os.path.isdir(lib_dir):
+        # We collect DLLs as data files instead of binaries to suppress binary
+        # analysis, which would result in duplicates (because it collects a copy
+        # into the top-level directory instead of preserving the original layout).
+        # In addition to DLls, this also collects .load-order* file (required on
+        # python < 3.8), and ensures that fastparquet.libs directory exists (required
+        # on python >= 3.8 due to os.add_dll_directory call).
+        datas = [
+            (os.path.join(lib_dir, lib_file), 'fastparquet.libs')
+            for lib_file in os.listdir(lib_dir)
+        ]

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1581,3 +1581,10 @@ def test_pylibmagic(pyi_builder):
             assert os.path.isfile(f"{pylibmagic_data_path}/{file}"), \
                 f"The {file} was not collected to _MEIPASS!"
     """)
+
+
+@importorskip('fastparquet')
+def test_fastparquet(pyi_builder):
+    pyi_builder.test_source("""
+        import fastparquet
+    """)


### PR DESCRIPTION
Closes #580.

While I would have liked to use the `PyInstaller.utils.hooks.collect_delvewheel_libs_directory` helper for this, at the moment we impose no PyInstaller version limit on these hooks while we would need
- PyInstaller >= 5.6 to have the helper available in the first place
- PyInstaller >= 5.11 to have the helper collect the `.load_order` file
- PyInstaller >= 5.4 to prevent duplication of DLLs due to lack of parent path preservation in older PyInstaller versions.

So for now, we do this "the old way", like we do in other hooks in this repository (e.g., `av`, `shapely`). 