### PR TITLE
hooks: update runtime hook for NLTK

### DIFF
--- a/news/646.update.rst
+++ b/news/646.update.rst
@@ -1,0 +1,1 @@
+If ``nltk_data`` can be found both in the frozen program and under the default location specified by ``NLTK``, the former should be preferred to the latter.

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_nltk.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_nltk.py
@@ -14,4 +14,4 @@ import os
 import nltk
 
 #add the path to nltk_data
-nltk.data.path.append(os.path.join(sys._MEIPASS, "nltk_data"))
+nltk.data.path.insert(0, os.path.join(sys._MEIPASS, "nltk_data"))


### PR DESCRIPTION
If `nltk_data` can be found both in the frozen program and under the default location specified by `NLTK`, the former should be preferred to the latter.