### PR TITLE
Fix up sspilib credential ordering

### DIFF
--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1768,8 +1768,8 @@ def test_sspilib(pyi_builder):
         )
 
         ctx = sspilib.ClientSecurityContext(
-            "host/server.domain.com",
             credential=cred,
+            target_name="host/server.domain.com",
         )
 
         print(ctx)


### PR DESCRIPTION
The change for `sspilib` https://github.com/jborean93/sspilib/pull/13 has changed the ordering of the arguments now that `credential` was deemed to be mandatory. While this was a breaking change this was the only example I found using GitHub search that showed an instance where the change would break. This PR uses kwargs to ensure it will work with the old and new syntax during the transition.