### PR TITLE
hooks: Fix googleapiclient.model missing docs and improve test

### DIFF
--- a/news/596.update.rst
+++ b/news/596.update.rst
@@ -1,0 +1,1 @@
+Update hook for ``googleapiclient.model``, fixing missing discovery docs and improving test.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -33,6 +33,7 @@ fiona==1.9.4.post1; sys_platform != 'win32'
 folium==0.14.0
 ffpyplayer==4.5.0
 geopandas==0.13.1; python_version >= '3.8' and sys_platform != 'win32'
+google-api-python-client==2.88.0; python_version >= '3.7'
 graphql-query==1.1.1
 python-gitlab==3.14.0
 h5py==3.8.0; python_version >= '3.7'

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-googleapiclient.model.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-googleapiclient.model.py
@@ -17,4 +17,4 @@ from PyInstaller.utils.hooks import collect_data_files
 # pkg_resources.get_distribution("google-api-python-client").version,
 # so we need to collect that package's metadata
 datas = copy_metadata('google_api_python_client')
-datas += collect_data_files('googleapiclient.discovery', excludes=['*.txt', '**/__pycache__'])
+datas += collect_data_files('googleapiclient.discovery_cache', excludes=['*.txt', '**/__pycache__'])

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -605,10 +605,21 @@ def test_torchvision_nms(pyi_builder):
     """)
 
 
-@importorskip('googleapiclient')
+@requires('google-api-python-client >= 2.0.0')
 def test_googleapiclient(pyi_builder):
     pyi_builder.test_source("""
-        from googleapiclient.discovery import build
+        from googleapiclient import discovery, discovery_cache
+
+        API_NAME = "youtube"
+        API_VERSION = "v3"
+
+        for file in os.listdir(discovery_cache.DISCOVERY_DOC_DIR): # Always up to date
+            if file.startswith("youtube.v") and file.endswith(".json"):
+                API_NAME, API_VERSION = file.split(".")[:2]
+                break
+
+        # developerKey can be any non-empty string
+        yt = discovery.build(API_NAME, API_VERSION, developerKey=":)", static_discovery=True)
         """)
 
 


### PR DESCRIPTION
The hook `googleapiclient.model` was raising this warning when running Pyinstaller: `WARNING: collect_data_files - skipping data collection for module 'googleapiclient.discovery' as it is not a package.` Needing workarounds to run the api client, see https://github.com/googleapis/google-api-python-client/issues/876. But this can be fixed by pointing it to the correct package `googleapiclient.discovery_cache`.


The test also received an improvement. The current test only run `from googleapiclient.discovery import build` which is  not sufficient because the error happens when calling the `build` function. Calling this function doesn't require a valid API key.

[Github Actions](https://github.com/ArthurKlausHoff/pyinstaller-hooks-contrib/actions/runs/5246383593)