### PR TITLE
hooks: torch: add support for MKL-enabled torch builds

### DIFF
--- a/news/712.update.rst
+++ b/news/712.update.rst
@@ -1,0 +1,4 @@
+Update ``torch`` hook to add support for MKL-enabled ``torch`` builds
+on Windows (e.g., the nightly ``2.3.0.dev20240308+cpu`` build). The hook
+now attempts to discover and collect DLLs from MKL and its dependencies
+(``mkl``, ``tbb``, ``intel-openmp``).


### PR DESCRIPTION
Add support for MKL-enabled `torch` builds on Windows (e.g., the nightly `2.3.0.dev20240308+cpu` build). The `torch` hook now attempts to discover and collect DLLs from MKL and its dependencies (`mkl`, `tbb`, `intel-openmp`).

This should prevent frozen program from silently crashing due to missing MKL DLLs, which slip past PyInstaller's binary dependency analysis due to being dynamically loaded at run time.

Closes pyinstaller/pyinstaller#8348.