### PR TITLE
hooks: add hook for pymorphy3

### DIFF
--- a/news/634.new.rst
+++ b/news/634.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``pymorphy3``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -146,6 +146,8 @@ eng-to-ipa==0.0.2
 python-mecab-ko==1.3.3
 khmer-nltk==1.5
 python-crfsuite==0.9.9
+pymorphy3==1.2.0
+pymorphy3-dicts-uk==2.4.1.1.1663094765
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pymorphy3.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pymorphy3.py
@@ -1,0 +1,25 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import can_import_module, copy_metadata, collect_data_files
+
+datas = copy_metadata('pymorphy3_dicts_ru')
+datas += collect_data_files('pymorphy3_dicts_ru')
+
+hiddenimports = ['pymorphy3_dicts_ru']
+
+# Check if the Ukrainian model is installed
+if can_import_module('pymorphy3_dicts_uk'):
+    datas += copy_metadata('pymorphy3_dicts_uk')
+    datas += collect_data_files('pymorphy3_dicts_uk')
+
+    hiddenimports += ['pymorphy3_dicts_uk']

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1803,3 +1803,13 @@ def test_pycrfsuite(pyi_builder):
     pyi_builder.test_source("""
         import pycrfsuite
     """)
+
+
+@importorskip('pymorphy3')
+def test_pymorphy3(pyi_builder):
+    pyi_builder.test_source("""
+        import pymorphy3
+
+        pymorphy3.MorphAnalyzer(lang='ru')
+        pymorphy3.MorphAnalyzer(lang='uk')
+    """)


### PR DESCRIPTION
This PR adds a hook for [pymorphy3](https://github.com/no-plagiarism/pymorphy3), which is a fork of [pymorphy2](https://github.com/pymorphy2/pymorphy2), which then is a morphological analyzer for Russian and Ukrainian.

The Ukrainian model (`pymorphy3-dicts-uk`) is not installed automatically as a dependency of `pymorphy3`, so it needs to be handled separately.

Notes: The maintenance of the [pymorphy2](https://github.com/pymorphy2/pymorphy2) project has stalled (pymorphy2/pymorphy2#160), and [pymorphy3](https://github.com/no-plagiarism/pymorphy3) seems to be the most active fork available now (the [spaCy](https://spacy.io/) project widely used for multilingual NLP has already switched from `pymorphy2` to `pymorphy3` in explosion/spaCy#11345).