### PR TITLE
hooks: netCDF4: explicitly collect files from netCDF4.libs

### DIFF
--- a/news/722.update.rst
+++ b/news/722.update.rst
@@ -1,0 +1,6 @@
+(Windows) Update ``netCDF4`` hook to explicitly collect DLLs and
+load-order file (if present) from ``netCDF4.libs`` directory. This
+fixes ``DLL load failed while importing _netCDF4`` error when using
+Anaconda python 3.8 or 3.9, where ``delvewheel`` (used by ``netCDF4``)
+needs to load DLLs via load-order file due to defunct
+``os.add_dll_directory`` function.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-netCDF4.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-netCDF4.py
@@ -10,6 +10,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
+from PyInstaller.compat import is_win
 from PyInstaller.utils.hooks import is_module_satisfies
 
 # netCDF4 (tested with v.1.1.9) has some hidden imports
@@ -25,3 +26,12 @@ else:
 # netCDF4/_netCDF4.pyx.
 if is_module_satisfies("netCDF4 >= 1.6.4"):
     hiddenimports += ['certifi']
+
+# netCDF 1.6.2 is the first version that uses `delvewheel` for bundling DLLs in Windows PyPI wheels. While contemporary
+# PyInstaller versions automatically pick up DLLs from external `netCDF4.libs` directory, this does not work on Anaconda
+# python 3.8 and 3.9 due to defunct `os.add_dll_directory`, which forces `delvewheel` to use the old load-order file
+# approach. So we need to explicitly ensure that load-order file as well as DLLs are collected.
+if is_win and is_module_satisfies("netCDF4 >= 1.6.2"):
+    if is_module_satisfies("PyInstaller >= 5.6"):
+        from PyInstaller.utils.hooks import collect_delvewheel_libs_directory
+        datas, binaries = collect_delvewheel_libs_directory("netCDF4")


### PR DESCRIPTION
Use the `collect_delvewheel_libs_directory` helper to ensure that DLLs and load-order file (if present) are collected from `netCDF4.libs` directory.

While contemporary PyInstaller versions automatically pick up DLLs from that directory thanks to dynamic DLL search path tracking, that does not work with Anaconda python 3.8 and 3.9, where, due to defunct `os.add_dll_directory` function, `delvewheel` needs to load DLLs via the load-order file.

Closes pyinstaller/pyinstaller#8405.