### PR TITLE
hooks: add hook for python-mecab-ko

### DIFF
--- a/news/632.new.rst
+++ b/news/632.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``python-mecab-ko``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -143,6 +143,7 @@ jieba==0.42.1
 simplemma==0.9.1
 wordcloud==1.9.2
 eng-to-ipa==0.0.2
+python-mecab-ko==1.3.3
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-mecab.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-mecab.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('mecab')
+datas += collect_data_files('mecab_ko_dic')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1780,3 +1780,12 @@ def test_eng_to_ipa(pyi_builder):
     pyi_builder.test_source("""
         import eng_to_ipa
     """)
+
+
+@importorskip('mecab')
+def test_mecab(pyi_builder):
+    pyi_builder.test_source("""
+        import mecab
+
+        mecab.MeCab()
+    """)


### PR DESCRIPTION
This PR adds a hook for [python-mecab-ko](https://github.com/jonghwanhyeon/python-mecab-ko), which is a python binding for [mecab-ko](https://bitbucket.org/eunjeon/mecab-ko).