### PR TITLE
hooks: update rtree hook for compatibility with RTree 1.1.0

### DIFF
--- a/news/657.update.rst
+++ b/news/657.update.rst
@@ -1,0 +1,1 @@
+Update ``rtree`` hook for compatibility with ``Rtree >= 1.1.0``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -85,7 +85,7 @@ pytz==2023.3.post1
 pyzmq==25.1.1
 PyQt5==5.15.10
 qtmodern==0.2.0
-Rtree==1.0.1
+Rtree==1.1.0
 sacremoses==0.0.53
 # Remove after merging https://github.com/pyinstaller/pyinstaller/pull/6587
 scipy==1.11.3; python_version > '3.8'

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-rtree.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-rtree.py
@@ -10,9 +10,31 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.compat import is_pure_conda
-from PyInstaller.utils.hooks import collect_dynamic_libs, conda
+import pathlib
 
-binaries = collect_dynamic_libs('rtree', destdir='rtree/lib')
-if not binaries and is_pure_conda:
+from PyInstaller import compat
+from PyInstaller.utils.hooks import collect_dynamic_libs, get_installer, get_package_paths
+
+
+# Query the installer of the `rtree` package; in PyInstaller prior to 6.0, this might raise an exception, whereas in
+# later versions, None is returned.
+try:
+    package_installer = get_installer('rtree')
+except Exception:
+    package_installer = None
+
+if package_installer == 'conda':
+    from PyInstaller.utils.hooks import conda
+
+    # In Anaconda-packaged `rtree`, `libspatialindex` and `libspatialindex_c` shared libs are packaged in a separate
+    # `libspatialindex` package. Collect the libraries into `rtree/lib` sub-directory to simulate PyPI wheel layout.
     binaries = conda.collect_dynamic_libs('libspatialindex', dest='rtree/lib', dependencies=False)
+else:
+    # pip-installed package. The shared libs are usually placed in `rtree/lib` directory.
+    binaries = collect_dynamic_libs('rtree')
+
+    # With rtree >= 1.1.0, Linux PyPI wheels place the shared library in a `Rtree.libs` top-level directory.
+    if compat.is_linux:
+        _, rtree_dir = get_package_paths('rtree')
+        rtree_libs_dir = pathlib.Path(rtree_dir).parent / 'Rtree.libs'
+        binaries += [(str(lib_file), 'Rtree.libs') for lib_file in rtree_libs_dir.glob("libspatialindex*.so*")]


### PR DESCRIPTION
Starting with RTree 1.0.0, the PyPI wheel for linux puts the `libspatialindex` shared library into top-level `Rtree.libs` directory.

Also, explicitly gate the codepath for Anaconda-based package based on the `INSTALLER` metadata to better handle situations when PyPI wheel is installed in Anaconda python environment.

Fixes #654.