### PR TITLE
hooks: add hook for fairscale

### DIFF
--- a/news/692.new.rst
+++ b/news/692.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``fairscale`` to collect its source .py files for
+TorchScript/JIT.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-fairscale.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-fairscale.py
@@ -1,0 +1,14 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# Collect source .py files for JIT/torchscript. Requires PyInstaller >= 5.3, no-op in older versions.
+module_collection_mode = 'pyz+py'

--- a/src/_pyinstaller_hooks_contrib/tests/test_deep_learning.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_deep_learning.py
@@ -285,7 +285,7 @@ def test_gpytorch_simple_gp_regression(pyi_builder):
     """)
 
 
-# Basic import test for fvcore.nn, which shows that we need to collect its source.py files for TorchScript/JIT.
+# Basic import test for fvcore.nn, which shows that we need to collect its source .py files for TorchScript/JIT.
 @importorskip('fvcore')
 @onedir_only
 def test_fvcore(pyi_builder):
@@ -294,7 +294,7 @@ def test_fvcore(pyi_builder):
     """)
 
 
-# Basic test for detectron2, which shows that we need to collect its source.py files for TorchScript/JIT.
+# Basic test for detectron2, which shows that we need to collect its source .py files for TorchScript/JIT.
 @importorskip('detectron2')
 @onedir_only
 def test_detectron2(pyi_builder):
@@ -349,4 +349,13 @@ def test_accelerate(pyi_builder):
         model, optimizer = accelerator.prepare(model, optimizer)
         print("Model:", model)
         print("Optimizer:", optimizer)
+    """)
+
+
+# Basic import test for fairscale, which shows that we need to collect its source .py files for TorchScript/JIT.
+@importorskip('fairscale')
+@onedir_only
+def test_fairscale(pyi_builder):
+    pyi_builder.test_source("""
+        import fairscale
     """)


### PR DESCRIPTION
Add hook for `fairscale` to collect its source .py files for torchscript/JIT.

Add a basic import test that demonstrates the need for that.