### PR TITLE
Add hooks for z3c.rml and freetype

### DIFF
--- a/news/674.new.1.rst
+++ b/news/674.new.1.rst
@@ -1,0 +1,2 @@
+Add a hook for ``freetype`` that collects the shared library that is
+bundled with ``freetype-py`` PyPI wheels.

--- a/news/674.new.rst
+++ b/news/674.new.rst
@@ -1,0 +1,2 @@
+Add a hook for ``z3c.rml`` that collects the required subset of Bitstream
+Vera TTF fonts from the ``reportlab`` package.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -162,6 +162,7 @@ sspilib==0.1.0
 rlp==4.0.0
 eth-rlp==1.0.0
 z3c.rml==4.4.0
+freetype-py==2.4.0
 
 # ------------------- Platform (OS) specifics
 

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -161,6 +161,7 @@ gmsh==4.11.1
 sspilib==0.1.0
 rlp==4.0.0
 eth-rlp==1.0.0
+z3c.rml==4.4.0
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-freetype.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-freetype.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_dynamic_libs
+
+# Collect the bundled freetype shared library, if available.
+binaries = collect_dynamic_libs('freetype')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-z3c.rml.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-z3c.rml.py
@@ -1,0 +1,25 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2023 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+# `z3c.rml` uses Bitstream Vera TTF fonts from the `reportlab` package. As that package can be used without the bundled
+# fonts and as some of the bundled fonts have restrictive license (e.g., DarkGarden), we collect the required subset
+# of fonts here, instead of collecting them all in a hook for `reportlab`.
+datas = collect_data_files(
+    "reportlab",
+    includes=[
+        "fonts/00readme.txt",
+        "fonts/bitstream-vera-license.txt",
+        "fonts/Vera*.ttf",
+    ],
+)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1917,3 +1917,31 @@ def test_eth_rlp(pyi_builder):
     pyi_builder.test_source("""
         import eth_rlp
     """)
+
+
+@importorskip('z3c.rml')
+def test_z3c_rml_rml2pdf(pyi_builder):
+    pyi_builder.test_source("""
+        from z3c.rml import rml2pdf
+
+        rml = '''
+        <!DOCTYPE document SYSTEM "rml.dtd" >
+        <document filename="test.pdf">
+          <template showBoundary="1">
+            <!--Debugging is now turned on, frame outlines -->
+            <!--will appear on the page -->
+            <pageTemplate id="main">
+              <!-- two frames are defined here: -->
+              <frame id="first" x1="100" y1="400" width="150" height="200" />
+              <frame id="second" x1="300" y1="400" width="150" height="200" />
+            </pageTemplate>
+          </template>
+          <stylesheet><!-- still empty...--></stylesheet>
+          <story>
+            <para>Welcome to RML.</para>
+          </story>
+        </document>
+        '''
+
+        pdf_bytes = rml2pdf.parseString(rml)
+    """)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1945,3 +1945,30 @@ def test_z3c_rml_rml2pdf(pyi_builder):
 
         pdf_bytes = rml2pdf.parseString(rml)
     """)
+
+
+@importorskip('freetype')
+def test_pyi_freetype(pyi_builder):
+    pyi_builder.test_source("""
+        import sys
+        import pathlib
+
+        import freetype
+
+        # Ensure that the freetype shared library is bundled with the frozen application; otherwise, freetype might be
+        # using system-wide library.
+
+        # First, check that freetype.FT_Library_filename is an absolute path; otherwise, it is likely using
+        # basename-only ctypes fallback.
+        ft_library_file = pathlib.Path(freetype.FT_Library_filename)
+        print(f"FT library file (original): {ft_library_file}", file=sys.stderr)
+        assert ft_library_file.is_absolute(), "FT library file is not an absolute path!"
+
+        # Check that fully-resolved freetype.FT_Library_filename is anchored in fully-resolved frozen application
+        # directory.
+        app_dir = pathlib.Path(__file__).resolve().parent
+        print(f"Application directory: {app_dir}", file=sys.stderr)
+        ft_library_path = pathlib.Path(ft_library_file).resolve()
+        print(f"FT library file (resolved): {ft_library_path}", file=sys.stderr)
+        assert app_dir in ft_library_path.parents, "FT library is not bundled with frozen application!"
+    """)


### PR DESCRIPTION
Add hook for `z3c.rml` that collects the required subset of Bitstream Vera TTF fonts from `reportlab` package (this is in contrast to the initial plan and the usual approach of collecting all fonts in `reportlab` hook - because `reportlab` can be used without its bundled fonts, and because DarkGarden font is GPL'd).

Closes https://github.com/pyinstaller/pyinstaller/issues/8135.

Add hook for `freetype` that collects the shared library that is bundled with `freetype-py` PyPI wheels. The upstream has a hook, but due to an oversight, it is currently defunct. The idea is to provide our copy while they decide on the fix (https://github.com/rougier/freetype-py/pull/180) and until they push an update.