### PR TITLE
hooks: add hook for jsonschema_specifications

### DIFF
--- a/news/614.new.rst
+++ b/news/614.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``jsonschema_specifications`` to collect the data files
+that ``jsonschema`` v4.18.0 moved into a separate package.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -134,6 +134,7 @@ sympy==1.12
 xyzservices==2023.5.0
 mistune==3.0.1
 pydantic==2.0.0
+jsonschema==4.18.0
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-jsonschema.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-jsonschema.py
@@ -10,8 +10,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-# This is needed to bundle draft3.json and draft4.json files that come
-# with jsonschema module
+# This is needed to bundle draft3.json and draft4.json files that come with jsonschema module.
+# NOTE: with jsonschema >= 4.18.0, the specification files are part of jsonschema_specifications package, and are
+# handled by the corresponding hook-jsonschema.
 
 from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-jsonschema_specifications.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-jsonschema_specifications.py
@@ -1,0 +1,14 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+datas = collect_data_files('jsonschema_specifications')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1672,3 +1672,26 @@ def test_mistune(pyi_builder):
     pyi_builder.test_source("""
         import mistune
     """)
+
+
+@importorskip('jsonschema')
+def test_jsonschema(pyi_builder):
+    pyi_builder.test_source("""
+        import jsonschema
+
+        # Sample schema
+        schema = {
+            "type" : "object",
+            "properties" : {
+                "price" : {"type" : "number"},
+                "name" : {"type" : "string"},
+            },
+        }
+
+        jsonschema.validate(instance={"name" : "Eggs", "price" : 3.38}, schema=schema)
+
+        try:
+            jsonschema.validate(instance={"name" : "Eggs", "price" : "Invalid"}, schema=schema)
+        except jsonschema.ValidationError as e:
+            print(f"Validation error: {e}")
+    """)


### PR DESCRIPTION
Required for jsonschema >= 4.18.0, where bundled specification files have been moved into separate package.

Fixes #613.