### PR TITLE
hooks: add hook for sspilib

### DIFF
--- a/news/669.new.rst
+++ b/news/669.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``sspilib`` that collects submodules of ``sspilib.raw``,
+most of which are cythonized extensions.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -158,6 +158,7 @@ wxPython==4.2.1; sys_platform == 'darwin' or sys_platform == 'win32'  # PyPI pro
 laonlp==1.1.3
 pythainlp==4.1.0b5
 gmsh==4.11.1
+sspilib==0.1.0
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sspilib.raw.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sspilib.raw.py
@@ -1,0 +1,20 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_submodules
+
+# This seems to be required in python <= 3.9; in later versions, the `dataclasses` module ends up included via a
+# different import chain. But for the sake of consistency, keep the hiddenimport for all python versions.
+hiddenimports = ['dataclasses']
+
+# Collect submodules of `sspilib.raw` - most of which are cythonized extensions.
+hiddenimports += collect_submodules('sspilib.raw')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1881,3 +1881,22 @@ def test_gmsh(pyi_builder):
     pyi_builder.test_source("""
         import gmsh
     """)
+
+
+@importorskip('sspilib')
+def test_sspilib(pyi_builder):
+    pyi_builder.test_source("""
+        import sspilib
+
+        cred = sspilib.UserCredential(
+            "username@DOMAIN.COM",
+            "password",
+        )
+
+        ctx = sspilib.ClientSecurityContext(
+            "host/server.domain.com",
+            credential=cred,
+        )
+
+        print(ctx)
+    """)


### PR DESCRIPTION
Add hook for `sspilib` that collects submodules of `sspilib.raw`, most of which are cythonized extensions.

See https://github.com/pyinstaller/pyinstaller/issues/8136 .