### PR TITLE
hooks: update pydantic hook for compatibility with pydantic v2.0.0

### DIFF
--- a/news/611.update.rst
+++ b/news/611.update.rst
@@ -1,0 +1,1 @@
+Update ``pydantic`` hook for compatibility with ``pydantic`` v2.0.0.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -133,6 +133,7 @@ librosa==0.10.0.post2
 sympy==1.12
 xyzservices==2023.5.0
 mistune==3.0.1
+pydantic==2.0.0
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
@@ -13,13 +13,16 @@
 from PyInstaller.utils.hooks import get_module_attribute, collect_submodules
 from PyInstaller.utils.hooks import is_module_satisfies
 
-# By default, pydantic from PyPi comes with all modules compiled as
-# cpython extensions, which seems to prevent pyinstaller from automatically
-# picking up the submodules.
-# NOTE: in PyInstaller 4.x and earlier, get_module_attribute() returns the
-# string representation of the value ('True'), while in PyInstaller 5.x
-# and later, the actual value is returned (True).
-is_compiled = get_module_attribute('pydantic', 'compiled') in {'True', True}
+# By default, PyPi wheels for pydantic < 2.0.0 come with all modules compiled as cython extensions, which prevents
+# PyInstaller from automatically picking up the submodules.
+if is_module_satisfies('pydantic >= 2.0.0'):
+    # The `pydantic.compiled` attribute was removed in v2.
+    is_compiled = False
+else:
+    # NOTE: in PyInstaller 4.x and earlier, get_module_attribute() returns the string representation of the value
+    # ('True'), while in PyInstaller 5.x and later, the actual value is returned (True).
+    is_compiled = get_module_attribute('pydantic', 'compiled') in {'True', True}
+
 if is_compiled:
     # Compiled version; we need to manually collect the submodules from
     # pydantic...

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -567,7 +567,23 @@ def test_pyproj(pyi_builder):
 @importorskip('pydantic')
 def test_pydantic(pyi_builder):
     pyi_builder.test_source("""
+        import datetime
+        import pprint
+
         import pydantic
+
+
+        class User(pydantic.BaseModel):
+            id: int
+            name: str = 'John Doe'
+            signup_ts: datetime.datetime
+
+
+        external_data = {'id': 'not an int', }
+        try:
+            User(**external_data)
+        except pydantic.ValidationError as e:
+            pprint.pprint(e.errors())
         """)
 
 


### PR DESCRIPTION
The v2.0.0 of pydantic seems to have removed the `pydantic.compiled` attribute, and cython-compiled version of PyPI wheels do not seem to be available anymore.

Fixes #610.