### PR TITLE
hooks: collect `cloudpickle_fast` from `numba.cloudpickle` and `cloudpickle`

### DIFF
--- a/news/716.new.rst
+++ b/news/716.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``cloudpickle`` to ensure that ``cloudpickle.cloudpickle_fast``
+is collected when using ``cloudpickle`` v3.0.0 or later.

--- a/news/716.update.rst
+++ b/news/716.update.rst
@@ -1,0 +1,2 @@
+Update ``numba`` hook to ensure that ``numba.cloudpickle.cloudpickle_fast``
+is collected when using ``numba`` v0.59.0 or later.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -19,6 +19,7 @@ cassandra-driver==3.29.0
 cf-units==3.2.0; sys_platform != 'win32'
 cftime==1.6.3
 charset_normalizer==3.3.2
+cloudpickle==3.0.0
 cloudscraper==1.2.71
 # compliance-checker requires cf-units, so same constraints apply.
 compliance-checker==5.1.0; sys_platform != 'win32'

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -53,6 +53,7 @@ moviepy==1.0.3
 mnemonic==0.21
 msoffcrypto-tool==5.3.1
 netCDF4==1.6.5
+numba==0.59.1; python_version >= '3.9'
 numcodecs==0.12.1
 Office365-REST-Python-Client==2.5.6
 openpyxl==3.1.2

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cloudpickle.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cloudpickle.py
@@ -1,0 +1,18 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import is_module_satisfies
+
+# cloudpickle to 3.0.0 keeps `cloudpickle_fast` module around for backward compatibility with existing pickled data,
+# but does not import it directly anymore. Ensure it is collected nevertheless.
+if is_module_satisfies("cloudpickle >= 3.0.0"):
+    hiddenimports = ["cloudpickle.cloudpickle_fast"]

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-numba.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-numba.py
@@ -16,5 +16,12 @@
 # Tested with:
 # numba 0.26 (Anaconda 4.1.1, Windows), numba 0.28 (Linux)
 
+from PyInstaller.utils.hooks import is_module_satisfies
+
 excludedimports = ["IPython", "scipy"]
 hiddenimports = ["llvmlite"]
+
+# numba 0.59.0 updated its vendored version of cloudpickle to 3.0.0; this version keeps `cloudpickle_fast` module
+# around for backward compatibility with existing pickled data, but does not import it directly anymore.
+if is_module_satisfies("numba >= 0.59.0"):
+    hiddenimports += ["numba.cloudpickle.cloudpickle_fast"]

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1934,3 +1934,17 @@ def test_numba_cloudpickle_fast(pyi_builder):
         modname = "numba.cloudpickle.cloudpickle_fast"
         mod = importlib.import_module(modname)
     """)
+
+
+# Check that `cloudpickle.cloudpickle_fast` is collected even if it is not directly imported anywhere.
+@importorskip('cloudpickle')
+def test_cloudpickle_fast(pyi_builder):
+    pyi_builder.test_source("""
+        # Assume the application or its dependencies import cloudpickle somewhere.
+        import cloudpickle
+
+        # Simulate indirect import of `cloudpickle.cloudpickle_fast`that would happen during data unpickling.
+        import importlib
+        modname = "cloudpickle.cloudpickle_fast"
+        mod = importlib.import_module(modname)
+    """)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1920,3 +1920,17 @@ def test_iso639(pyi_builder):
         from iso639 import Lang
         test = Lang("en")
     """)
+
+
+# Check that `numba.cloudpickle.cloudpickle_fast` is collected even if it is not directly imported anywhere.
+@importorskip('numba')
+def test_numba_cloudpickle_fast(pyi_builder):
+    pyi_builder.test_source("""
+        # Assume the application or its dependencies import numba somewhere.
+        import numba
+
+        # Simulate indirect import of `numba.cloudpickle.cloudpickle_fast`that would happen during data unpickling.
+        import importlib
+        modname = "numba.cloudpickle.cloudpickle_fast"
+        mod = importlib.import_module(modname)
+    """)


### PR DESCRIPTION
Update `numba` hook to ensure that `numba.cloudpickle.cloudpickle_fast` is collected when using `numba` v0.59.0 or later.

Add hook for `cloudpickle` to ensure that `cloudpickle.cloudpickle_fast` is collected when using `cloudpickle` v3.0.0 or later.

In `cloudpickle` v3.0.0 (upstream or vendored version in `numba`), the `cloudpickle_fast` module became a compatibility shim for unpickling data that was pickled with earlier versions. However, it is not directly imported from the `cloudpickle` package anymore. Therefore, it ends up missing from the frozen application and results in error when trying to unpickle data. See pyinstaller/pyinstaller#8337.