### PR TITLE
hooks: add hook for opentelemetry

### DIFF
--- a/news/725.new.rst
+++ b/news/725.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``opentelemetry`` that collects all entry-points with
+``opentelemetry_`` prefix.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -176,6 +176,7 @@ pygwalker==0.4.7
 eth-hash==0.7.0
 pypylon==3.0.1
 python-pptx==0.6.23
+opentelemetry-sdk==1.24.0
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-opentelemetry.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-opentelemetry.py
@@ -1,0 +1,41 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_entry_point
+
+# All known `opentelementry_` entry-point groups
+ENTRY_POINT_GROUPS = (
+    'opentelemetry_context',
+    'opentelemetry_environment_variables',
+    'opentelemetry_id_generator',
+    'opentelemetry_logger_provider',
+    'opentelemetry_logs_exporter',
+    'opentelemetry_meter_provider',
+    'opentelemetry_metrics_exporter',
+    'opentelemetry_propagator',
+    'opentelemetry_resource_detector',
+    'opentelemetry_tracer_provider',
+    'opentelemetry_traces_exporter',
+    'opentelemetry_traces_sampler',
+)
+
+# Collect entry points
+datas = set()
+hiddenimports = set()
+
+for entry_point_group in ENTRY_POINT_GROUPS:
+    ep_datas, ep_hiddenimports = collect_entry_point(entry_point_group)
+    datas.update(ep_datas)
+    hiddenimports.update(ep_hiddenimports)
+
+datas = list(datas)
+hiddenimports = list(hiddenimports)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1957,3 +1957,25 @@ def test_pptx(pyi_builder):
         import pptx
         pptx.Presentation()
     """)
+
+
+@importorskip('opentelemetry.sdk')
+def test_opentelemetry(pyi_builder):
+    # Basic tracer example, taken from
+    # https://github.com/open-telemetry/opentelemetry-python/blob/main/docs/examples/basic_tracer/basic_trace.py
+    pyi_builder.test_source("""
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import (
+            BatchSpanProcessor,
+            ConsoleSpanExporter,
+        )
+
+        trace.set_tracer_provider(TracerProvider())
+        trace.get_tracer_provider().add_span_processor(
+            BatchSpanProcessor(ConsoleSpanExporter())
+        )
+        tracer = trace.get_tracer(__name__)
+        with tracer.start_as_current_span("foo"):
+            print("Hello world!")
+    """)


### PR DESCRIPTION
Add hook for `opentelemetry` that collects all entry-points with `opentelemetry_` prefix.

Closes pyinstaller/pyinstaller#8413.