### PR TITLE
tests: allow test_pymorphy3 to run without the uk dictionary installed

### DIFF
--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1807,12 +1807,23 @@ def test_pycrfsuite(pyi_builder):
 
 @importorskip('pymorphy3')
 def test_pymorphy3(pyi_builder):
+    # Language availability depends on installed packages.
+    available_languages = []
+    if can_import_module('pymorphy3_dicts_ru'):
+        available_languages.append('ru')
+    if can_import_module('pymorphy3_dicts_uk'):
+        available_languages.append('uk')
+
     pyi_builder.test_source("""
+        import sys
         import pymorphy3
 
-        pymorphy3.MorphAnalyzer(lang='ru')
-        pymorphy3.MorphAnalyzer(lang='uk')
-    """)
+        languages = sys.argv[1:]
+        print(f"Languages to test: {languages}")
+
+        for language in languages:
+            pymorphy3.MorphAnalyzer(lang=language)
+    """, app_args=available_languages)
 
 
 @importorskip('sudachipy')


### PR DESCRIPTION
Modify the `pymorphy3` test to dynamically determine what dictionaries (`ru`, `uk`) are available in the environment, and test for that. Allows the test to run when the pyup pull request updates only the `morphy3` package (which installs only `ru` dictionary by default).