### PR TITLE
hooks: update scikit-image hooks for compatibility with version 0.21.0

### DIFF
--- a/news/594.update.rst
+++ b/news/594.update.rst
@@ -1,0 +1,1 @@
+Update ``scikit-image`` hooks for compatibility with version 0.21.0.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -124,7 +124,7 @@ exchangelib==5.0.3
 NBT==1.5.1
 minecraft-launcher-lib==5.3; python_version >= '3.8'
 scikit-learn==1.2.2; python_version >= '3.8'
-scikit-image==0.20.0; python_version >= '3.8'
+scikit-image==0.21.0; python_version >= '3.8'
 customtkinter==5.1.3
 fastparquet==2023.4.0; python_version >= '3.8'
 librosa==0.10.0.post2

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.color.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.color.py
@@ -1,0 +1,19 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import is_module_satisfies, collect_data_files, collect_submodules
+
+# As of scikit-image 0.21.0, we need to collect the __init__.pyi file for `lazy_loader`, as well as collect submodules
+# due to lazy loading.
+if is_module_satisfies("scikit-image >= 0.21.0"):
+    datas = collect_data_files("skimage.color", includes=["*.pyi"])
+    hiddenimports = collect_submodules('skimage.color', filter=lambda name: name != 'skimage.color.tests')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.draw.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.draw.py
@@ -1,0 +1,19 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import is_module_satisfies, collect_data_files, collect_submodules
+
+# As of scikit-image 0.21.0, we need to collect the __init__.pyi file for `lazy_loader`, as well as collect submodules
+# due to lazy loading.
+if is_module_satisfies("scikit-image >= 0.21.0"):
+    datas = collect_data_files("skimage.draw", includes=["*.pyi"])
+    hiddenimports = collect_submodules('skimage.draw', filter=lambda name: name != 'skimage.draw.tests')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.exposure.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.exposure.py
@@ -1,0 +1,19 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import is_module_satisfies, collect_data_files, collect_submodules
+
+# As of scikit-image 0.21.0, we need to collect the __init__.pyi file for `lazy_loader`, as well as collect submodules
+# due to lazy loading.
+if is_module_satisfies("scikit-image >= 0.21.0"):
+    datas = collect_data_files("skimage.exposure", includes=["*.pyi"])
+    hiddenimports = collect_submodules('skimage.exposure', filter=lambda name: name != 'skimage.exposure.tests')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.future.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.future.py
@@ -1,0 +1,19 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import is_module_satisfies, collect_data_files, collect_submodules
+
+# As of scikit-image 0.21.0, we need to collect the __init__.pyi file for `lazy_loader`, as well as collect submodules
+# due to lazy loading.
+if is_module_satisfies("scikit-image >= 0.21.0"):
+    datas = collect_data_files("skimage.future", includes=["*.pyi"])
+    hiddenimports = collect_submodules('skimage.future', filter=lambda name: name != 'skimage.future.tests')


### PR DESCRIPTION
Add hooks for sub-packages that are now using `lazy_loader`; we need to collect the `__init__.pyi` and all submodules.