### PR TITLE
hooks: add hooks for LaoNLP and PyThaiNLP

### DIFF
--- a/news/644.new.1.rst
+++ b/news/644.new.1.rst
@@ -1,0 +1,1 @@
+Add hook for ``PyThaiNLP``.

--- a/news/644.new.rst
+++ b/news/644.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``LaoNLP``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -153,6 +153,7 @@ sudachidict-core==20230711
 sudachidict-small==20230711
 sudachidict-full==20230711
 wxPython==4.2.1; sys_platform == 'darwin' or sys_platform == 'win32'  # PyPI provides binary wheels for Windows and macOS
+laonlp==1.1.2
 
 # ------------------- Platform (OS) specifics
 

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -154,6 +154,7 @@ sudachidict-small==20230711
 sudachidict-full==20230711
 wxPython==4.2.1; sys_platform == 'darwin' or sys_platform == 'win32'  # PyPI provides binary wheels for Windows and macOS
 laonlp==1.1.2
+pythainlp==4.1.0b5
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-laonlp.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-laonlp.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('laonlp')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pythainlp.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pythainlp.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('pythainlp')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1842,3 +1842,10 @@ def test_laonlp(pyi_builder):
     pyi_builder.test_source("""
         import laonlp
     """)
+
+
+@importorskip('pythainlp')
+def test_pythainlp(pyi_builder):
+    pyi_builder.test_source("""
+        import pythainlp
+    """)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1835,3 +1835,10 @@ def test_sudachipy(pyi_builder):
         Dictionary(dict_type='core').create()
         Dictionary(dict_type='full').create()
     """)
+
+
+@importorskip('laonlp')
+def test_laonlp(pyi_builder):
+    pyi_builder.test_source("""
+        import laonlp
+    """)


### PR DESCRIPTION
This PR adds a hook for [LaoNLP](https://github.com/wannaphong/LaoNLP), which is an NLP library for Lao (Laotian).
Another hook for [PyThaiNLP](https://github.com/PyThaiNLP/pythainlp), which is an NLP library for the Thai language, is also added.