### PR TITLE
Discard header files (and static libraries on Windows) of `torch`

### DIFF
--- a/news/666.update.rst
+++ b/news/666.update.rst
@@ -1,1 +1,1 @@
-Modernize the torch for ``hook`` and reduce the amount of unnecessarily collected data files (header files and static libraries). Requires PyInstaller >= 6.0.
+Modernize the hook for ``torch`` and reduce the amount of unnecessarily collected data files (header files and static libraries). Requires PyInstaller >= 6.0.

--- a/news/666.update.rst
+++ b/news/666.update.rst
@@ -1,0 +1,1 @@
+Discard header files (and static libraries on Windows) of ``torch``

--- a/news/666.update.rst
+++ b/news/666.update.rst
@@ -1,1 +1,1 @@
-Discard header files (and static libraries on Windows) of ``torch``
+Modernize the torch for ``hook`` and reduce the amount of unnecessarily collected data files (header files and static libraries). Requires PyInstaller >= 6.0.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-torch.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-torch.py
@@ -10,9 +10,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import logger, get_package_paths, is_module_satisfies
+from PyInstaller.utils.hooks import logger, collect_data_files, is_module_satisfies
 
-datas = [(get_package_paths('torch')[1], "torch")]
+datas = collect_data_files("torch", excludes=["**/*.h", "**/*.hpp", "**/*.cuh",
+                                              "**/*.lib"], include_py_files=True)
 
 # With torch 2.0.0, PyInstaller's modulegraph analysis hits the recursion limit.
 # So, unless the user has already done so, increase it automatically.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-torch.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-torch.py
@@ -10,11 +10,14 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import logger, collect_data_files, is_module_satisfies, collect_dynamic_libs
-from PyInstaller.compat import ALL_SUFFIXES
+from PyInstaller.utils.hooks import logger, collect_data_files, is_module_satisfies, collect_dynamic_libs, collect_submodules
 
-datas = collect_data_files("torch", excludes=["**/*.h", "**/*.hpp", "**/*.cuh", "**/*.lib"])
-datas += collect_dynamic_libs("torch", search_patterns=["**/*" + i for i in ALL_SUFFIXES if i.lower() != ".pyc"])
+module_collection_mode = 'pyz+py'
+
+datas = collect_data_files("torch", excludes=["**/*.h", "**/*.hpp", "**/*.cuh",
+                                              "**/*.lib", "**/*.cpp", "**/*.pyi", "**/*.cmake"])
+binaries = collect_dynamic_libs("torch")
+hiddenimports = collect_submodules("torch")
 
 # With torch 2.0.0, PyInstaller's modulegraph analysis hits the recursion limit.
 # So, unless the user has already done so, increase it automatically.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-torch.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-torch.py
@@ -10,10 +10,11 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import logger, collect_data_files, is_module_satisfies
+from PyInstaller.utils.hooks import logger, collect_data_files, is_module_satisfies, collect_dynamic_libs
+from PyInstaller.compat import ALL_SUFFIXES
 
-datas = collect_data_files("torch", excludes=["**/*.h", "**/*.hpp", "**/*.cuh",
-                                              "**/*.lib"], include_py_files=True)
+datas = collect_data_files("torch", excludes=["**/*.h", "**/*.hpp", "**/*.cuh", "**/*.lib"])
+datas += collect_dynamic_libs("torch", search_patterns=["**/*" + i for i in ALL_SUFFIXES if i.lower() != ".pyc"])
 
 # With torch 2.0.0, PyInstaller's modulegraph analysis hits the recursion limit.
 # So, unless the user has already done so, increase it automatically.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-torch.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-torch.py
@@ -10,19 +10,40 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import logger, collect_data_files, is_module_satisfies, collect_dynamic_libs, collect_submodules
+from PyInstaller.utils.hooks import (
+    logger,
+    collect_data_files,
+    is_module_satisfies,
+    collect_dynamic_libs,
+    collect_submodules,
+    get_package_paths,
+)
 
-module_collection_mode = 'pyz+py'
+if is_module_satisfies("PyInstaller >= 6.0"):
+    module_collection_mode = "pyz+py"
 
-datas = collect_data_files("torch", excludes=["**/*.h", "**/*.hpp", "**/*.cuh",
-                                              "**/*.lib", "**/*.cpp", "**/*.pyi", "**/*.cmake"])
-binaries = collect_dynamic_libs("torch")
-hiddenimports = collect_submodules("torch")
+    datas = collect_data_files(
+        "torch",
+        excludes=[
+            "**/*.h",
+            "**/*.hpp",
+            "**/*.cuh",
+            "**/*.lib",
+            "**/*.cpp",
+            "**/*.pyi",
+            "**/*.cmake",
+        ],
+    )
+    binaries = collect_dynamic_libs("torch")
+    hiddenimports = collect_submodules("torch")
+else:
+    datas = [(get_package_paths("torch")[1], "torch")]
 
 # With torch 2.0.0, PyInstaller's modulegraph analysis hits the recursion limit.
 # So, unless the user has already done so, increase it automatically.
-if is_module_satisfies('torch >= 2.0.0'):
+if is_module_satisfies("torch >= 2.0.0"):
     import sys
+
     new_limit = 5000
     if sys.getrecursionlimit() < new_limit:
         logger.info("hook-torch: raising recursion limit to %d", new_limit)

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-torch.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-torch.py
@@ -21,6 +21,7 @@ from PyInstaller.utils.hooks import (
 
 if is_module_satisfies("PyInstaller >= 6.0"):
     module_collection_mode = "pyz+py"
+    warn_on_missing_hiddenimports = False
 
     datas = collect_data_files(
         "torch",

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -587,6 +587,16 @@ def test_pydantic(pyi_builder):
         """)
 
 
+@importorskip('torch')
+@torch_onedir_only
+def test_torch(pyi_builder):
+    pyi_builder.test_source("""
+        import torch
+
+        torch.rand((10, 10)) * torch.rand((10, 10))
+    """)
+
+
 def torch_onedir_only(test):
 
     def wrapped(pyi_builder):

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -587,16 +587,6 @@ def test_pydantic(pyi_builder):
         """)
 
 
-@importorskip('torch')
-@torch_onedir_only
-def test_torch(pyi_builder):
-    pyi_builder.test_source("""
-        import torch
-
-        torch.rand((10, 10)) * torch.rand((10, 10))
-    """)
-
-
 def torch_onedir_only(test):
 
     def wrapped(pyi_builder):
@@ -606,6 +596,16 @@ def torch_onedir_only(test):
         test(pyi_builder)
 
     return wrapped
+
+
+@importorskip('torch')
+@torch_onedir_only
+def test_torch(pyi_builder):
+    pyi_builder.test_source("""
+        import torch
+
+        torch.rand((10, 10)) * torch.rand((10, 10))
+    """)
 
 
 @importorskip('torchvision')


### PR DESCRIPTION
I've read #531 and found a new solution.
We know thousands of headers are included in the wheel of torch, which are provided for situations like libraries which would be compiled when being installed as they should use the same version of CUDA, because none of source codes of PyTorch is included. So those header files can be simply filtered to reduce file amount in the packed application (so it can be moved or copied easier)

I still encountered a problem, though. After modifying these, tests on Linux will fail:
<details>
  <summary>Click to expand</summary>

```
----------------------------- Captured stdout call -----------------------------
------- Starting build. -------
------- Build finished, now running executable. -------
[6545]  RUNNING:  '/tmp/pytest-of-runner/pytest-0/test_torch_onedir_0/dist/test_source/test_source' , args:  ['./test_source']
----------------------------- Captured stderr call -----------------------------
------- Starting build. -------
------- Build finished, now running executable. -------
[6545] PyInstaller Bootloader 6.x
[6545] LOADER: executable is /tmp/pytest-of-runner/pytest-0/test_torch_onedir_0/dist/test_source/test_source
[6545] LOADER: _MEIPASS2 is not set
[6545] LOADER: archivename is /tmp/pytest-of-runner/pytest-0/test_torch_onedir_0/dist/test_source/test_source
[6545] LOADER: Cookie found at offset 0x14FC749
[6545] LOADER: No need to extract files to run; setting up environment and restarting bootloader...
[6545] LOADER: LD_LIBRARY_PATH_ORIG=/opt/hostedtoolcache/Python/3.11.6/x64/lib
[6545] LOADER: LD_LIBRARY_PATH=/tmp/pytest-of-runner/pytest-0/test_torch_onedir_0/dist/test_source/_internal:/opt/hostedtoolcache/Python/3.11.6/x64/lib
[6545] PyInstaller Bootloader 6.x
[6545] LOADER: executable is /tmp/pytest-of-runner/pytest-0/test_torch_onedir_0/dist/test_source/test_source
[6545] LOADER: _MEIPASS2 is /tmp/pytest-of-runner/pytest-0/test_torch_onedir_0/dist/test_source/_internal
[6545] LOADER: archivename is /tmp/pytest-of-runner/pytest-0/test_torch_onedir_0/dist/test_source/test_source
[6545] LOADER: Cookie found at offset 0x14FC749
[6545] LOADER: Already in the child - running user's code.
[6545] LOADER: Python library: /tmp/pytest-of-runner/pytest-0/test_torch_onedir_0/dist/test_source/_internal/libpython3.11.so.1.0
[6545] LOADER: Loaded functions from Python library.
[6545] LOADER: Pre-initializing embedded python interpreter...
[6545] LOADER: Creating PyConfig structure...
[6545] LOADER: Initializing interpreter configuration...
[6545] LOADER: Setting program name...
[6545] LOADER: Setting python home path...
[6545] LOADER: Setting module search paths...
[6545] LOADER: Setting sys.argv...
[6545] LOADER: Applying run-time options...
[6545] LOADER: Starting embedded python interpreter...
[6545] LOADER: setting sys._MEIPASS
[6545] LOADER: importing modules from CArchive
[6545] LOADER: extracted struct
[6545] LOADER: running unmarshalled code object for struct...
[6545] LOADER: extracted pyimod01_archive
[6545] LOADER: running unmarshalled code object for pyimod01_archive...
[6545] LOADER: extracted pyimod02_importers
[6545] LOADER: running unmarshalled code object for pyimod02_importers...
[6545] LOADER: extracted pyimod03_ctypes
[6545] LOADER: running unmarshalled code object for pyimod03_ctypes...
[6545] LOADER: Installing PYZ archive with Python modules.
[6545] LOADER: PYZ archive: PYZ-02.pyz
[6545] LOADER: Running pyiboot01_bootstrap.py
[6545] LOADER: Running pyi_rth_inspect.py
[6545] LOADER: Running pyi_rth_pkgutil.py
[6545] LOADER: Running pyi_rth_multiprocessing.py
[6545] LOADER: Running pyi_rth_pkgres.py
[6545] LOADER: Running pyi_rth_setuptools.py
[6545] LOADER: Running test_source.py
Traceback (most recent call last):
  File "PyInstaller/loader/pyimod03_ctypes.py", line 53, in __init__
  File "ctypes/__init__.py", line 376, in __init__
OSError: /tmp/pytest-of-runner/pytest-0/test_torch_onedir_0/dist/test_source/_internal/torch/lib/libtorch_global_deps.so: cannot open shared object file: No such file or directory

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "test_source.py", line 3, in <module>
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "PyInstaller/loader/pyimod02_importers.py", line 419, in exec_module
  File "torch/__init__.py", line 234, in <module>
  File "torch/__init__.py", line 193, in _load_global_deps
  File "torch/__init__.py", line 174, in _load_global_deps
  File "PyInstaller/loader/pyimod03_ctypes.py", line 55, in __init__
pyimod03_ctypes.install.<locals>.PyInstallerImportError: Failed to load dynlib/dll '/tmp/pytest-of-runner/pytest-0/test_torch_onedir_0/dist/test_source/_internal/torch/lib/libtorch_global_deps.so'. Most likely this dynlib/dll was not found when the application was frozen.
[6545] Failed to execute script 'test_source' due to unhandled exception!
[6545] LOADER: ERROR.
[6545] LOADER: Manually flushing stdout and stderr
[6545] LOADER: Cleaning up Python interpreter.
------------------------------ Captured log call -------------------------------
INFO     PyInstaller.configure:configure.py:104 UPX is available but is disabled on non-Windows due to known compatibility problems.
INFO     PyInstaller.__main__:__main__.py:184 PyInstaller: 6.2.0
INFO     PyInstaller.__main__:__main__.py:185 Python: 3.11.6
INFO     PyInstaller.__main__:__main__.py:186 Platform: Linux-6.2.0-1016-azure-x86_64-with-glibc2.35
INFO     PyInstaller.__main__:__main__.py:63 wrote /tmp/pytest-of-runner/pytest-0/test_torch_onedir_0/test_source.spec
INFO     PyInstaller.building.build_main:build_main.py:[411](https://github.com/CarlGao4/pyinstaller-hooks-contrib/actions/runs/7006213955/job/19057606366#step:7:412) Extending PYTHONPATH with paths
['/tmp/pytest-of-runner/pytest-0/test_torch_onedir_0',
 '/home/runner/work/pyinstaller-hooks-contrib/pyinstaller-hooks-contrib/src/_pyinstaller_hooks_contrib/tests/modules']
INFO     PyInstaller.building.datastruct:datastruct.py:169 checking Analysis
INFO     PyInstaller.building.datastruct:datastruct.py:173 Building Analysis because Analysis-02.toc is non existent
INFO     PyInstaller.depend.analysis:analysis.py:919 Reusing cached module dependency graph...
INFO     PyInstaller.depend.analysis:analysis.py:121 Caching module graph hooks...
INFO     PyInstaller.building.build_main:build_main.py:574 Running Analysis Analysis-02.toc
INFO     PyInstaller.building.build_main:build_main.py:577 Looking for Python shared library...
INFO     PyInstaller.building.build_main:build_main.py:582 Using Python shared library: /opt/hostedtoolcache/Python/3.11.6/x64/lib/libpython3.11.so.1.0
INFO     PyInstaller.building.build_main:build_main.py:607 Analyzing /tmp/pytest-of-runner/pytest-0/test_torch_onedir_0/test_source.py
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-torch.py' from '/home/runner/work/pyinstaller-hooks-contrib/pyinstaller-hooks-contrib/src/_pyinstaller_hooks_contrib/hooks/stdhooks'...
INFO     PyInstaller.utils.hooks:hook-torch.py:24 hook-torch: raising recursion limit to 5000
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-platform.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-packaging.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-pkg_resources.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-xml.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-sysconfig.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-difflib.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-multiprocessing.util.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-sympy.py' from '/home/runner/work/pyinstaller-hooks-contrib/pyinstaller-hooks-contrib/src/_pyinstaller_hooks_contrib/hooks/stdhooks'...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-py.py' from '/home/runner/work/pyinstaller-hooks-contrib/pyinstaller-hooks-contrib/src/_pyinstaller_hooks_contrib/hooks/stdhooks'...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-pytest.py' from '/home/runner/work/pyinstaller-hooks-contrib/pyinstaller-hooks-contrib/src/_pyinstaller_hooks_contrib/hooks/stdhooks'...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-xml.dom.domreg.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-setuptools.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.depend.analysis:analysis.py:[459](https://github.com/CarlGao4/pyinstaller-hooks-contrib/actions/runs/7006213955/job/19057606366#step:7:460) Processing pre-safe import module hook distutils from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks/pre_safe_import_module/hook-distutils.py'.
INFO     PyInstaller.depend.analysis:analysis.py:502 Processing pre-find module path hook distutils from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks/pre_find_module_path/hook-distutils.py'.
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-distutils.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-distutils.util.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-psutil.py' from '/home/runner/work/pyinstaller-hooks-contrib/pyinstaller-hooks-contrib/src/_pyinstaller_hooks_contrib/hooks/stdhooks'...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-xml.etree.cElementTree.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.depend.analysis:analysis.py:459 Processing pre-safe import module hook win32com from '/home/runner/work/pyinstaller-hooks-contrib/pyinstaller-hooks-contrib/src/_pyinstaller_hooks_contrib/hooks/pre_safe_import_module/hook-win32com.py'.
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-sqlite3.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.depend.analysis:analysis.py:304 Processing module hooks...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-pickle.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-setuptools.msvc.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-setuptools._distutils.command.check.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-heapq.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-encodings.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.building.build_main:build_main.py:660 Looking for ctypes DLLs
WARNING  PyInstaller.depend.utils:utils.py:298 Library msvcp140.dll required via ctypes not found
WARNING  PyInstaller.depend.utils:utils.py:298 Library vcruntime140.dll required via ctypes not found
WARNING  PyInstaller.depend.utils:utils.py:298 Library vcruntime140_1.dll required via ctypes not found
WARNING  PyInstaller.depend.utils:utils.py:110 Ignoring /usr/lib64/libgomp.so.1 imported from /opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/torch/_inductor/codecache.py - only basenames are supported with ctypes imports!
INFO     PyInstaller.depend.analysis:analysis.py:687 Analyzing run-time hooks ...
INFO     PyInstaller.depend.analysis:analysis.py:707 Including run-time hook '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks/rthooks/pyi_rth_inspect.py'
INFO     PyInstaller.depend.analysis:analysis.py:707 Including run-time hook '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks/rthooks/pyi_rth_pkgutil.py'
INFO     PyInstaller.depend.analysis:analysis.py:502 Processing pre-find module path hook _pyi_rth_utils from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks/pre_find_module_path/hook-_pyi_rth_utils.py'.
INFO     PyInstaller.depend.imphook:imphook.py:381 Loading module hook 'hook-_pyi_rth_utils.py' from '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks'...
INFO     PyInstaller.depend.analysis:analysis.py:707 Including run-time hook '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks/rthooks/pyi_rth_multiprocessing.py'
INFO     PyInstaller.depend.analysis:analysis.py:707 Including run-time hook '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks/rthooks/pyi_rth_pkgres.py'
INFO     PyInstaller.depend.analysis:analysis.py:707 Including run-time hook '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/hooks/rthooks/pyi_rth_setuptools.py'
INFO     PyInstaller.building.build_main:build_main.py:799 Looking for dynamic libraries
WARNING  PyInstaller.depend.bindepend:bindepend.py:217 Library not found: could not resolve 'libnvfuser_codegen.so', dependency of '/opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/torch/bin/nvfuser_tests'.
INFO     PyInstaller.building.build_main:build_main.py:887 Warnings written to /tmp/pytest-of-runner/pytest-0/test_torch_onedir_0/build/test_source/warn-test_source.txt
INFO     PyInstaller.building.build_main:build_main.py:896 Graph cross-reference written to /tmp/pytest-of-runner/pytest-0/test_torch_onedir_0/build/test_source/xref-test_source.html
INFO     PyInstaller.building.datastruct:datastruct.py:169 checking PYZ
INFO     PyInstaller.building.datastruct:datastruct.py:173 Building PYZ because PYZ-02.toc is non existent
INFO     PyInstaller.building.api:api.py:130 Building PYZ (ZlibArchive) /tmp/pytest-of-runner/pytest-0/test_torch_onedir_0/build/test_source/PYZ-02.pyz
INFO     PyInstaller.building.api:api.py:151 Building PYZ (ZlibArchive) /tmp/pytest-of-runner/pytest-0/test_torch_onedir_0/build/test_source/PYZ-02.pyz completed successfully.
INFO     PyInstaller.building.datastruct:datastruct.py:169 checking PKG
INFO     PyInstaller.building.datastruct:datastruct.py:173 Building PKG because PKG-02.toc is non existent
INFO     PyInstaller.building.api:api.py:256 Building PKG (CArchive) test_source.pkg
INFO     PyInstaller.building.api:api.py:331 Building PKG (CArchive) test_source.pkg completed successfully.
INFO     PyInstaller.building.api:api.py:706 Bootloader /opt/hostedtoolcache/Python/3.11.6/x64/lib/python3.11/site-packages/PyInstaller/bootloader/Linux-64bit-intel/run_d
INFO     PyInstaller.building.datastruct:datastruct.py:169 checking EXE
INFO     PyInstaller.building.datastruct:datastruct.py:173 Building EXE because EXE-02.toc is non existent
INFO     PyInstaller.building.api:api.py:717 Building EXE from EXE-02.toc
INFO     PyInstaller.building.api:api.py:730 Copying bootloader EXE to /tmp/pytest-of-runner/pytest-0/test_torch_onedir_0/build/test_source/test_source
INFO     PyInstaller.building.api:api.py:788 Appending PKG archive to custom ELF section in EXE
INFO     PyInstaller.building.api:api.py:858 Building EXE from EXE-02.toc completed successfully.
INFO     PyInstaller.building.datastruct:datastruct.py:169 checking COLLECT
INFO     PyInstaller.building.datastruct:datastruct.py:173 Building COLLECT because COLLECT-01.toc is non existent
INFO     PyInstaller.building.api:api.py:1097 Building COLLECT COLLECT-01.toc
INFO     PyInstaller.building.api:api.py:1162 Building COLLECT COLLECT-01.toc completed successfully.
```

</details>