### PR TITLE
Fix weekly breakage

### DIFF
--- a/news/599.update.1.rst
+++ b/news/599.update.1.rst
@@ -1,0 +1,1 @@
+Update ``netCDF4`` hook for compatibility with ``netCDF4`` v1.6.4.

--- a/news/599.update.rst
+++ b/news/599.update.rst
@@ -1,0 +1,1 @@
+Update ``cairocffi`` hook for compatibility with ``cairocffi`` v1.6.0.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -48,7 +48,7 @@ markdown==3.4.3
 moviepy==1.0.3
 mnemonic==0.20
 msoffcrypto-tool==5.0.0
-netCDF4==1.6.3; python_version >= '3.8'
+netCDF4==1.6.4; python_version >= '3.8'
 numcodecs==0.11.0; python_version >= '3.8'
 Office365-REST-Python-Client==2.4.1
 openpyxl==3.1.2

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -13,7 +13,7 @@ boto==2.49.0
 boto3==1.26.146
 botocore==1.29.146
 branca==0.6.0
-cairocffi==1.5.1
+cairocffi==1.6.0
 CairoSVG==2.7.0
 cassandra-driver==3.27.0
 cf-units==3.2.0; sys_platform != 'win32' and python_version >= '3.8'

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cairocffi.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cairocffi.py
@@ -13,7 +13,7 @@ import ctypes.util
 import os
 
 from PyInstaller.depend.utils import _resolveCtypesImports
-from PyInstaller.utils.hooks import collect_data_files, logger
+from PyInstaller.utils.hooks import collect_data_files, is_module_satisfies, logger
 
 datas = collect_data_files("cairocffi")
 
@@ -38,3 +38,8 @@ except Exception as e:
 
 if not binaries:
     logger.warning("Cairo library not found - cairocffi will likely fail to work!")
+
+# cairocffi 1.6.0 requires cairocffi/constants.py source file, so make sure it is collected.
+# The module collection mode setting requires PyInstaller >= 5.3.
+if is_module_satisfies('cairocffi >= 1.6.0'):
+    module_collection_mode = {'cairocffi.constants': 'pyz+py'}

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-netCDF4.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-netCDF4.py
@@ -20,3 +20,8 @@ if is_module_satisfies("netCDF4 < 1.4.0"):
     hiddenimports += ['netcdftime']
 else:
     hiddenimports += ['cftime']
+
+# Starting with netCDF 1.6.4, certifi is a hidden import made in
+# netCDF4/_netCDF4.pyx.
+if is_module_satisfies("netCDF4 >= 1.6.4"):
+    hiddenimports += ['certifi']


### PR DESCRIPTION
Update hooks for `cairocffi` and `netCDF4` for their latest released versions.