### PR TITLE
hooks: add hook for eng_to_ipa

### DIFF
--- a/news/631.new.rst
+++ b/news/631.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``eng_to_ipa``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -142,6 +142,7 @@ opencc-python-reimplemented==0.1.7
 jieba==0.42.1
 simplemma==0.9.1
 wordcloud==1.9.2
+eng-to-ipa==0.0.2
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-eng_to_ipa.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-eng_to_ipa.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('eng_to_ipa')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1773,3 +1773,10 @@ def test_wordcloud(pyi_builder):
 
         wordcloud.WordCloud().generate('test')
     """)
+
+
+@importorskip('eng_to_ipa')
+def test_eng_to_ipa(pyi_builder):
+    pyi_builder.test_source("""
+        import eng_to_ipa
+    """)


### PR DESCRIPTION
This PR adds a hook for [eng_to_ipa](https://github.com/mphilli/English-to-IPA), which is library for converting English text into the [International Phonetic Alphabet](https://en.wikipedia.org/wiki/International_Phonetic_Alphabet).