### PR TITLE
test requirements: restrict adbutils to python < 3.10

### DIFF
--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -4,7 +4,8 @@ importlib_resources==5.12.0; python_version < '3.9'
 # ------------------ LIBRARIES ------------------ #
 # TODO: Add most of the libraries we have hooks for, and write tests
 av==10.0.0
-adbutils==1.2.9; sys_platform == 'darwin' or sys_platform == 'win32'
+# The latest release of adbutils (1.2.11) explicitly requires requests<2.16, which is incompatible with python >= 3.10.
+adbutils==1.2.11; (sys_platform == 'darwin' or sys_platform == 'win32') and python_version < '3.10'
 APScheduler==3.10.1
 backports.zoneinfo==0.2.1; python_version < '3.9'
 bokeh==3.1.1; python_version >= '3.8'


### PR DESCRIPTION
The latest release of `adbutils` (1.2.11) explicitly pins `requests<2.16`, resulting in installation of `requests-2.15.1`, which is incompatible with python >= 3.10 due to use of `collections.Mapping` that was moved to `collections.abc`.

Hence, the package is essentially incompatible with python >= 3.10, and we should not be testing it there.