### PR TITLE
Pick up beta releases in check for pydantic 2.0.0+

### DIFF
--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pydantic.py
@@ -15,7 +15,7 @@ from PyInstaller.utils.hooks import is_module_satisfies
 
 # By default, PyPi wheels for pydantic < 2.0.0 come with all modules compiled as cython extensions, which prevents
 # PyInstaller from automatically picking up the submodules.
-if is_module_satisfies('pydantic >= 2.0.0'):
+if is_module_satisfies('pydantic >= 2.0.0') or is_module_satisfies('pydantic >= 2.0.0b'):
     # The `pydantic.compiled` attribute was removed in v2.
     is_compiled = False
 else:


### PR DESCRIPTION
Some pre-releases of pydantic have versions in the form "2.X.XbX" so update the conditional in the hook to recognize those versions as well.