### PR TITLE
hooks: add hook for wordcloud

### DIFF
--- a/news/630.new.rst
+++ b/news/630.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``wordcloud``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -141,6 +141,7 @@ lingua-language-detector==1.3.2; python_version >= '3.8'
 opencc-python-reimplemented==0.1.7
 jieba==0.42.1
 simplemma==0.9.1
+wordcloud==1.9.2
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-wordcloud.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-wordcloud.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('wordcloud')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1764,3 +1764,12 @@ def test_simplemma(pyi_builder):
 
         assert simplemma.lemmatize('tests', lang='en') == 'test'
     """)
+
+
+@importorskip('wordcloud')
+def test_wordcloud(pyi_builder):
+    pyi_builder.test_source("""
+        import wordcloud
+
+        wordcloud.WordCloud().generate('test')
+    """)


### PR DESCRIPTION
This PR adds a hook for [wordcloud](https://github.com/amueller/word_cloud), which is a word cloud generator.