### PR TITLE
cleanup: clean up and simplify `get_hooks_dirs` entry-point

### DIFF
--- a/src/_pyinstaller_hooks_contrib/hooks/__init__.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/__init__.py
@@ -10,15 +10,13 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 import os
-from . import stdhooks
-from . import rthooks
-
-_FILE_DIR = os.path.dirname(__file__)
 
 
 def get_hook_dirs():
+    hooks_dir = os.path.dirname(__file__)
     return [
-        *stdhooks.get_hook_dirs(),
-        *rthooks.get_hook_dirs(),
-        _FILE_DIR  # pre_* hooks
+        # Required because standard hooks are in sub-directory instead of the top-level hooks directory.
+        os.path.join(hooks_dir, 'stdhooks'),
+        # pre_* and run-time hooks
+        hooks_dir,
     ]

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks/__init__.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks/__init__.py
@@ -8,19 +8,3 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # ------------------------------------------------------------------
-import os
-
-DIR = os.path.dirname(__file__)
-"""
-This sub-package includes runtime hooks for pyinstaller.
-"""
-
-
-def get_hook_dirs():
-    dirs = []
-    # For every directory and sub directory (including cwd)
-    for path, _, _ in os.walk(DIR):
-        # Add the norm'd path to dirs
-        dirs.append(os.path.normpath(path))
-
-    return dirs

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/__init__.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/__init__.py
@@ -9,23 +9,3 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
-import os
-
-DIR = os.path.dirname(__file__)
-"""
-All sub folders in this folder - "stdhooks" - are considered hook directories.
-
-All sub folders MUST define an `__init__.py` file.
-We recommend that it contains the copyright header, and nothing else.
-"""
-
-
-def get_hook_dirs():
-
-    dirs = []
-    # For every directory and sub directory (including cwd)
-    for path, _, _ in os.walk(DIR):
-        # Add the norm'd path to dirs
-        dirs.append(os.path.normpath(path))
-
-    return dirs


### PR DESCRIPTION
The package's implementation of `get_hook_dirs` currently returns the following paths:

```
[
 '[...]/_pyinstaller_hooks_contrib/hooks/stdhooks',
 '[...]/_pyinstaller_hooks_contrib/hooks/stdhooks/__pycache__',
 '[...]/_pyinstaller_hooks_contrib/hooks/rthooks',
 '[...]/_pyinstaller_hooks_contrib/hooks/rthooks/__pycache__',
 '[...]/_pyinstaller_hooks_contrib/hooks',
]
```

whereas only

```
[
 '[...]/_pyinstaller_hooks_contrib/hooks/stdhooks',
 '[...]/_pyinstaller_hooks_contrib/hooks',
]
```

would suffice. The first path is required because we use non-standard layout for standard hooks - normally, PyInstaller expects them to be in the top-level hooks directory. All other hooks are discovered based on the top-level hooks directory (the second path), including the run-time hooks; PyInstaller looks for `rthooks.dat` in the hooks directory, and assumes that hooks themselves are stored in `rthooks` directory next to the `rthooks.dat` file.

Clean up and simplify the path computation code. Remove the sub-directory search part, as we are not using sub-directories to further organize hooks of a particular type.