### PR TITLE
Drop flake8's no longer supported `--diff` flag

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,24 +14,15 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
-        fetch-depth: 0
 
-    - name: Get out of detached head state
-      run: |
-        git fetch origin ${{ github.base_ref }}
-        git fetch origin ${{ github.ref }}
-        git checkout FETCH_HEAD --
     - name: Setup Python
       uses: actions/setup-python@v4
-      with:
-        python-version: 3.7
 
     - name: Install dependencies
       run: pip install -U flake8 wheel setuptools
 
     - name: Run Lint
-      run: |
-        git diff -U0 origin/${{ github.base_ref }} -- | flake8 --diff -v -
+      run: flake8 -v
     - name: Test Distribution
       run: |
         python setup.py sdist bdist_wheel

--- a/README.md
+++ b/README.md
@@ -295,25 +295,15 @@ rerunning a configuration is just a case of pressing up then enter.
 
 We use `flake8` to enforce code-style.
 `pip install flake8` if you haven't already then run it with the following.
-Note that this assumes that you did create a new branch in the [setup step](#setup).
 
 ```
-git diff -U0 master | flake8 --diff -
+flake8
 ```
 
 No news is good news.
 If it complains about your changes then do what it asks then run it again.
 If you don't understand the errors it come up with them lookup the error code
 in each line (a capital letter followed by a number e.g. `W391`).
-
-If it complains about code which you haven't written,
-or if you didn't create a new branch at the start then, using `git log`,
-find the commit ID of the newest commit which you didn't write, copy it
-and replace `master` in the above command with that ID.
-
-```
-git diff -U0 a5d3841c282fa23fd68c3d6a85519e73c08acb4a | flake8 --diff -
-```
 
 **Please do not fix flake8 issues found in parts of the repository other than the bit that you are working on.** Not only is it very boring for you, but it is harder for maintainers to
 review your changes because so many of them are irrelevant to the hook you are adding or changing.
@@ -334,7 +324,7 @@ A brief checklist for before submitting your pull request:
 
 * [ ] All new Python files have [the appropriate copyright header](#add-the-copyright-header).
 * [ ] You have written a [news entry](#add-a-news-entry).
-* [ ] Your changes [satisfy the linter](#run-linter) (run `git diff -U0 master | flake8 --diff -`).
+* [ ] Your changes [satisfy the linter](#run-linter) (run `flake8`).
 * [ ] You have written tests (if possible), [pinned the test requirement](#pin-the-test-requirement) and linked to a successful CI build.
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,15 +25,15 @@ class BumpVersion(Command):
         ('minor', None, 'Bump the minor (middle) version number. If specified, the build NO will be set to 0.'),
         ('build', None, 'Bump the build (rightmost) version number. (Default)')
     ]
-    
+
     def get_version_tuple(self, str_ver):
         return list(int(x) for x in str_ver.split('.'))
-    
+
     def initialize_options(self):
         self.major = False
         self.minor = False
         self.build = True
-    
+
     def finalize_options(self):
         if self.major:
             self.major = True
@@ -47,7 +47,7 @@ class BumpVersion(Command):
             self.major = False
             self.minor = False
             self.build = True
-    
+
     def run(self):
         import re
         # REGEX:
@@ -56,7 +56,7 @@ class BumpVersion(Command):
         #  [.]*[0-9]*  - Third - and optional - part of version
         #  [^.]$  - The entire string must not end with a dot
         version_regex = re.compile('[0-9]+[.][0-9]*[.]*[0-9]*[^.]$')
-        
+
         # List of ABSOLUTE file paths of files to bump
         files = [
             os.path.abspath(os.path.join(DIR, 'src/_pyinstaller_hooks_contrib/__init__.py'))
@@ -64,11 +64,11 @@ class BumpVersion(Command):
         for file in files:
             old_file = open(file).readlines()
             changed = False
-            
+
             for i in range(len(old_file)):
                 # Get rid of line endings, if they exist
                 line = old_file[i].replace('\n', '')
-                
+
                 # If the line starts with version, try and bump it
                 if line.startswith('__version__'):
                     print('Line {ln} in {file} appears to be a version. Attempting to bump...'.format(ln=i, file=file))
@@ -78,18 +78,18 @@ class BumpVersion(Command):
                         # Convert a "valid" version to a tuple of ints
                         ver = self.get_version_tuple(m.string)
                         print(ver)
-                        
+
                         # If the tuple isn't valid - not len(3) - then it's not a valid version
                         if len(ver) not in (2, 3):
                             print('Invalid version number. Skipping...')
                             continue
-                        
+
                         if len(ver) == 3:
                             if self.major:
                                 ver[0] += 1
                                 ver[1] = 0
                                 ver[2] = 0
-                                
+
                             elif self.minor:
                                 ver[1] += 1
                                 ver[2] = 0
@@ -101,22 +101,22 @@ class BumpVersion(Command):
                                 ver[1] = 0
                             else:
                                 ver[1] += 1
-                        
+
                         ver = '.'.join(str(x) for x in ver)
-                        
+
                         old_file[i] = old_file[i].replace(m.string, ver)
                         print('Version bumped from {} to {}.'.format(m.string, ver))
                         changed = True
                     else:
                         print('No version found - {file}:{ln}'.format(ln=i, file=file))
-            
+
             if changed:
                 # Write the changes to the file
                 with open(file, 'w') as f:
                     f.writelines(old_file)
                 # And print that to the console.
                 print('Changes written to {}'.format(file))
-                        
+
 
 setup(
     setup_requires="setuptools >= 30.3.0",

--- a/src/_pyinstaller_hooks_contrib/hooks/__init__.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/__init__.py
@@ -12,6 +12,7 @@
 import os
 from . import stdhooks
 from . import rthooks
+
 _FILE_DIR = os.path.dirname(__file__)
 
 

--- a/src/_pyinstaller_hooks_contrib/hooks/pre_safe_import_module/hook-win32com.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/pre_safe_import_module/hook-win32com.py
@@ -8,7 +8,6 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-
 """
 PyWin32 package 'win32com' extends it's __path__ attribute with win32comext
 directory and thus PyInstaller is not able to find modules in it. For example
@@ -18,7 +17,6 @@ module 'win32com.shell' is in reality 'win32comext.shell'.
 ['win32com', 'C:\\Python27\\Lib\\site-packages\\win32comext']
 
 """
-
 
 import os
 

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks/__init__.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks/__init__.py
@@ -9,8 +9,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # ------------------------------------------------------------------
 import os
-DIR = os.path.dirname(__file__)
 
+DIR = os.path.dirname(__file__)
 """
 This sub-package includes runtime hooks for pyinstaller.
 """
@@ -22,5 +22,5 @@ def get_hook_dirs():
     for path, _, _ in os.walk(DIR):
         # Add the norm'd path to dirs
         dirs.append(os.path.normpath(path))
-    
+
     return dirs

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_nltk.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_nltk.py
@@ -9,7 +9,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-
 import sys
 import os
 import nltk

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_pygraphviz.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_pygraphviz.py
@@ -13,6 +13,7 @@ import pygraphviz
 
 # Override pygraphviz.AGraph._which method to search for graphviz executables inside sys._MEIPASS
 if hasattr(pygraphviz.AGraph, '_which'):
+
     def _pygraphviz_override_which(self, name):
         import os
         import sys

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_traitlets.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_traitlets.py
@@ -9,7 +9,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-
 # 'traitlets' uses module 'inspect' from default Python library to inspect
 # source code of modules. However, frozen app does not contain source code
 # of Python modules.
@@ -18,7 +17,9 @@
 
 import traitlets.traitlets
 
+
 def _disabled_deprecation_warnings(method, cls, method_name, msg):
     pass
+
 
 traitlets.traitlets._deprecated_method = _disabled_deprecation_warnings

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_usb.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_usb.py
@@ -9,7 +9,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-
 import ctypes
 import glob
 import os
@@ -17,20 +16,21 @@ import sys
 # Pyusb changed these libusb module names in commit 2082e7.
 try:
     import usb.backend.libusb10 as libusb10
-except:
+except ImportError:
     import usb.backend.libusb1 as libusb10
 try:
     import usb.backend.libusb01 as libusb01
-except:
-    import usb.backend.libusb0 as libusb01 
+except ImportError:
+    import usb.backend.libusb0 as libusb01
 import usb.backend.openusb as openusb
 
 
 def get_load_func(type, candidates):
+
     def _load_library(find_library=None):
         exec_path = sys._MEIPASS
 
-        l = None
+        library = None
         for candidate in candidates:
             # Do linker's path lookup work to force load bundled copy.
             if os.name == 'posix' and sys.platform == 'darwin':
@@ -44,22 +44,23 @@ def get_load_func(type, candidates):
                     # NOTE: libusb01 is using CDLL under win32.
                     # (see usb.backends.libusb01)
                     if sys.platform == 'win32' and type != 'libusb01':
-                        l = ctypes.WinDLL(libname)
+                        library = ctypes.WinDLL(libname)
                     else:
-                        l = ctypes.CDLL(libname)
-                    if l is not None:
+                        library = ctypes.CDLL(libname)
+                    if library is not None:
                         break
-                except:
-                    l = None
-            if l is not None:
+                except OSError:
+                    library = None
+            if library is not None:
                 break
         else:
             raise OSError('USB library could not be found')
 
         if type == 'libusb10':
-            if not hasattr(l, 'libusb_init'):
+            if not hasattr(library, 'libusb_init'):
                 raise OSError('USB library could not be found')
-        return l
+        return library
+
     return _load_library
 
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/__init__.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/__init__.py
@@ -10,8 +10,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 import os
-DIR = os.path.dirname(__file__)
 
+DIR = os.path.dirname(__file__)
 """
 All sub folders in this folder - "stdhooks" - are considered hook directories.
 
@@ -21,11 +21,11 @@ We recommend that it contains the copyright header, and nothing else.
 
 
 def get_hook_dirs():
-    
+
     dirs = []
     # For every directory and sub directory (including cwd)
     for path, _, _ in os.walk(DIR):
         # Add the norm'd path to dirs
         dirs.append(os.path.normpath(path))
-    
+
     return dirs

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-Crypto.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-Crypto.py
@@ -9,7 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
 """
 Hook for PyCryptodome library: https://pypi.python.org/pypi/pycryptodome
 
@@ -43,7 +42,7 @@ from PyInstaller.utils.hooks import get_module_file_attribute
 
 binaries = []
 binary_module_names = [
-    'Crypto.Math',      # First in the list
+    'Crypto.Math',  # First in the list
     'Crypto.Cipher',
     'Crypto.Util',
     'Crypto.Hash',

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-Cryptodome.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-Cryptodome.py
@@ -9,7 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
 """
 Hook for Cryptodome module: https://pypi.python.org/pypi/pycryptodomex
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-IPython.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-IPython.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # Tested with IPython 4.0.0.
 
 from PyInstaller.compat import is_win, is_darwin

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-OpenGL.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-OpenGL.py
@@ -9,15 +9,12 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 Hook for PyOpenGL 3.x versions from 3.0.0b6 up. Previous versions have a
 plugin system based on pkg_resources which is problematic to handle correctly
 under pyinstaller; 2.x versions used to run fine without hooks, so this one
 shouldn't hurt.
 """
-
 
 from PyInstaller.compat import is_win, is_darwin
 from PyInstaller.utils.hooks import collect_data_files, exec_statement
@@ -56,13 +53,11 @@ elif is_darwin:
 else:
     hiddenimports = ['OpenGL.platform.glx']
 
-
 # Arrays modules are needed too.
 hiddenimports += opengl_arrays_modules()
 
-
 # PyOpenGL 3.x uses ctypes to load DLL libraries. PyOpenGL windows installer
-# adds necessary dll files to 
+# adds necessary dll files to
 #   DLL_DIRECTORY = os.path.join( os.path.dirname( OpenGL.__file__ ), 'DLLS')
 # PyInstaller is not able to find these dlls. Just include them all as data
 # files.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-OpenGL_accelerate.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-OpenGL_accelerate.py
@@ -9,15 +9,12 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 OpenGL_accelerate contais modules written in cython. This module
 should speed up some functions from OpenGL module. The following
 hiddenimports are not resolved by PyInstaller because OpenGL_accelerate
 is compiled to native Python modules.
 """
-
 
 hiddenimports = [
     'OpenGL_accelerate.wrapper',

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-Xlib.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-Xlib.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 from PyInstaller.utils.hooks import collect_submodules
 
 hiddenimports = collect_submodules('Xlib')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-_mysql.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-_mysql.py
@@ -9,8 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 Hook for _mysql, required if higher-level pure python module is not imported
 """

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-accessible_output2.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-accessible_output2.py
@@ -9,7 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
 """
 accessible_output2: http://hg.q-continuum.net/accessible_output2
 """

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-adios.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-adios.py
@@ -9,11 +9,8 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 Hook for http://pypi.python.org/pypi/adios/
 """
-
 
 hiddenimports = ['adios._hl.selections']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-amazonproduct.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-amazonproduct.py
@@ -9,13 +9,10 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 Hook for Python bindings for Amazon's Product Advertising API.
 https://bitbucket.org/basti/python-amazon-product-api
 """
-
 
 hiddenimports = ['amazonproduct.processors.__init__',
                  'amazonproduct.processors._lxml',

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-anyio.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-anyio.py
@@ -9,7 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
 """
 AnyIO contains a number of back-ends as dynamically imported modules.
 This hook was tested against AnyIO v1.4.0.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-appdirs.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-appdirs.py
@@ -9,8 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 Import hook for appdirs.
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-apscheduler.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-apscheduler.py
@@ -9,7 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
 """
 APScheduler uses entry points to dynamically load executors, job
 stores and triggers.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-astroid.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-astroid.py
@@ -44,5 +44,5 @@ datas = collect_data_files('astroid', True, 'brain')
 # simplicity, include everything in astroid. Exclude all the test/ subpackage
 # contents and the test_util module.
 hiddenimports = ['six'] + collect_submodules('astroid',
-  lambda name: (not is_module_or_submodule(name, 'astroid.tests')) and
-               (not name == 'test_util'))
+                                             lambda name: (not is_module_or_submodule(name, 'astroid.tests')) and
+                                             (not name == 'test_util'))

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-av.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-av.py
@@ -16,7 +16,6 @@ from PyInstaller.utils.hooks import collect_submodules, is_module_satisfies, get
 
 hiddenimports = ['fractions'] + collect_submodules("av")
 
-
 # Starting with av 9.1.1, the DLLs shipped with Windows PyPI wheels are stored
 # in site-packages/av.libs instead of directly in the site-packages/av.
 if is_module_satisfies("av >= 9.1.1") and is_win:

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-avro.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-avro.py
@@ -16,7 +16,6 @@ Avro is a serialization and RPC framework.
 import os
 from PyInstaller.utils.hooks import get_module_file_attribute
 
-
 res_loc = os.path.dirname(get_module_file_attribute("avro"))
 # see https://github.com/apache/avro/blob/master/lang/py3/setup.py
 datas = [

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-bacon.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-bacon.py
@@ -24,8 +24,9 @@ def collect_native_files(package, files):
     pkg_base, pkg_dir = get_package_paths(package)
     return [(os.path.join(pkg_dir, file), '.') for file in files]
 
+
 if is_win:
-    files = ['Bacon.dll', 
+    files = ['Bacon.dll',
              'd3dcompiler_46.dll',
              'libEGL.dll',
              'libGLESv2.dll',

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-bcrypt.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-bcrypt.py
@@ -9,11 +9,8 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 Hook for https://pypi.org/project/bcrypt/
 """
-
 
 hiddenimports = ['_cffi_backend']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-blspy.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-blspy.py
@@ -16,7 +16,6 @@ import glob
 from PyInstaller.utils.hooks import get_module_file_attribute
 from PyInstaller.compat import is_win
 
-
 # blspy comes as a stand-alone extension module that's placed directly
 # in site-packages.
 #

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-bokeh.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-bokeh.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 from PyInstaller.utils.hooks import collect_data_files, copy_metadata, is_module_satisfies
 
 # core/_templates/*
@@ -19,10 +18,9 @@ from PyInstaller.utils.hooks import collect_data_files, copy_metadata, is_module
 # bokeh/_sri.json
 
 datas = collect_data_files('bokeh.core') + \
-        collect_data_files('bokeh.server') + \
-        collect_data_files('bokeh.command.subcommands', include_py_files=True) + \
-        collect_data_files('bokeh')
-
+    collect_data_files('bokeh.server') + \
+    collect_data_files('bokeh.command.subcommands', include_py_files=True) + \
+    collect_data_files('bokeh')
 
 # bokeh >= 3.0.0 sets its __version__ from metadata
 if is_module_satisfies('bokeh >= 3.0.0'):

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-clr.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-clr.py
@@ -10,13 +10,11 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # There is a name clash between pythonnet's clr module/extension (which this hooks is for) and clr package that provides
 # the terminal styling library (https://pypi.org/project/clr/). Therefore, we must first check if pythonnet is actually
 # available...
 from PyInstaller.utils.hooks import is_module_satisfies
 from PyInstaller.compat import is_win
-
 
 if is_module_satisfies("pythonnet"):
     # pythonnet requires both clr.pyd and Python.Runtime.dll, but the latter isn't found by PyInstaller.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-clr_loader.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-clr_loader.py
@@ -10,10 +10,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 from PyInstaller.compat import is_win, is_cygwin
 from PyInstaller.utils.hooks import collect_dynamic_libs
-
 
 # The clr-loader is used by pythonnet 3.x to load CLR (.NET) runtime.
 # On Windows, the default runtime is the .NET Framework, and its corresponding

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cryptography.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cryptography.py
@@ -9,8 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 Hook for cryptography module from the Python Cryptography Authority.
 """

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cv2.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cv2.py
@@ -43,7 +43,6 @@ hiddenimports += hookutils.collect_submodules('cv2', filter=lambda name: name !=
 # We also need to explicitly exclude `cv2.load_config_py2` due to it being imported in `cv2.__init__`.
 excludedimports = ['cv2.load_config_py2']
 
-
 # OpenCV loader from 4.5.4.60 requires extra config files and modules.
 # We need to collect `config.py`  and `load_config_py3`; to improve compatibility with PyInstaller < 5.2, where
 # `module_collection_mode` (see below) is not implemented.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cx_Oracle.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cx_Oracle.py
@@ -10,6 +10,4 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 hiddenimports = ['decimal']
-

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cytoolz.itertoolz.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cytoolz.itertoolz.py
@@ -13,4 +13,4 @@
 # Hook for the cytoolz package: https://pypi.python.org/pypi/cytoolz
 # Tested with cytoolz 0.9.0 and Python 3.5.2, on Ubuntu Linux x64
 
-hiddenimports = [ 'cytoolz.utils', 'cytoolz._signatures' ]
+hiddenimports = ['cytoolz.utils', 'cytoolz._signatures']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dask.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dask.py
@@ -8,7 +8,6 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-
 """
 Collects in-repo dask.yaml and dask-schema.yaml data files.
 """

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-discid.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-discid.py
@@ -15,7 +15,6 @@ import os
 from PyInstaller.utils.hooks import get_module_attribute, logger
 from PyInstaller.depend.utils import _resolveCtypesImports
 
-
 binaries = []
 
 # Use the _LIB_NAME attribute of discid.libdiscid to resolve the shared library name. This saves us from having to

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-distorm3.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-distorm3.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # Hook for the diStorm3 module: https://pypi.python.org/pypi/distorm3
 # Tested with distorm3 3.3.0, Python 2.7, Windows
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dns.rdata.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dns.rdata.py
@@ -10,8 +10,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # This is hook for DNS python package dnspython.
 
 from PyInstaller.utils.hooks import collect_submodules
+
 hiddenimports = collect_submodules('dns.rdtypes')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-docutils.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-docutils.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 from PyInstaller.utils.hooks import collect_submodules, collect_data_files
 
 hiddenimports = (collect_submodules('docutils.languages') +

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-docx.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-docx.py
@@ -10,8 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 from PyInstaller.utils.hooks import collect_data_files
-
 
 datas = collect_data_files("docx")

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-docx2pdf.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-docx2pdf.py
@@ -10,11 +10,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later.
 # ------------------------------------------------------------------
 
-
 # Hook for docx2pdf: https://pypi.org/project/docx2pdf/
 
 from PyInstaller.utils.hooks import copy_metadata, collect_data_files
-
 
 datas = copy_metadata('docx2pdf')
 datas += collect_data_files('docx2pdf')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-enchant.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-enchant.py
@@ -9,8 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 Import hook for PyEnchant.
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-enzyme.parsers.ebml.core.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-enzyme.parsers.ebml.core.py
@@ -9,7 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
 """
 enzyme:
 https://github.com/Diaoul/enzyme

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-fmpy.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-fmpy.py
@@ -9,8 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 Hook for FMPy, a library to simulate Functional Mockup Units (FMUs)
 https://github.com/CATIA-Systems/FMPy

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gadfly.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gadfly.py
@@ -10,5 +10,4 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 hiddenimports = ["sql_mar"]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gcloud.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gcloud.py
@@ -10,6 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 from PyInstaller.utils.hooks import copy_metadata
+
 datas = copy_metadata('gcloud')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-geopandas.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-geopandas.py
@@ -10,8 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 from PyInstaller.utils.hooks import collect_data_files
-
 
 datas = collect_data_files("geopandas", subdir="datasets")

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gooey.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gooey.py
@@ -9,7 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
 """
 Gooey GUI carries some language and images for it's UI to function.
 """

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-google.api.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-google.api.py
@@ -11,4 +11,5 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import copy_metadata
+
 datas = copy_metadata('google-api-core')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-google.api_core.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-google.api_core.py
@@ -11,4 +11,5 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import copy_metadata
+
 datas = copy_metadata('google-api-core')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-google.cloud.kms_v1.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-google.cloud.kms_v1.py
@@ -15,4 +15,5 @@
 # https://cloud.google.com/kms/docs/reference/libraries#client-libraries-install-python
 
 from PyInstaller.utils.hooks import copy_metadata
+
 datas = copy_metadata('google-cloud-kms')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-google.cloud.pubsub_v1.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-google.cloud.pubsub_v1.py
@@ -11,4 +11,5 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import copy_metadata
+
 datas = copy_metadata('google-cloud-pubsub')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-google.cloud.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-google.cloud.py
@@ -11,4 +11,5 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import copy_metadata
+
 datas = copy_metadata('google-cloud-core')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-google.cloud.speech.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-google.cloud.speech.py
@@ -11,4 +11,5 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import copy_metadata
+
 datas = copy_metadata('google-cloud-speech')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-google.cloud.storage.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-google.cloud.storage.py
@@ -11,4 +11,5 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import copy_metadata
+
 datas = copy_metadata('google-cloud-storage')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-google.cloud.translate.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-google.cloud.translate.py
@@ -11,4 +11,5 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import copy_metadata
+
 datas = copy_metadata('google-cloud-translate')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-grpc.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-grpc.py
@@ -11,4 +11,5 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import collect_data_files
+
 datas = collect_data_files('grpc')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gst._gst.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gst._gst.py
@@ -10,17 +10,14 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # GStreamer contains a lot of plugins. We need to collect them and bundle
 # them wih the exe file.
 # We also need to resolve binary dependencies of these GStreamer plugins.
-
 
 import glob
 import os
 from PyInstaller.compat import is_win
 from PyInstaller.utils.hooks import exec_statement
-
 
 hiddenimports = ['gmodule', 'gobject']
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gtk.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gtk.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 hiddenimports = ['gtkglext', 'gdkgl', 'gdkglext', 'gdk', 'gtk.gdk', 'gtk.gtkgl',
                  'gtk.gtkgl._gtkgl', 'gtkgl', 'pangocairo', 'pango', 'atk',
                  'gobject', 'gtk.glade', 'cairo', 'gio',

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-h5py.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-h5py.py
@@ -9,11 +9,8 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 Hook for http://pypi.python.org/pypi/h5py/
 """
-
 
 hiddenimports = ['h5py._proxy', 'h5py.utils', 'h5py.defs', 'h5py.h5ac']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-humanize.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-humanize.py
@@ -9,7 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
 """
 This modest package contains various common humanization utilities, like turning a number into a fuzzy human
 readable duration ("3 minutes ago") or into a human readable size or throughput.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-ijson.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-ijson.py
@@ -11,4 +11,5 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import collect_submodules
+
 hiddenimports = collect_submodules("ijson.backends")

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-jinja2.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-jinja2.py
@@ -10,5 +10,4 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 hiddenimports = ['jinja2.ext']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-jira.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-jira.py
@@ -9,7 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
 """
 Hook for https://pypi.python.org/pypi/jira/
 """

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-jsonrpcserver.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-jsonrpcserver.py
@@ -14,4 +14,5 @@
 # jsonrpcserver package
 
 from PyInstaller.utils.hooks import collect_data_files
+
 datas = collect_data_files('jsonrpcserver')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-jsonschema.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-jsonschema.py
@@ -14,5 +14,6 @@
 # with jsonschema module
 
 from PyInstaller.utils.hooks import collect_data_files, copy_metadata
+
 datas = collect_data_files('jsonschema')
 datas += copy_metadata('jsonschema')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-kinterbasdb.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-kinterbasdb.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # kinterbasdb
 hiddenimports = ['k_exceptions', 'services', 'typeconv_naked',
                  'typeconv_backcompat', 'typeconv_23plus',

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-libaudioverse.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-libaudioverse.py
@@ -9,7 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
 """
 Libaudioverse: https://github.com/libaudioverse/libaudioverse
 """

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-lightgbm.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-lightgbm.py
@@ -10,8 +10,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 #
-# A fast, distributed, high performance gradient boosting 
-# (GBT, GBDT, GBRT, GBM or MART) framework based on decision 
+# A fast, distributed, high performance gradient boosting
+# (GBT, GBDT, GBRT, GBM or MART) framework based on decision
 # tree algorithms, used for ranking, classification and
 # many other machine learning tasks.
 #

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-lxml.etree.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-lxml.etree.py
@@ -10,5 +10,4 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 hiddenimports = ['lxml._elementpath', 'gzip', 'contextlib']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-lxml.objectify.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-lxml.objectify.py
@@ -10,5 +10,4 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 hiddenimports = ['lxml.etree']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-lz4.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-lz4.py
@@ -12,4 +12,5 @@
 # hook for https://github.com/python-lz4/python-lz4
 
 from PyInstaller.utils.hooks import copy_metadata
+
 datas = copy_metadata('lz4')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-mako.codegen.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-mako.codegen.py
@@ -9,12 +9,9 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 codegen generates Python code that is then executed through exec().
 This Python code imports the following modules.
 """
-
 
 hiddenimports = ['mako.cache', 'mako.runtime', 'mako.filters']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-mariadb.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-mariadb.py
@@ -19,7 +19,6 @@ from PyInstaller.utils.hooks import is_module_satisfies, collect_submodules
 # collected as a hidden import.
 hiddenimports = ['decimal']
 
-
 # mariadb >= 1.1.0 requires several hidden imports from mariadb.constants.
 # Collect them all, just to be on the safe side...
 if is_module_satisfies("mariadb >= 1.1.0"):

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-mpl_toolkits.basemap.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-mpl_toolkits.basemap.py
@@ -10,12 +10,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 from PyInstaller.utils.hooks import collect_data_files
 from PyInstaller.compat import is_win, base_prefix
 
-import os, sys
-
+import os
 
 # mpl_toolkits.basemap (tested with v.1.0.7) is shipped with auxiliary data,
 # usually stored in mpl_toolkits\basemap\data and used to plot maps
@@ -23,7 +21,7 @@ datas = collect_data_files('mpl_toolkits.basemap', subdir='data')
 
 # check if the data has been effectively found
 if len(datas) == 0:
-    
+
     # - conda-specific
 
     if is_win:

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-msoffcrypto.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-msoffcrypto.py
@@ -8,7 +8,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # ------------------------------------------------------------------
-
 """
 msoffcrypto contains hidden metadata as of v4.12.0
 """

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-nacl.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-nacl.py
@@ -10,16 +10,13 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # Tested with PyNaCl 0.3.0 on Mac OS X.
-
 
 import os.path
 import glob
 
 from PyInstaller.compat import EXTENSION_SUFFIXES
 from PyInstaller.utils.hooks import collect_data_files, get_module_file_attribute
-
 
 datas = collect_data_files('nacl')
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-ncclient.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-ncclient.py
@@ -9,8 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 Hook for ncclient. ncclient is a Python library that facilitates client-side
 scripting and application development around the NETCONF protocol.
@@ -23,5 +21,3 @@ from PyInstaller.utils.hooks import collect_submodules
 # Modules 'ncclient.devices.*' are dynamically loaded and PyInstaller
 # is not able to find them.
 hiddenimports = collect_submodules('ncclient.devices')
-
-

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-nltk.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-nltk.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # hook for nltk
 import nltk
 import os

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-nnpy.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-nnpy.py
@@ -9,11 +9,8 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 Hook for https://pypi.org/project/nnpy/
 """
-
 
 hiddenimports = ['_cffi_backend']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-office365.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-office365.py
@@ -8,7 +8,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # ------------------------------------------------------------------
-
 """
 Office365-REST-Python-Client contains xml templates that are needed by some methods
 This hook ensures that all of the data used by the package is bundled

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-osgeo.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-osgeo.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 from PyInstaller.utils.hooks import collect_data_files
 from PyInstaller.compat import is_win, is_darwin
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-parsedatetime.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-parsedatetime.py
@@ -8,7 +8,6 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-
 """
 Fixes https://github.com/pyinstaller/pyinstaller/issues/4995
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-paste.exceptions.reporter.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-paste.exceptions.reporter.py
@@ -9,12 +9,9 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
-Some modules use the old-style import: explicitly include 
+Some modules use the old-style import: explicitly include
 the new module when the old one is referenced.
 """
-
 
 hiddenimports = ["email.mime.text", "email.mime.multipart"]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pendulum.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pendulum.py
@@ -12,7 +12,6 @@
 
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
-
 # Pendulum checks for locale modules via os.path.exists before import.
 # If the include_py_files option is turned off, this check fails, pendulum
 # will raise a ValueError.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pingouin.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pingouin.py
@@ -11,4 +11,5 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import collect_data_files
+
 datas = collect_data_files('pingouin')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pint.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pint.py
@@ -10,9 +10,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 from PyInstaller.utils.hooks import collect_data_files, copy_metadata
-
 
 datas = collect_data_files('pint')
 datas += copy_metadata('pint')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-prettytable.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-prettytable.py
@@ -11,4 +11,5 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import copy_metadata
+
 datas = copy_metadata('prettytable')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-psychopy.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-psychopy.py
@@ -13,4 +13,5 @@
 # Tested on Windows 7 64bit with python 2.7.6 and PsychoPy 1.81.03
 
 from PyInstaller.utils.hooks import collect_data_files
+
 datas = collect_data_files('psychopy')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-psycopg2.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-psycopg2.py
@@ -10,5 +10,4 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 hiddenimports = ['mx.DateTime']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel-io.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel-io.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # This hook was tested with pyexcel-io 0.5.18:
 # https://github.com/pyexcel/pyexcel-io
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel-ods.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel-ods.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # This hook was tested with pyexcel-ods 0.5.6:
 # https://github.com/pyexcel/pyexcel-ods
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel-ods3.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel-ods3.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # This hook was tested with pyexcel-ods3 0.5.3:
 # https://github.com/pyexcel/pyexcel-ods3
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel-odsr.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel-odsr.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # This hook was tested with pyexcel-io 0.5.2:
 # https://github.com/pyexcel/pyexcel-io
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel-xls.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel-xls.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # This hook was tested with pyexcel-xls 0.5.8:
 # https://github.com/pyexcel/pyexcel-xls
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel-xlsx.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel-xlsx.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # This hook was tested with pyexcel-xlsx 0.4.2:
 # https://github.com/pyexcel/pyexcel-xlsx
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel-xlsxw.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel-xlsxw.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # This hook was tested with pyexcel-xlsxw 0.4.2:
 # https://github.com/pyexcel/pyexcel-xlsxw
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # This hook was tested with pyexcel 0.5.13:
 # https://github.com/pyexcel/pyexcel
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel_io.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel_io.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # This hook was tested with pyexcel-io 0.5.18:
 # https://github.com/pyexcel/pyexcel-io
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel_ods.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel_ods.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # This hook was tested with pyexcel-ods 0.5.6:
 # https://github.com/pyexcel/pyexcel-ods
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel_ods3.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel_ods3.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # This hook was tested with pyexcel-ods3 0.5.3:
 # https://github.com/pyexcel/pyexcel-ods3
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel_odsr.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel_odsr.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # This hook was tested with pyexcel-io 0.5.2:
 # https://github.com/pyexcel/pyexcel-io
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel_xls.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel_xls.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # This hook was tested with pyexcel-xls 0.5.8:
 # https://github.com/pyexcel/pyexcel-xls
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel_xlsx.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel_xlsx.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # This hook was tested with pyexcel-xlsx 0.4.2:
 # https://github.com/pyexcel/pyexcel-xlsx
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel_xlsxw.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcel_xlsxw.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # This hook was tested with pyexcel-xlsxw 0.4.2:
 # https://github.com/pyexcel/pyexcel-xlsxw
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcelerate.Writer.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyexcelerate.Writer.py
@@ -11,4 +11,5 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import collect_data_files
+
 datas = collect_data_files('pyexcelerate')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pylibmagic.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pylibmagic.py
@@ -9,7 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
 """
 Pylibmagic contains data files (libmagic compiled and configurations) required to use the python-magic package.
 """

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pylint.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pylint.py
@@ -55,10 +55,10 @@ from PyInstaller.utils.hooks import collect_data_files, collect_submodules, is_m
     get_module_file_attribute
 
 datas = (
-         [(get_module_file_attribute('pylint.__init__'), 'pylint')] +
-         collect_data_files('pylint.checkers', True) +
-         collect_data_files('pylint.reporters', True)
-         )
+    [(get_module_file_attribute('pylint.__init__'), 'pylint')] +
+    collect_data_files('pylint.checkers', True) +
+    collect_data_files('pylint.reporters', True)
+)
 
 
 # Add imports from dynamically loaded modules, excluding pylint.test

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pymediainfo.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pymediainfo.py
@@ -18,6 +18,7 @@ binaries = collect_dynamic_libs("pymediainfo")
 
 # On linux, no wheels are available, and pymediainfo uses system shared library.
 if not binaries and not (is_win or is_darwin):
+
     def _find_system_mediainfo_library():
         import os
         import ctypes.util

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pynput.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pynput.py
@@ -11,4 +11,5 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import collect_submodules
+
 hiddenimports = collect_submodules("pynput")

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyodbc.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyodbc.py
@@ -10,9 +10,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 from PyInstaller.utils.hooks import get_pyextension_imports
-
 
 # It's hard to detect imports of binary Python module without importing it.
 # Let's try importing that module in a subprocess.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyopencl.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyopencl.py
@@ -13,5 +13,6 @@
 # Hook for the pyopencl module: https://github.com/pyopencl/pyopencl
 
 from PyInstaller.utils.hooks import copy_metadata, collect_data_files
+
 datas = copy_metadata('pyopencl')
 datas += collect_data_files('pyopencl')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyproj.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyproj.py
@@ -13,8 +13,7 @@
 import os
 import sys
 from PyInstaller.utils.hooks import collect_data_files, is_module_satisfies, copy_metadata
-from PyInstaller.compat import is_win
-
+from PyInstaller.compat import is_win, is_conda
 
 hiddenimports = [
     "pyproj.datadir"
@@ -48,7 +47,6 @@ else:  # both linux and darwin
     tgt_proj_data = os.path.join('share', 'proj')
     src_proj_data = os.path.join(root_path, 'share', 'proj')
 
-from PyInstaller.compat import is_conda
 if is_conda:
     if os.path.exists(src_proj_data):
         datas.append((src_proj_data, tgt_proj_data))

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pypylon.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pypylon.py
@@ -19,7 +19,6 @@
 # As the module is already relocatable, we circumvent this issue by bundling
 # pypylon as-is - for pyinstaller we treat the shared library files as just data.
 
-
 import os
 
 from PyInstaller.utils.hooks import collect_data_files

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyshark.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyshark.py
@@ -13,7 +13,6 @@
 # Python wrapper for pyshark(https://pypi.org/project/pyshark/)
 # Tested with version 0.4.5
 
-
 from PyInstaller.utils.hooks import collect_data_files, is_module_satisfies
 
 hiddenimports = ['pyshark.config']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pytest.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pytest.py
@@ -9,11 +9,10 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 Hook for http://pypi.python.org/pypi/pytest/
 """
 
 import pytest
+
 hiddenimports = pytest.freeze_includes()

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyttsx.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyttsx.py
@@ -9,13 +9,10 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 pyttsx imports drivers module based on specific platform.
 Found at http://mrmekon.tumblr.com/post/5272210442/pyinstaller-and-pyttsx
 """
-
 
 hiddenimports = [
     'drivers',

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-raven.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-raven.py
@@ -10,5 +10,4 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 hiddenimports = ['raven.events', 'raven.processors']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-rdflib.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-rdflib.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 from PyInstaller.utils.hooks import collect_submodules
 
 hiddenimports = collect_submodules('rdflib.plugins')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-redmine.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-redmine.py
@@ -10,5 +10,4 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 hiddenimports = ['redmine.resources']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-regex.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-regex.py
@@ -10,5 +10,4 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 hiddenimports = ['warnings']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-reportlab.lib.utils.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-reportlab.lib.utils.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # Needed for ReportLab 3
 hiddenimports = [
     'reportlab.rl_settings',

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-reportlab.pdfbase._fontdata.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-reportlab.pdfbase._fontdata.py
@@ -15,4 +15,4 @@ from PyInstaller.utils.hooks import collect_submodules
 # Tested on Windows 7 x64 with Python 2.7.6 x32 using ReportLab 3.0
 # This has been observed to *not* work on ReportLab 2.7
 hiddenimports = collect_submodules('reportlab.pdfbase',
-                  lambda name: name.startswith('reportlab.pdfbase._fontdata_'))
+                                   lambda name: name.startswith('reportlab.pdfbase._fontdata_'))

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-rpy2.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-rpy2.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 hiddenimports = [
     "rpy2",
     "rpy2.robjects",

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-selenium.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-selenium.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 from PyInstaller.utils.hooks import collect_data_files
 
 datas = collect_data_files('selenium')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-shapely.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-shapely.py
@@ -25,7 +25,6 @@ if is_module_satisfies('shapely >= 2.0.0'):
     # extensions were introduced in v2.0.0.
     hiddenimports += ['shapely._geos']
 
-
 pkg_base, pkg_dir = get_package_paths('shapely')
 
 binaries = []
@@ -73,9 +72,9 @@ if compat.is_win:
 
     if not geos_c_dll_found:
         raise SystemExit(
-                "Error: geos_c.dll not found, required by hook-shapely.py.\n"
-                "Please check your installation or provide a pull request to "
-                "PyInstaller to update hook-shapely.py.")
+            "Error: geos_c.dll not found, required by hook-shapely.py.\n"
+            "Please check your installation or provide a pull request to "
+            "PyInstaller to update hook-shapely.py.")
 elif compat.is_linux and is_module_satisfies('shapely < 1.7'):
     # This duplicates the libgeos*.so* files in the build.  PyInstaller will
     # copy them into the root of the build by default, but shapely cannot load

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.io.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.io.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # This hook was tested with scikit-image (skimage) 0.14.1:
 # https://scikit-image.org
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sklearn.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sklearn.py
@@ -13,4 +13,5 @@
 # Tested on Windows 10 64bit with python 3.7.1
 
 from PyInstaller.utils.hooks import collect_data_files
+
 datas = collect_data_files('sklearn')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sound_lib.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sound_lib.py
@@ -9,7 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
 """
 sound_lib: http://hg.q-continuum.net/sound_lib
 """

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sounddevice.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sounddevice.py
@@ -9,7 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
 """
 sounddevice:
 https://github.com/spatialaudio/python-sounddevice/

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-soundfile.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-soundfile.py
@@ -9,7 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
 """
 pysoundfile:
 https://github.com/bastibe/SoundFile

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-spacy.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-spacy.py
@@ -8,7 +8,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # ------------------------------------------------------------------
-
 """
 Spacy contains hidden imports and data files which are needed to import it
 """

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-srsly.msgpack._packer.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-srsly.msgpack._packer.py
@@ -8,7 +8,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # ------------------------------------------------------------------
-
 """
 srsly.msgpack._packer contains hidden imports which are needed to import it
 This hook was created to make spacy work correctly.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-statsmodels.tsa.statespace.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-statsmodels.tsa.statespace.py
@@ -13,4 +13,4 @@
 from PyInstaller.utils.hooks import collect_submodules
 
 hiddenimports = collect_submodules('statsmodels.tsa.statespace._filters') \
-              + collect_submodules('statsmodels.tsa.statespace._smoothers')
+    + collect_submodules('statsmodels.tsa.statespace._smoothers')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-stdnum.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-stdnum.py
@@ -12,4 +12,5 @@
 
 # Collect data files that are required by some of the stdnum's sub-modules
 from PyInstaller.utils.hooks import collect_data_files
+
 datas = collect_data_files("stdnum")

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-storm.database.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-storm.database.py
@@ -9,15 +9,12 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 Hook for storm ORM.
 """
-
 
 hiddenimports = [
     'storm.databases.sqlite',
     'storm.databases.postgres',
     'storm.databases.mysql'
-    ]
+]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sympy.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sympy.py
@@ -12,7 +12,6 @@
 
 from PyInstaller.utils.hooks import logger, is_module_satisfies
 
-
 # With sympy 1.12, PyInstaller's modulegraph analysis hits the recursion limit.
 # So, unless the user has already done so, increase it automatically.
 if is_module_satisfies('sympy >= 1.12'):

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tables.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tables.py
@@ -10,6 +10,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # PyTables is a package for managing hierarchical datasets
 hiddenimports = ["tables._comp_lzo", "tables._comp_bzip2"]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tensorflow.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tensorflow.py
@@ -18,7 +18,6 @@ tf_post_1_15_0 = is_module_satisfies("tensorflow >= 1.15.0")
 tf_pre_2_0_0 = is_module_satisfies("tensorflow < 2.0.0")
 tf_pre_2_2_0 = is_module_satisfies("tensorflow < 2.2.0")
 
-
 # Exclude from data collection:
 #  - development headers in include subdirectory
 #  - XLA AOT runtime sources

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-text_unidecode.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-text_unidecode.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 # -----------------------------------------------------------------------------
-
 """
 text-unidecode:
 https://github.com/kmike/text-unidecode/
@@ -18,7 +17,6 @@ https://github.com/kmike/text-unidecode/
 
 import os
 from PyInstaller.utils.hooks import get_package_paths
-
 
 package_path = get_package_paths("text_unidecode")
 data_bin_path = os.path.join(package_path[1], "data.bin")

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-thinc.backends.numpy_ops.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-thinc.backends.numpy_ops.py
@@ -8,7 +8,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # ------------------------------------------------------------------
-
 """
 thinc.banckends.numpy_ops contains hidden imports which are needed to import it
 This hook was created to make spacy work correctly.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-thinc.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-thinc.py
@@ -8,7 +8,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # ------------------------------------------------------------------
-
 """
 Thinc contains data files and hidden imports. This hook was created to make spacy work correctly.
 """

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tinycss2.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tinycss2.py
@@ -9,8 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 Hook for tinycss2. tinycss2 is a low-level CSS parser and generator.
 https://github.com/Kozea/tinycss2

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-torch.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-torch.py
@@ -12,7 +12,7 @@
 
 from PyInstaller.utils.hooks import logger, get_package_paths, is_module_satisfies
 
-datas = [(get_package_paths('torch')[1],"torch"),]
+datas = [(get_package_paths('torch')[1], "torch")]
 
 # With torch 2.0.0, PyInstaller's modulegraph analysis hits the recursion limit.
 # So, unless the user has already done so, increase it automatically.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-ttkthemes.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-ttkthemes.py
@@ -53,5 +53,4 @@ Windows 7 (Python 3.7, minimal system-wide installation).
 """
 from PyInstaller.utils.hooks import collect_data_files
 
-
 datas = collect_data_files("ttkthemes")

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-ttkwidgets.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-ttkwidgets.py
@@ -33,7 +33,6 @@ Windows 7 (Python 3.5.4 system-wide).
 >>> window.mainloop()
 """
 
-
 from PyInstaller.utils.hooks import collect_data_files
 
 datas = collect_data_files("ttkwidgets")

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-u1db.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-u1db.py
@@ -9,7 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
 """
 Pyinstaller hook for u1db module
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-umap.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-umap.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 from PyInstaller.utils.hooks import copy_metadata
 
 datas = copy_metadata('umap-learn')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-unidecode.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-unidecode.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # Hook for the unidecode package: https://pypi.python.org/pypi/unidecode
 # Tested with Unidecode 0.4.21 and Python 3.6.2, on Windows 10 x64.
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-uniseg.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-uniseg.py
@@ -13,4 +13,5 @@
 # Hook for the uniseg module: https://pypi.python.org/pypi/uniseg
 
 from PyInstaller.utils.hooks import collect_data_files
+
 datas = collect_data_files('uniseg')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-usb.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-usb.py
@@ -17,7 +17,6 @@ from PyInstaller.depend.utils import _resolveCtypesImports
 from PyInstaller.compat import is_cygwin, getenv
 from PyInstaller.utils.hooks import logger
 
-
 # Include glob for library lookup in run-time hook.
 hiddenimports = ['glob']
 
@@ -26,12 +25,10 @@ hiddenimports = ['glob']
 
 binaries = []
 
-
 # Running usb.core.find() in this script crashes Ubuntu 14.04LTS,
 # let users circumvent pyusb discovery with an environment variable.
 skip_pyusb_discovery = \
     bool(getenv('PYINSTALLER_USB_HOOK_SKIP_PYUSB_DISCOVERY'))
-
 
 # Try to use pyusb's library locator.
 if not skip_pyusb_discovery:
@@ -56,7 +53,6 @@ if not skip_pyusb_discovery:
     except (ValueError, usb.core.USBError) as exc:
         logger.warning("%s", exc)
 
-
 # If pyusb didn't find a backend, manually search for usb libraries.
 if not binaries:
     # NOTE: Update these lists when adding further libs.
@@ -65,9 +61,12 @@ if not binaries:
     else:
         libusb_candidates = [
             # libusb10
-            'usb-1.0', 'usb', 'libusb-1.0',
+            'usb-1.0',
+            'usb',
+            'libusb-1.0',
             # libusb01
-            'usb-0.1', 'libusb0',
+            'usb-0.1',
+            'libusb0',
             # openusb
             'openusb',
         ]
@@ -79,7 +78,6 @@ if not binaries:
             backend_library_basenames.append(os.path.basename(libname))
     if backend_library_basenames:
         binaries = _resolveCtypesImports(backend_library_basenames)
-
 
 # Validate and normalize the first found usb library.
 if binaries:

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-vtkpython.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-vtkpython.py
@@ -10,9 +10,16 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 import os
 if os.name == 'posix':
-    hiddenimports = ['libvtkCommonPython','libvtkFilteringPython','libvtkIOPython','libvtkImagingPython','libvtkGraphicsPython','libvtkRenderingPython','libvtkHybridPython','libvtkParallelPython','libvtkPatentedPython']
+    hiddenimports = [
+        'libvtkCommonPython', 'libvtkFilteringPython', 'libvtkIOPython',
+        'libvtkImagingPython', 'libvtkGraphicsPython', 'libvtkRenderingPython',
+        'libvtkHybridPython', 'libvtkParallelPython', 'libvtkPatentedPython'
+    ]
 else:
-    hiddenimports = ['vtkCommonPython','vtkFilteringPython','vtkIOPython','vtkImagingPython','vtkGraphicsPython','vtkRenderingPython','vtkHybridPython','vtkParallelPython','vtkPatentedPython']
+    hiddenimports = [
+        'vtkCommonPython', 'vtkFilteringPython', 'vtkIOPython',
+        'vtkImagingPython', 'vtkGraphicsPython', 'vtkRenderingPython',
+        'vtkHybridPython', 'vtkParallelPython', 'vtkPatentedPython'
+    ]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-wavefile.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-wavefile.py
@@ -9,7 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
 """
 python-wavefile: https://github.com/vokimon/python-wavefile
 """

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-win32com.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-win32com.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 hiddenimports = [
     # win32com client and server util
     # modules could be hidden imports

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-workflow.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-workflow.py
@@ -11,4 +11,5 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import copy_metadata
+
 datas = copy_metadata('workflow')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-wx.lib.activex.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-wx.lib.activex.py
@@ -10,8 +10,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 from PyInstaller.utils.hooks import exec_statement
 
 # This needed because comtypes wx.lib.activex generates some stuff.
-exec_statement("import wx.lib.activex") 
+exec_statement("import wx.lib.activex")

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-wx.lib.pubsub.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-wx.lib.pubsub.py
@@ -25,4 +25,3 @@
 from PyInstaller.utils.hooks import collect_data_files
 
 datas = collect_data_files('wx.lib.pubsub', include_py_files=True, excludes=['*.txt', '**/__pycache__'])
-

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-xml.dom.html.HTMLDocument.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-xml.dom.html.HTMLDocument.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # xml.dom.html.HTMLDocument
 hiddenimports = ['xml.dom.html.HTMLAnchorElement',
                  'xml.dom.html.HTMLAppletElement',
@@ -65,4 +64,4 @@ hiddenimports = ['xml.dom.html.HTMLAnchorElement',
                  'xml.dom.html.HTMLTextAreaElement',
                  'xml.dom.html.HTMLTitleElement',
                  'xml.dom.html.HTMLUListElement',
-        ]
+                 ]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-xml.sax.saxexts.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-xml.sax.saxexts.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 # xml.sax.saxexts
 hiddenimports = ["xml.sax.drivers2.drv_pyexpat",
                  "xml.sax.drivers.drv_xmltok",
@@ -23,4 +22,4 @@ hiddenimports = ["xml.sax.drivers2.drv_pyexpat",
                  'xml.sax.drivers.drv_htmllib',
                  'xml.sax.drivers.drv_sgmlop',
                  "xml.sax.drivers.drv_sgmllib",
-            ]
+                 ]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-xmldiff.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-xmldiff.py
@@ -12,4 +12,5 @@
 # Hook for https://github.com/Shoobx/xmldiff
 
 from PyInstaller.utils.hooks import copy_metadata
+
 datas = copy_metadata('xmldiff')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-xsge_gui.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-xsge_gui.py
@@ -13,5 +13,5 @@
 # Hook for the xsge_gui module: https://pypi.python.org/pypi/xsge_gui
 
 from PyInstaller.utils.hooks import collect_data_files
-datas = collect_data_files('xsge_gui')
 
+datas = collect_data_files('xsge_gui')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-xyzservices.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-xyzservices.py
@@ -11,4 +11,5 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import collect_data_files
+
 datas = collect_data_files('xyzservices')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-zeep.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-zeep.py
@@ -14,4 +14,5 @@
 # Tested with zeep 0.13.0, Python 2.7, Windows
 
 from PyInstaller.utils.hooks import copy_metadata
+
 datas = copy_metadata('zeep')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-zmq.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-zmq.py
@@ -9,8 +9,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-
-
 """
 Hook for PyZMQ. Cython based Python bindings for messaging library ZeroMQ.
 http://www.zeromq.org/

--- a/src/_pyinstaller_hooks_contrib/tests/__init__.py
+++ b/src/_pyinstaller_hooks_contrib/tests/__init__.py
@@ -10,19 +10,19 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 import os
-DIR = os.path.dirname(__file__)
 
+DIR = os.path.dirname(__file__)
 """
 This directory and every sub directory contains tests
 """
 
 
 def get_test_dirs():
-    
+
     dirs = []
     # For every directory and sub directory (including cwd)
     for path, _, _ in os.walk(DIR):
         # Add the norm'd path to dirs
         dirs.append(os.path.normpath(path))
-    
+
     return dirs

--- a/src/_pyinstaller_hooks_contrib/tests/conftest.py
+++ b/src/_pyinstaller_hooks_contrib/tests/conftest.py
@@ -10,4 +10,4 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 # Import all fixtures from PyInstaller into the tests.
-from PyInstaller.utils.conftest import *
+from PyInstaller.utils.conftest import *  # noqa: F401,F403

--- a/src/_pyinstaller_hooks_contrib/tests/scripts/pyi_lib_tensorflow_mnist.py
+++ b/src/_pyinstaller_hooks_contrib/tests/scripts/pyi_lib_tensorflow_mnist.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-
 import os
 
 # Force CPU
@@ -44,7 +43,7 @@ model.compile(optimizer='adam', loss=loss_fn, metrics=['accuracy'])
 model.fit(x_train, y_train, epochs=1, verbose=1)
 
 # Evaluate
-results = model.evaluate(x_test,  y_test, verbose=1)
+results = model.evaluate(x_test, y_test, verbose=1)
 
 # Expected accuracy after a single epoch is around 95%, so use 90%
 # as a passing bar

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -572,6 +572,7 @@ def test_pydantic(pyi_builder):
 
 
 def torch_onedir_only(test):
+
     def wrapped(pyi_builder):
         if pyi_builder._mode != 'onedir':
             pytest.skip('PyTorch tests support only onedir mode '
@@ -851,7 +852,7 @@ def test_pythonnet2(pyi_builder):
 
 @requires('pythonnet >= 3.dev')
 def test_pythonnet3(pyi_builder):
-    pyi_builder.test_source(f"""
+    pyi_builder.test_source("""
         from clr_loader import get_coreclr
         from pythonnet import set_runtime
         set_runtime(get_coreclr())  # Pick up and use any installed .NET runtime.


### PR DESCRIPTION
This forces us to address all the legacy flake8 issues from parts of the codebase that were written before adopting flake8.

I've ran CI on the two hooks that weren't purely whitespace changes: https://github.com/bwoodsend/pyinstaller-hooks-contrib/actions/runs/5383903946