### PR TITLE
Add hooks for rlp and eth_rlp

### DIFF
--- a/news/672.new.1.rst
+++ b/news/672.new.1.rst
@@ -1,0 +1,1 @@
+Add hook for ``eth_rlp``.

--- a/news/672.new.rst
+++ b/news/672.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``rlp``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -159,6 +159,7 @@ laonlp==1.1.3
 pythainlp==4.1.0b5
 gmsh==4.11.1
 sspilib==0.1.0
+rlp==4.0.0
 
 # ------------------- Platform (OS) specifics
 

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -160,6 +160,7 @@ pythainlp==4.1.0b5
 gmsh==4.11.1
 sspilib==0.1.0
 rlp==4.0.0
+eth-rlp==1.0.0
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-eth_rlp.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-eth_rlp.py
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import is_module_satisfies, copy_metadata
+
+# Starting with v1.0.0, `eth_rlp` queries its version from metadata.
+if is_module_satisfies("eth-rlp >= 1.0.0"):
+    datas = copy_metadata('eth-rlp')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-rlp.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-rlp.py
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import is_module_satisfies, copy_metadata
+
+# Starting with v4.0.0, `rlp` queries its version from metadata.
+if is_module_satisfies("rlp >= 4.0.0"):
+    datas = copy_metadata('rlp')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1907,3 +1907,10 @@ def test_rlp(pyi_builder):
     pyi_builder.test_source("""
         import rlp
     """)
+
+
+@importorskip('eth_rlp')
+def test_eth_rlp(pyi_builder):
+    pyi_builder.test_source("""
+        import eth_rlp
+    """)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1900,3 +1900,10 @@ def test_sspilib(pyi_builder):
 
         print(ctx)
     """)
+
+
+@importorskip('rlp')
+def test_rlp(pyi_builder):
+    pyi_builder.test_source("""
+        import rlp
+    """)


### PR DESCRIPTION
Add hooks for `rlp` and `eth_rlp`; as of their respective latest releases, both of these packages now query their version from metadata.

Fixes the failing `web3` tests in https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/671.