### PR TITLE
Improve osgeo hook

### DIFF
--- a/news/693.update.rst
+++ b/news/693.update.rst
@@ -1,0 +1,1 @@
+    Fix hook for ``osgeo``, to include proj data files.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-osgeo.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-osgeo.py
@@ -39,8 +39,8 @@ is_conda = False
 
 # Auxiliary data:
 #
-# - general case (data in 'osgeo/data/gdal'):
-datas = collect_data_files('osgeo', subdir=os.path.join('data', 'gdal'))
+# - general case (data in 'osgeo/data'):
+datas = collect_data_files('osgeo', subdir='data')
 
 # check if the data has been effectively found in 'osgeo/data/gdal'
 if len(datas) == 0:

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1896,6 +1896,7 @@ def test_pypylon(pyi_builder):
         from pypylon import pylon
     """)
 
+
 @importorskip('osgeo')
 def test_osgeo(pyi_builder):
     pyi_builder.test_source("""
@@ -1904,3 +1905,4 @@ def test_osgeo(pyi_builder):
         sr.ImportFromEPSG(4326)
         assert(sr.EPSGTreatsAsLatLong())
     """)
+    

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1905,4 +1905,3 @@ def test_osgeo(pyi_builder):
         sr.ImportFromEPSG(4326)
         assert(sr.EPSGTreatsAsLatLong())
     """)
-    

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1895,3 +1895,12 @@ def test_pypylon(pyi_builder):
     pyi_builder.test_source("""
         from pypylon import pylon
     """)
+
+@importorskip('osgeo')
+def test_osgeo(pyi_builder):
+    pyi_builder.test_source("""
+        from osgeo import osr
+        sr = osr.SpatialReference()
+        sr.ImportFromEPSG(4326)
+        assert(sr.EPSGTreatsAsLatLong())
+    """)


### PR DESCRIPTION
Had issues trying to use GDAL (using the unofficial windows binaries), when loading a chart with EPSG coordinates.  This required the data/proj folder to be bundled as well.