### PR TITLE
tests: compliance_checker: use a different .nc file

### DIFF
--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -19,7 +19,7 @@ cftime==1.6.2
 charset_normalizer==3.1.0
 cloudscraper==1.2.71
 # compliance-checker requires cf-units, so same constraints apply.
-compliance-checker==5.0.2; sys_platform != 'win32' and python_version >= '3.8'
+compliance-checker==5.1.0; sys_platform != 'win32' and python_version >= '3.8'
 dash==2.9.3
 dash-bootstrap-components==1.4.1
 dash-uploader==0.6.0

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1496,7 +1496,7 @@ def test_compliance_checker(pyi_builder):
     # The test file - taken from the package's own test data/examples. Use an .nc file instead of .cdl one, because
     # loading the latter requires ncgen utility to be available on the system.
     pkg_path = get_module_attribute('compliance_checker', '__path__')[0]
-    input_file = Path(pkg_path) / 'tests/data/trajectory.nc'
+    input_file = Path(pkg_path) / 'tests/data/bad-trajectory.nc'
     assert input_file.is_file(), f"Selected test file, {input_file!s} does not exist! Fix the test!"
 
     pyi_builder.test_source("""


### PR DESCRIPTION
Use `compliance_checker/tests/data/bad-trajectory.nc` as a test file; in contrast to previously used `trajectory.nc`, the `bad-trajectory.nc` is part of `compliance-checker`'s git repository, and is available in 5.1.0 wheel.