### PR TITLE
hooks: fix pypylon hook for PyInstaller 6.0 and later

### DIFF
--- a/news/691.update.rst
+++ b/news/691.update.rst
@@ -1,0 +1,1 @@
+Update ``pypylon`` hook for compatibility with PyInstaller 6.0 and later.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -171,6 +171,7 @@ seedir==0.4.2
 cel-python==0.1.5
 pygwalker==0.4.2
 eth-hash==0.6.0
+pypylon==3.0.1
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1888,3 +1888,10 @@ def test_pygwalker(pyi_builder):
     pyi_builder.test_source("""
         import pygwalker
     """)
+
+
+@importorskip('pypylon')
+def test_pypylon(pyi_builder):
+    pyi_builder.test_source("""
+        from pypylon import pylon
+    """)


### PR DESCRIPTION
Fix the `pypylon` hook for compatibility with PyInstaller >= 6.0. The `collect_data_files(..., include_py_files=True)` does not include binary extensions anymore, and PyInstaller 6.2 (pyinstaller/pyinstaller@ecc218c) fixed the module exclusion for relative imports; so the extensions that hook tries to exclude actually end up excluded without being collected via the alternative codepath.

Presumably that part of hook was needed on older PyInstaller versions, so keep it around, but disable it for PyInstaller >= 6.0.

Fixes #689.