### PR TITLE
hooks: add hook for sympy

### DIFF
--- a/news/587.new.rst
+++ b/news/587.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``sympy`` that automatically raises recursion limit
+to 5000 if ``sympy`` >= 1.12 is detected.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -128,6 +128,7 @@ scikit-image==0.20.0; python_version >= '3.8'
 customtkinter==5.1.3
 fastparquet==2023.4.0; python_version >= '3.8'
 librosa==0.10.0.post2
+sympy==1.12; python_version >= '3.8'
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sympy.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sympy.py
@@ -1,0 +1,23 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import logger, is_module_satisfies
+
+
+# With sympy 1.12, PyInstaller's modulegraph analysis hits the recursion limit.
+# So, unless the user has already done so, increase it automatically.
+if is_module_satisfies('sympy >= 1.12'):
+    import sys
+    new_limit = 5000
+    if sys.getrecursionlimit() < new_limit:
+        logger.info("hook-sympy: raising recursion limit to %d", new_limit)
+        sys.setrecursionlimit(new_limit)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1615,3 +1615,10 @@ def test_librosa_util_function(pyi_builder):
         expected = np.array([False,  True, False, False,  True, False,  True, False])
         assert (result == expected).all()
     """)
+
+
+@importorskip('sympy')
+def test_sympy(pyi_builder):
+    pyi_builder.test_source("""
+        import sympy
+    """)


### PR DESCRIPTION
Add hook for `sympy` that automatically raises recursion limit to 5000 if `sympy` >= 1.12 is detected.

Closes #584.

Oneshot: [before](https://github.com/rokm/pyinstaller-hooks-contrib/actions/runs/5050627060/jobs/9061568971) and [after](https://github.com/rokm/pyinstaller-hooks-contrib/actions/runs/5050708408) - as can be seen, we could get away without raising the limit under python 3.8, but let's tie this only to `sympy` version for now...