### PR TITLE
hooks: pyproj: explicitly collect files from pyproj.libs

### DIFF
--- a/news/726.update.rst
+++ b/news/726.update.rst
@@ -1,0 +1,6 @@
+(Windows) Update ``pyproj`` hook to explicitly collect DLLs and
+load-order file (if present) from ``pyproj.libs`` directory. This
+fixes ``DLL load failed while importing _network`` error when using
+Anaconda python 3.8 or 3.9, where ``delvewheel`` (used by ``pyproj``)
+needs to load DLLs via load-order file due to defunct
+``os.add_dll_directory`` function.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyproj.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-pyproj.py
@@ -19,6 +19,8 @@ hiddenimports = [
     "pyproj.datadir"
 ]
 
+binaries = []
+
 # Versions prior to 2.3.0 also require pyproj._datadir
 if not is_module_satisfies("pyproj >= 2.3.0"):
     hiddenimports += ["pyproj._datadir"]
@@ -59,3 +61,12 @@ if is_conda:
 # `__init__.py`. This change was reverted in subsequent releases of pyproj, so we collect metadata only for 3.4.0.
 if is_module_satisfies("pyproj == 3.4.0"):
     datas += copy_metadata("pyproj")
+
+# pyproj 3.4.0 was also the first release that used `delvewheel` for its Windows PyPI wheels. While contemporary
+# PyInstaller versions automatically pick up DLLs from external `pyproj.libs` directory, this does not work on Anaconda
+# python 3.8 and 3.9 due to defunct `os.add_dll_directory`, which forces `delvewheel` to use the old load-order file
+# approach. So we need to explicitly ensure that load-order file as well as DLLs are collected.
+if is_win and is_module_satisfies("pyproj >= 3.4.0"):
+    if is_module_satisfies("PyInstaller >= 5.6"):
+        from PyInstaller.utils.hooks import collect_delvewheel_libs_directory
+        datas, binaries = collect_delvewheel_libs_directory("pyproj", datas=datas, binaries=binaries)


### PR DESCRIPTION
Use the `collect_delvewheel_libs_directory` helper to ensure that DLLs and load-order file (if present) are collected from `pyproj.libs` directory.

While contemporary PyInstaller versions automatically pick up DLLs from that directory thanks to dynamic DLL search path tracking, that does not work with Anaconda python 3.8 and 3.9, where, due to defunct `os.add_dll_directory` function, `delvewheel` needs to load DLLs via the load-order file.

Closes pyinstaller/pyinstaller#8415.