### PR TITLE
hooks: update pyqtgraph hook to use Qt bindings selection helper

### DIFF
--- a/news/710.update.rst
+++ b/news/710.update.rst
@@ -1,0 +1,4 @@
+Update ``pyqtgraph`` hook to use the helper for automatic Qt bindings
+selection and exclusion from PyInstaller >= 6.5 (no-op with earlier
+versions). This should help preventing multiple Qt bindings from
+being collected into frozen application.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyqtgraph.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyqtgraph.py
@@ -41,3 +41,16 @@ hiddenimports = [name for name in all_imports if "Template" in name]
 # hook to handle the pyqtgraph's multiprocessing implementation. The pyqtgraph.multiprocess seems to be imported
 # automatically on the import of pyqtgraph itself, so there is no point in creating a separate hook for this.
 hiddenimports += ['pyqtgraph.multiprocess.bootstrap']
+
+# Attempt to auto-select applicable Qt bindings and exclude extraneous Qt bindings.
+# Available in PyInstaller >= 6.5, which has `PyInstaller.utils.hooks.qt.exclude_extraneous_qt_bindings` helper.
+try:
+    from PyInstaller.utils.hooks.qt import exclude_extraneous_qt_bindings
+except ImportError:
+    pass
+else:
+    # Use the helper's default preference order, to keep it consistent across multiple hooks that use the same helper.
+    excludedimports = exclude_extraneous_qt_bindings(
+        hook_name="hook-pyqtgraph",
+        qt_bindings_order=None,
+    )

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1246,19 +1246,19 @@ def test_pyshark(pyi_builder):
     )
 
 
-@importorskip('pyqtgraph')
 @importorskip('PyQt5')
+@importorskip('pyqtgraph')
 def test_pyqtgraph(pyi_builder):
     pyi_builder.test_source(
         """
         import pyqtgraph.graphicsItems.PlotItem
         import pyqtgraph.graphicsItems.ViewBox.ViewBoxMenu
         import pyqtgraph.imageview.ImageView
-        """,
-        pyi_args=['--exclude', 'PySide2', '--exclude', 'PySide6', '--exclude', 'PyQt6']
+        """
     )
 
 
+@importorskip('PyQt5')
 @importorskip('pyqtgraph')
 def test_pyqtgraph_colormap(pyi_builder):
     pyi_builder.test_source(
@@ -1269,8 +1269,8 @@ def test_pyqtgraph_colormap(pyi_builder):
     )
 
 
-@importorskip('pyqtgraph')
 @importorskip('PyQt5')
+@importorskip('pyqtgraph')
 def test_pyqtgraph_remote_graphics_view(pyi_builder):
     pyi_builder.test_source(
         """
@@ -1305,8 +1305,7 @@ def test_pyqtgraph_remote_graphics_view(pyi_builder):
         QtCore.QTimer.singleShot(1000, app.exit)
 
         sys.exit(app.exec_())
-        """,
-        pyi_args=['--exclude', 'PySide2', '--exclude', 'PySide6', '--exclude', 'PyQt6']
+        """
     )
 
 


### PR DESCRIPTION
Update `pyqtgraph` hook to use Qt bindings selection helper, which should help to automatically exclude extraneous Qt bindings, in order to prevent multiple Qt bindings from being collected. The change requires PyInstaller >= 6.5 (and should be no-op with earlier versions).

Remove the explicit excludes in `pyqtgraph` tests.