### PR TITLE
hooks: add hook for khmer-nltk and python-crfsuite

### DIFF
--- a/news/633.new.1.rst
+++ b/news/633.new.1.rst
@@ -1,0 +1,1 @@
+Add hook for ``python-crfsuite``.

--- a/news/633.new.rst
+++ b/news/633.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``khmer-nltk``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -144,6 +144,7 @@ simplemma==0.9.1
 wordcloud==1.9.2
 eng-to-ipa==0.0.2
 python-mecab-ko==1.3.3
+khmer-nltk==1.5
 
 # ------------------- Platform (OS) specifics
 

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -145,6 +145,7 @@ wordcloud==1.9.2
 eng-to-ipa==0.0.2
 python-mecab-ko==1.3.3
 khmer-nltk==1.5
+python-crfsuite==0.9.9
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-khmernltk.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-khmernltk.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('khmernltk')
+hiddenimports = ['sklearn_crfsuite']

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pycrfsuite.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pycrfsuite.py
@@ -1,0 +1,13 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+hiddenimports = ['pycrfsuite._dumpparser', 'pycrfsuite._logparser', 'tempfile']

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1789,3 +1789,10 @@ def test_mecab(pyi_builder):
 
         mecab.MeCab()
     """)
+
+
+@importorskip('khmernltk')
+def test_khmernltk(pyi_builder):
+    pyi_builder.test_source("""
+        import khmernltk
+    """)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1796,3 +1796,10 @@ def test_khmernltk(pyi_builder):
     pyi_builder.test_source("""
         import khmernltk
     """)
+
+
+@importorskip('pycrfsuite')
+def test_pycrfsuite(pyi_builder):
+    pyi_builder.test_source("""
+        import pycrfsuite
+    """)


### PR DESCRIPTION
This PR adds a hook for [khmer-nltk](https://github.com/VietHoang1512/khmer-nltk), which is a Khmer (Cambodian) natural language processing toolkit.