### PR TITLE
hooks: add hook for opencc-python

### DIFF
--- a/news/627.new.rst
+++ b/news/627.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``opencc-python``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -138,6 +138,7 @@ jsonschema==4.19.0
 psutil==5.9.5
 litestar==2.0.0rc1
 lingua-language-detector==1.3.2; python_version >= '3.8'
+opencc-python-reimplemented==0.1.7
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-opencc.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-opencc.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('opencc')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1736,6 +1736,7 @@ def test_lingua_language_detector(pyi_builder):
         assert detector.detect_language_of("languages are awesome") == Language.ENGLISH
     """)
 
+
 @importorskip('opencc')
 def test_opencc(pyi_builder):
     pyi_builder.test_source("""

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1735,3 +1735,13 @@ def test_lingua_language_detector(pyi_builder):
 
         assert detector.detect_language_of("languages are awesome") == Language.ENGLISH
     """)
+
+@importorskip('opencc')
+def test_opencc(pyi_builder):
+    pyi_builder.test_source("""
+        import opencc
+
+        cc = opencc.OpenCC('s2t')
+
+        assert cc.convert('开放中文转换') == '開放中文轉換'
+    """)


### PR DESCRIPTION
This PR adds a hook for [opencc-python](https://github.com/yichen0831/opencc-python).

Note: The name of the project and Github repository is `opencc-python`, which is a pure Python implementation of [OpenCC](https://github.com/yichen0831/opencc-python). The package name in PyPI is `opencc-python-reimplemented`. And the name used to import the package in Python is `opencc`.