### PR TITLE
tests: fix dependencies of sudachipy test

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -50,6 +50,13 @@ jobs:
           set -e
           echo '-r requirements-test.txt' >> requirements-test-libraries.txt
           if grep -q pyqtgraph requirements-test-libraries.txt ; then echo PyQt5 >> requirements-test-libraries.txt ;fi
+          # NOTE: specify minimum allowed version for sudachidict-* packages, to prevent pip from installing invalid
+          # SudachiDict_full-0.0.0-py3-none-any.whl due to --prefer-binary switch used with pip install...
+          if grep -q sudachipy requirements-test-libraries.txt; then
+            echo "sudachidict-small>=20230927" >> requirements-test-libraries.txt;
+            echo "sudachidict-core>=20230927" >> requirements-test-libraries.txt;
+            echo "sudachidict-full>=20230927" >> requirements-test-libraries.txt;
+          fi
           cat requirements-test-libraries.txt
 
       - name: Set up .NET Core for pythonnet tests

--- a/news/673.update.rst
+++ b/news/673.update.rst
@@ -1,0 +1,1 @@
+Update ``sudachipy`` hook for ``sudachipy`` 0.6.8.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -150,7 +150,7 @@ khmer-nltk==1.6
 python-crfsuite==0.9.9
 pymorphy3==1.2.1
 pymorphy3-dicts-uk==2.4.1.1.1663094765
-sudachipy==0.6.7
+sudachipy==0.6.8
 sudachidict-core==20230927
 sudachidict-small==20230927
 sudachidict-full==20230927

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sudachipy.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-sudachipy.py
@@ -10,10 +10,17 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import can_import_module, collect_data_files
+from PyInstaller.utils.hooks import can_import_module, collect_data_files, is_module_satisfies
 
 datas = collect_data_files('sudachipy')
 hiddenimports = []
+
+# In v0.6.8, `sudachipy.config` and `sudachipy.errors` modules were added, and are referenced from binary extension.
+if is_module_satisfies('sudachipy >= 0.6.8'):
+    hiddenimports += [
+        'sudachipy.config',
+        'sudachipy.errors',
+    ]
 
 # Check which types of dictionary are installed
 for sudachi_dict in ['sudachidict_small', 'sudachidict_core', 'sudachidict_full']:

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1859,9 +1859,9 @@ def test_sudachipy(pyi_builder):
     pyi_builder.test_source("""
         from sudachipy import Dictionary
 
-        Dictionary(dict_type='small').create()
-        Dictionary(dict_type='core').create()
-        Dictionary(dict_type='full').create()
+        Dictionary(dict='small').create()
+        Dictionary(dict='core').create()
+        Dictionary(dict='full').create()
     """)
 
 

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1852,6 +1852,9 @@ def test_pymorphy3(pyi_builder):
 
 
 @importorskip('sudachipy')
+@importorskip('sudachidict_small')
+@importorskip('sudachidict_core')
+@importorskip('sudachidict_full')
 def test_sudachipy(pyi_builder):
     pyi_builder.test_source("""
         from sudachipy import Dictionary


### PR DESCRIPTION
`sudachipy` test depends on availability of dictionary packages (`sudachidict_small`, `sudachidict_core`, and `sudachidict_full`), so skip the test if they are not available.

In practice, this means that we likely will not be running this test on the pyup-bot PRs, unless both `sudachipy` and dictionary packages get updated at the same time.