### PR TITLE
hooks: add hook for SudachiPy

### DIFF
--- a/news/635.new.rst
+++ b/news/635.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``SudachiPy``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -148,6 +148,10 @@ khmer-nltk==1.5
 python-crfsuite==0.9.9
 pymorphy3==1.2.0
 pymorphy3-dicts-uk==2.4.1.1.1663094765
+sudachipy==0.6.7
+sudachidict-core==20230711
+sudachidict-small==20230711
+sudachidict-full==20230711
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sudachipy.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sudachipy.py
@@ -1,0 +1,23 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import can_import_module, collect_data_files
+
+datas = collect_data_files('sudachipy')
+hiddenimports = []
+
+# Check which types of dictionary are installed
+for sudachi_dict in ['sudachidict_small', 'sudachidict_core', 'sudachidict_full']:
+    if can_import_module(sudachi_dict):
+        datas += collect_data_files(sudachi_dict)
+
+        hiddenimports += [sudachi_dict]

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1813,3 +1813,14 @@ def test_pymorphy3(pyi_builder):
         pymorphy3.MorphAnalyzer(lang='ru')
         pymorphy3.MorphAnalyzer(lang='uk')
     """)
+
+
+@importorskip('sudachipy')
+def test_sudachipy(pyi_builder):
+    pyi_builder.test_source("""
+        from sudachipy import Dictionary
+
+        Dictionary(dict_type='small').create()
+        Dictionary(dict_type='core').create()
+        Dictionary(dict_type='full').create()
+    """)


### PR DESCRIPTION
This PR adds a hook for [SudachiPy](https://github.com/WorksApplications/sudachi.rs/tree/develop/python), which is a Python binding of [Sudachi](https://github.com/WorksApplications/Sudachi), which then is a Japanese morphological analyzer.

There are 3 types of dictionary: `sudachidict-small`, `sudachidict-core`, `sudachidict-full`, all of which needs to be installed separately.