### PR TITLE
hooks: IPython: update exclude list for GUI frameworks

### DIFF
--- a/news/708.update.rst
+++ b/news/708.update.rst
@@ -1,0 +1,2 @@
+Update the exclude list for GUI frameworks in the ``IPython`` hook with
+additional contemporary Qt bindings (``PySide2``, ``PySide6``, and ``PyQt6``).

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-IPython.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-IPython.py
@@ -19,7 +19,16 @@ from PyInstaller.utils.hooks import collect_data_files
 # Ignore GUI libraries. IPython supports integration with GUI frameworks.
 # Assume that it will be imported by any other module when the user really
 # uses it.
-excludedimports = ['gtk', 'matplotlib', 'PyQt4', 'PyQt5', 'PySide']
+excludedimports = [
+    'gtk',
+    'matplotlib',
+    'PySide',
+    'PyQt4',
+    'PySide2',
+    'PyQt5',
+    'PySide6',
+    'PyQt6',
+]
 
 # IPython uses 'tkinter' for clipboard access on Linux/Unix. Exclude it on Windows and OS X.
 if is_win or is_darwin:


### PR DESCRIPTION
Update exclude list for GUI frameworks with contemporary Qt bindings (`PySide2`, `PySide6`, and `PyQt6`).