### PR TITLE
hooks: update skimage hooks for scikit-image 0.22.0

### DIFF
--- a/news/652.update.rst
+++ b/news/652.update.rst
@@ -1,0 +1,1 @@
+Update ``skimage`` hooks for compatibility with ``scikit-image`` 0.22.0.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -126,7 +126,7 @@ exchangelib==5.1.0
 NBT==1.5.1
 minecraft-launcher-lib==6.2
 scikit-learn==1.3.1
-scikit-image==0.21.0
+scikit-image==0.22.0; python_version >= '3.9'
 customtkinter==5.2.0
 fastparquet==2023.8.0
 librosa==0.10.1

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.feature.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.feature.py
@@ -10,6 +10,13 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-# The following missing module prevents import of skimage.feature
-# with skimage 0.17.x.
+from PyInstaller.utils.hooks import is_module_satisfies, collect_data_files, collect_submodules
+
+# The following missing module prevents import of skimage.feature with skimage 0.17.x.
 hiddenimports = ['skimage.feature._orb_descriptor_positions', ]
+
+# As of scikit-image 0.22.0, we need to collect the __init__.pyi file for `lazy_loader`, as well as collect submodules
+# due to lazy loading.
+if is_module_satisfies("scikit-image >= 0.22.0"):
+    datas = collect_data_files("skimage.feature", includes=["*.pyi"])
+    hiddenimports = collect_submodules('skimage.feature', filter=lambda name: name != 'skimage.feature.tests')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.measure.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.measure.py
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------
-# Copyright (c) 2020 PyInstaller Development Team.
+# Copyright (c) 2023 PyInstaller Development Team.
 #
 # This file is distributed under the terms of the GNU General Public
 # License (version 2.0 or later).
@@ -12,11 +12,8 @@
 
 from PyInstaller.utils.hooks import is_module_satisfies, collect_data_files, collect_submodules
 
-# The following missing module prevents import of skimage.graph with skimage 0.17.x.
-hiddenimports = ['skimage.graph.heap', ]
-
 # As of scikit-image 0.22.0, we need to collect the __init__.pyi file for `lazy_loader`, as well as collect submodules
 # due to lazy loading.
 if is_module_satisfies("scikit-image >= 0.22.0"):
-    datas = collect_data_files("skimage.graph", includes=["*.pyi"])
-    hiddenimports = collect_submodules('skimage.graph', filter=lambda name: name != 'skimage.graph.tests')
+    datas = collect_data_files("skimage.measure", includes=["*.pyi"])
+    hiddenimports = collect_submodules('skimage.measure', filter=lambda name: name != 'skimage.measure.tests')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.registration.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.registration.py
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------
-# Copyright (c) 2020 PyInstaller Development Team.
+# Copyright (c) 2023 PyInstaller Development Team.
 #
 # This file is distributed under the terms of the GNU General Public
 # License (version 2.0 or later).
@@ -12,11 +12,8 @@
 
 from PyInstaller.utils.hooks import is_module_satisfies, collect_data_files, collect_submodules
 
-# The following missing module prevents import of skimage.graph with skimage 0.17.x.
-hiddenimports = ['skimage.graph.heap', ]
-
 # As of scikit-image 0.22.0, we need to collect the __init__.pyi file for `lazy_loader`, as well as collect submodules
 # due to lazy loading.
 if is_module_satisfies("scikit-image >= 0.22.0"):
-    datas = collect_data_files("skimage.graph", includes=["*.pyi"])
-    hiddenimports = collect_submodules('skimage.graph', filter=lambda name: name != 'skimage.graph.tests')
+    datas = collect_data_files("skimage.registration", includes=["*.pyi"])
+    hiddenimports = collect_submodules('skimage.registration', filter=lambda name: name != 'skimage.registration.tests')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.restoration.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.restoration.py
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------
-# Copyright (c) 2020 PyInstaller Development Team.
+# Copyright (c) 2023 PyInstaller Development Team.
 #
 # This file is distributed under the terms of the GNU General Public
 # License (version 2.0 or later).
@@ -12,11 +12,8 @@
 
 from PyInstaller.utils.hooks import is_module_satisfies, collect_data_files, collect_submodules
 
-# The following missing module prevents import of skimage.graph with skimage 0.17.x.
-hiddenimports = ['skimage.graph.heap', ]
-
 # As of scikit-image 0.22.0, we need to collect the __init__.pyi file for `lazy_loader`, as well as collect submodules
 # due to lazy loading.
 if is_module_satisfies("scikit-image >= 0.22.0"):
-    datas = collect_data_files("skimage.graph", includes=["*.pyi"])
-    hiddenimports = collect_submodules('skimage.graph', filter=lambda name: name != 'skimage.graph.tests')
+    datas = collect_data_files("skimage.restoration", includes=["*.pyi"])
+    hiddenimports = collect_submodules('skimage.restoration', filter=lambda name: name != 'skimage.restoration.tests')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.transform.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.transform.py
@@ -9,13 +9,16 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import is_module_satisfies, collect_data_files, collect_submodules
 
-# Hook tested with scikit-image (skimage) 0.9.3 on Mac OS 10.9 and Windows 7
-# 64-bit
+# Hook tested with scikit-image (skimage) 0.9.3 on Mac OS 10.9 and Windows 7 64-bit
 hiddenimports = ['skimage.draw.draw',
                  'skimage._shared.geometry',
                  'skimage._shared.transform',
                  'skimage.filters.rank.core_cy']
 
-datas = collect_data_files('skimage')
+# As of scikit-image 0.22.0, we need to collect the __init__.pyi file for `lazy_loader`, as well as collect submodules
+# due to lazy loading.
+if is_module_satisfies("scikit-image >= 0.22.0"):
+    datas = collect_data_files("skimage.transform", includes=["*.pyi"])
+    hiddenimports += collect_submodules('skimage.transform', filter=lambda name: name != 'skimage.transform.tests')


### PR DESCRIPTION
Add/modify hooks for skimage sub-packages that switched to lazy loader in scikit-image 0.22.0.