### PR TITLE
hooks: add hook for ens package

### DIFF
--- a/news/617.new.rst
+++ b/news/617.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``ens`` package, required by ``web3`` v6.6.0 and later.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -99,7 +99,7 @@ Twisted==22.10.0
 tzdata==2023.3
 Unidecode==1.3.6
 weasyprint==59.0
-web3==6.5.0
+web3==6.6.1
 websockets==11.0.3
 zeep==4.2.1
 pypsexec==0.3.0

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-ens.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-ens.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files("ens")


### PR DESCRIPTION
Add hook for `ens` package to collect its data files. Required by `web3` >= 6.6.0.