### PR TITLE
hooks: update graphql_query hook for compatibility with v1.2.0

### DIFF
--- a/news/621.update.rst
+++ b/news/621.update.rst
@@ -1,0 +1,2 @@
+Update ``graphql_query`` hook for compatibility with ``graphql-query``
+v1.2.0.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -34,7 +34,7 @@ folium==0.14.0
 ffpyplayer==4.5.0
 geopandas==0.13.2; sys_platform != 'win32'
 google-api-python-client==2.95.0
-graphql-query==1.1.1
+graphql-query==1.2.0
 python-gitlab==3.15.0
 h5py==3.9.0
 humanize==4.7.0

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-graphql_query.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-graphql_query.py
@@ -14,4 +14,4 @@ PyInstaller hook file for graphql_query. Tested with version 1.0.3.
 
 from PyInstaller.utils.hooks import collect_data_files
 
-datas = collect_data_files('graphql_query.templates')
+datas = collect_data_files('graphql_query')


### PR DESCRIPTION
Update `graphql_query` hook for compatibility with `graphql-query` v1.2.0. Collect data files from `graphql_query` instead of `graphql_query.templates`; the templates directory cannot be treated as a namespace subpackage anymore due to introduction of eponymous submodule.