### PR TITLE
hooks: skimage.feature: collect file with ORB descriptor positions

### DIFF
--- a/news/675.update.rst
+++ b/news/675.update.rst
@@ -1,0 +1,3 @@
+Update hook for ``skimage.feature`` to collect the
+``orb_descriptor_positions.txt`` data file, which is required by
+the ``skimage.feature.ORB`` class.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.feature.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-skimage.feature.py
@@ -15,8 +15,12 @@ from PyInstaller.utils.hooks import is_module_satisfies, collect_data_files, col
 # The following missing module prevents import of skimage.feature with skimage 0.17.x.
 hiddenimports = ['skimage.feature._orb_descriptor_positions', ]
 
+# Collect the data file with ORB descriptor positions. In earlier versions of scikit-image, this file was in
+# `skimage/data` directory, and it was moved to `skimage/feature` in v0.17.0. Collect if from wherever it is.
+datas = collect_data_files('skimage', includes=['**/orb_descriptor_positions.txt'])
+
 # As of scikit-image 0.22.0, we need to collect the __init__.pyi file for `lazy_loader`, as well as collect submodules
 # due to lazy loading.
 if is_module_satisfies("scikit-image >= 0.22.0"):
-    datas = collect_data_files("skimage.feature", includes=["*.pyi"])
+    datas += collect_data_files("skimage.feature", includes=["*.pyi"])
     hiddenimports = collect_submodules('skimage.feature', filter=lambda name: name != 'skimage.feature.tests')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -489,43 +489,6 @@ def test_pydivert(pyi_builder):
         """)
 
 
-@pytest.mark.slow
-@importorskip('skimage')
-@pytest.mark.skipif(not is_module_satisfies('scikit_image >= 0.16'),
-                    reason='The test supports only scikit-image >= 0.16.')
-@pytest.mark.parametrize('submodule', [
-    'color', 'data', 'draw', 'exposure', 'feature', 'filters', 'future',
-    'graph', 'io', 'measure', 'metrics', 'morphology', 'registration',
-    'restoration', 'segmentation', 'transform', 'util'
-])
-def test_skimage(pyi_builder, submodule):
-    pyi_builder.test_source("""
-        import skimage.{0}
-        """.format(submodule))
-
-
-@pytest.mark.slow
-@importorskip('sklearn')
-@pytest.mark.skipif(not is_module_satisfies('scikit_learn >= 0.21'),
-                    reason='The test supports only scikit-learn >= 0.21.')
-@pytest.mark.parametrize('submodule', [
-    'calibration', 'cluster', 'covariance', 'cross_decomposition',
-    'datasets', 'decomposition', 'dummy', 'ensemble', 'exceptions',
-    'experimental', 'externals', 'feature_extraction',
-    'feature_selection', 'gaussian_process', 'inspection',
-    'isotonic', 'kernel_approximation', 'kernel_ridge',
-    'linear_model', 'manifold', 'metrics', 'mixture',
-    'model_selection', 'multiclass', 'multioutput',
-    'naive_bayes', 'neighbors', 'neural_network', 'pipeline',
-    'preprocessing', 'random_projection', 'semi_supervised',
-    'svm', 'tree', 'discriminant_analysis', 'impute', 'compose'
-])
-def test_sklearn(pyi_builder, submodule):
-    pyi_builder.test_source("""
-        import sklearn.{0}
-        """.format(submodule))
-
-
 @importorskip('statsmodels')
 @pytest.mark.skipif(not is_module_satisfies('statsmodels >= 0.12'),
                     reason='This has only been tested with statsmodels >= 0.12.')

--- a/src/_pyinstaller_hooks_contrib/tests/test_scikit_image.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_scikit_image.py
@@ -37,3 +37,34 @@ def test_skimage(pyi_builder, submodule):
     pyi_builder.test_source("""
         import skimage.{0}
         """.format(submodule))
+
+
+# Test the ORB descriptor, which requires the data file with descriptor sample points.
+@importorskip('skimage')
+def test_skimage_feature_orb(pyi_builder):
+    pyi_builder.test_source("""
+        import skimage.feature
+        import numpy as np
+
+        # Prepare test images
+        img1 = np.zeros((100, 100))
+        img2 = np.zeros_like(img1)
+        rng = np.random.default_rng(1984)
+        square = rng.random((20, 20))
+        img1[40:60, 40:60] = square
+        img2[53:73, 53:73] = square
+
+        # ORB detector/descriptor extractor
+        detector_extractor1 = skimage.feature.ORB(n_keypoints=5)
+        detector_extractor2 = skimage.feature.ORB(n_keypoints=5)
+
+        # Process
+        detector_extractor1.detect_and_extract(img1)
+        detector_extractor2.detect_and_extract(img2)
+
+        matches = skimage.feature.match_descriptors(
+            detector_extractor1.descriptors,
+            detector_extractor2.descriptors,
+        )
+        print(matches)
+        """)

--- a/src/_pyinstaller_hooks_contrib/tests/test_scikit_image.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_scikit_image.py
@@ -16,8 +16,13 @@ from PyInstaller.utils.hooks import is_module_satisfies
 from PyInstaller.utils.tests import importorskip
 
 
-# Basic import tests for sub-packages of skimage.
+# Run the tests in onedir mode only
+onedir_only = pytest.mark.parametrize('pyi_builder', ['onedir'], indirect=True)
+
+
+# Basic import tests for sub-packages of skimage. Run only on demand, and only in onedir mode.
 @pytest.mark.slow
+@onedir_only
 @importorskip('skimage')
 @pytest.mark.skipif(
     not is_module_satisfies('scikit_image >= 0.16'),

--- a/src/_pyinstaller_hooks_contrib/tests/test_scikit_image.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_scikit_image.py
@@ -1,0 +1,34 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+import pytest
+
+from PyInstaller.utils.hooks import is_module_satisfies
+from PyInstaller.utils.tests import importorskip
+
+
+# Basic import tests for sub-packages of skimage.
+@pytest.mark.slow
+@importorskip('skimage')
+@pytest.mark.skipif(
+    not is_module_satisfies('scikit_image >= 0.16'),
+    reason='The test supports only scikit-image >= 0.16.',
+)
+@pytest.mark.parametrize('submodule', [
+    'color', 'data', 'draw', 'exposure', 'feature', 'filters', 'future',
+    'graph', 'io', 'measure', 'metrics', 'morphology', 'registration',
+    'restoration', 'segmentation', 'transform', 'util'
+])
+def test_skimage(pyi_builder, submodule):
+    pyi_builder.test_source("""
+        import skimage.{0}
+        """.format(submodule))

--- a/src/_pyinstaller_hooks_contrib/tests/test_scikit_learn.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_scikit_learn.py
@@ -1,0 +1,41 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+import pytest
+
+from PyInstaller.utils.hooks import is_module_satisfies
+from PyInstaller.utils.tests import importorskip
+
+
+# Basic import tests for sub-packages of sklearn.
+@pytest.mark.slow
+@importorskip('sklearn')
+@pytest.mark.skipif(
+    not is_module_satisfies('scikit_learn >= 0.21'),
+    reason='The test supports only scikit-learn >= 0.21.',
+)
+@pytest.mark.parametrize('submodule', [
+    'calibration', 'cluster', 'covariance', 'cross_decomposition',
+    'datasets', 'decomposition', 'dummy', 'ensemble', 'exceptions',
+    'experimental', 'externals', 'feature_extraction',
+    'feature_selection', 'gaussian_process', 'inspection',
+    'isotonic', 'kernel_approximation', 'kernel_ridge',
+    'linear_model', 'manifold', 'metrics', 'mixture',
+    'model_selection', 'multiclass', 'multioutput',
+    'naive_bayes', 'neighbors', 'neural_network', 'pipeline',
+    'preprocessing', 'random_projection', 'semi_supervised',
+    'svm', 'tree', 'discriminant_analysis', 'impute', 'compose'
+])
+def test_sklearn(pyi_builder, submodule):
+    pyi_builder.test_source("""
+        import sklearn.{0}
+        """.format(submodule))

--- a/src/_pyinstaller_hooks_contrib/tests/test_scikit_learn.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_scikit_learn.py
@@ -16,8 +16,13 @@ from PyInstaller.utils.hooks import is_module_satisfies
 from PyInstaller.utils.tests import importorskip
 
 
-# Basic import tests for sub-packages of sklearn.
+# Run the tests in onedir mode only
+onedir_only = pytest.mark.parametrize('pyi_builder', ['onedir'], indirect=True)
+
+
+# Basic import tests for sub-packages of sklearn.  Run only on demand, and only in onedir mode.
 @pytest.mark.slow
+@onedir_only
 @importorskip('sklearn')
 @pytest.mark.skipif(
     not is_module_satisfies('scikit_learn >= 0.21'),


### PR DESCRIPTION
Have the hook for `skimage.feature` collect the `orb_descriptor_positions.txt` file, which is required by `skimage.feature.ORB`. Closes https://github.com/pyinstaller/pyinstaller/issues/8176.

Add a basic test for ORB detector and descriptor extractor.

This PR also extracts the tests for scikit-image and scikit-learn from `test_libraries.py` into separate test files, as a first step of planned refactoring of that huge test file into smaller files based on a specific package or thematically similar packages.