### PR TITLE
Add hooks for langchain and seedir

### DIFF
--- a/news/681.new.1.rst
+++ b/news/681.new.1.rst
@@ -1,0 +1,2 @@
+Add hook for ``seedir`` that collects the ``words.txt`` data file from
+the package.

--- a/news/681.new.rst
+++ b/news/681.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``langchain`` that collects data files from the package.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -164,6 +164,7 @@ eth-rlp==1.0.0
 z3c.rml==4.4.0
 freetype-py==2.4.0
 vaderSentiment==3.3.2
+langchain==0.0.353
 
 # ------------------- Platform (OS) specifics
 

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -165,6 +165,7 @@ z3c.rml==4.4.0
 freetype-py==2.4.0
 vaderSentiment==3.3.2
 langchain==0.0.353
+seedir==0.4.2
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-langchain.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-langchain.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('langchain')

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-seedir.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-seedir.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('seedir')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1852,3 +1852,10 @@ def test_vadersentiment(pyi_builder):
         import vaderSentiment.vaderSentiment
         vaderSentiment.vaderSentiment.SentimentIntensityAnalyzer()
     """)
+
+
+@importorskip('langchain')
+def test_langchain_llm_summarization_checker(pyi_builder):
+    pyi_builder.test_source("""
+        import langchain.chains.llm_summarization_checker.base
+    """)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1859,3 +1859,10 @@ def test_langchain_llm_summarization_checker(pyi_builder):
     pyi_builder.test_source("""
         import langchain.chains.llm_summarization_checker.base
     """)
+
+
+@importorskip('seedir')
+def test_seedir(pyi_builder):
+    pyi_builder.test_source("""
+        import seedir
+    """)


### PR DESCRIPTION
Add hooks for `langchain` and `seedir` to collect data files from these packages.

See:
https://github.com/orgs/pyinstaller/discussions/8197
and 
https://github.com/pyinstaller/pyinstaller/issues/8205


