### PR TITLE
hooks: cryptography: collect OpenSSL >= 3.0.0 modules, if available

### DIFF
--- a/news/724.update.rst
+++ b/news/724.update.rst
@@ -1,0 +1,8 @@
+Extend ``cryptography`` hook to collect OpenSSL modules (the
+``ossl-modules`` directory) when available. Add a run-time hook that
+overrides OpenSSL module search path by setting the ``OPENSSL_MODULES``
+environment variable to the bundled ``ossl-modules`` directory. This
+fixes ``RuntimeError: OpenSSL 3.0's legacy provider failed to load.``
+error when using ``cryptography`` with OpenSSL >= 3.0 builds that have
+modules enabled (e.g., most Linux distributions, msys/MinGW on Windows,
+and Homebrew on macOS).

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -22,6 +22,7 @@ cloudpickle==3.0.0
 cloudscraper==1.2.71
 # compliance-checker requires cf-units, so same constraints apply.
 compliance-checker==5.1.0; sys_platform != 'win32'
+cryptography==42.0.5
 dash==2.16.1
 dash-bootstrap-components==1.6.0
 dash-uploader==0.6.0

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks.dat
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks.dat
@@ -1,4 +1,5 @@
 {
+    'cryptography': ['pyi_rth_cryptography_openssl.py'],
     'enchant': ['pyi_rth_enchant.py'],
     'ffpyplayer': ['pyi_rth_ffpyplayer.py'],
     'osgeo': ['pyi_rth_osgeo.py'],

--- a/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_cryptography_openssl.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/rthooks/pyi_rth_cryptography_openssl.py
@@ -1,0 +1,20 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2024, PyInstaller Development Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+#-----------------------------------------------------------------------------
+
+import os
+import sys
+
+# If we collected OpenSSL modules into `ossl-modules` directory, override the OpenSSL search path by setting the
+# `OPENSSL_MODULES` environment variable.
+_ossl_modules_dir = os.path.join(sys._MEIPASS, 'ossl-modules')
+if os.path.isdir(_ossl_modules_dir):
+    os.environ['OPENSSL_MODULES'] = _ossl_modules_dir
+del _ossl_modules_dir

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cryptography.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cryptography.py
@@ -13,12 +13,19 @@
 Hook for cryptography module from the Python Cryptography Authority.
 """
 
-import os.path
+import os
 import glob
+import pathlib
 
-from PyInstaller.compat import EXTENSION_SUFFIXES
-from PyInstaller.utils.hooks import collect_submodules, get_module_file_attribute
-from PyInstaller.utils.hooks import copy_metadata
+from PyInstaller import compat
+from PyInstaller import isolated
+from PyInstaller.utils.hooks import (
+    collect_submodules,
+    copy_metadata,
+    get_module_file_attribute,
+    is_module_satisfies,
+    logger,
+)
 
 # get the package data so we can load the backends
 datas = copy_metadata('cryptography')
@@ -34,9 +41,74 @@ hiddenimports += collect_submodules('cryptography.hazmat.bindings.openssl') + ['
 # The cffi verifier expects to find them inside the package directory for
 # the main module. We cannot use hiddenimports because that would add the modules
 # outside the package.
+# NOTE: this is not true anymore with PyInstaller >= 6.0, but we keep it like this for compatibility with 5.x series.
 binaries = []
 cryptography_dir = os.path.dirname(get_module_file_attribute('cryptography'))
-for ext in EXTENSION_SUFFIXES:
+for ext in compat.EXTENSION_SUFFIXES:
     ffimods = glob.glob(os.path.join(cryptography_dir, '*_cffi_*%s*' % ext))
     for f in ffimods:
         binaries.append((f, 'cryptography'))
+
+
+# Check if cryptography was built with support for OpenSSL >= 3.0.0. In that case, we might need to collect external
+# OpenSSL modules, if OpenSSL was built with modules support. It seems the best indication of this is the presence
+# of ossl-modules directory next to the OpenSSL shared library.
+try:
+    @isolated.decorate
+    def _check_cryptography_openssl3():
+        from cryptography.hazmat.backends.openssl.backend import backend
+        return bool(backend._lib.CRYPTOGRAPHY_OPENSSL_300_OR_GREATER)
+
+    uses_openssl3 = _check_cryptography_openssl3()
+except Exception:
+    logger.warning(
+        "hook-cryptography: failed to determine whether cryptography is using OpenSSL >= 3.0.0", exc_info=True
+    )
+    uses_openssl3 = False
+
+if uses_openssl3:
+    # Determine location of OpenSSL shared library.
+    # This requires the new PyInstaller.bindepend API from PyInstaller >= 6.0.
+    openssl_lib = None
+    if is_module_satisfies("PyInstaller >= 6.0"):
+        from PyInstaller.depend import bindepend
+
+        if compat.is_win:
+            # Resolve the given library name; first, search the python library directory for python-provided OpenSSL.
+            lib_name = 'libssl-3-x64.dll' if compat.is_64bits else 'libssl-3.dll'
+            openssl_lib = bindepend.resolve_library_path(lib_name, search_paths=[compat.base_prefix])
+        elif compat.is_darwin:
+            # First, attempt to resolve using only {sys.base_prefix}/lib - `bindepend.resolve_library_path` uses
+            # standard dyld search semantics and uses the given search paths as fallback (and would therefore
+            # favor Homebrew-provided version of the library).
+            lib_name = 'libssl.3.dylib'
+            base_prefix_lib_dir = os.path.join(compat.base_prefix, 'lib')
+            openssl_lib = bindepend._resolve_library_path_in_search_paths(lib_name, search_paths=[base_prefix_lib_dir])
+            if openssl_lib is None:
+                openssl_lib = bindepend.resolve_library_path(lib_name, search_paths=[base_prefix_lib_dir])
+        else:
+            # Linux and other POSIX systems
+            lib_name = 'libssl.so.3'
+            openssl_lib = bindepend.resolve_library_path(lib_name)
+    else:
+        logger.warning(
+            "hook-cryptography: full support for cryptography + OpenSSL >= 3.0.0 requires PyInstaller >= 6.0"
+        )
+
+    # Check for presence of ossl-modules directory next to the OpenSSL shared library.
+    if openssl_lib:
+        logger.debug("hook-cryptography: OpenSSL shared library location: %r", openssl_lib)
+
+        openssl_lib_dir = pathlib.Path(openssl_lib).parent
+
+        # Collect whole ossl-modules directory, if it exists.
+        ossl_modules_dir = openssl_lib_dir / 'ossl-modules'
+
+        # Msys2/MinGW installations on Windows put the shared library into `bin` directory, but the modules are
+        # located in `lib` directory. Account for that possibility.
+        if not ossl_modules_dir.is_dir() and openssl_lib_dir.name == 'bin':
+            ossl_modules_dir = openssl_lib_dir.parent / 'lib' / 'ossl-modules'
+
+        if ossl_modules_dir.is_dir():
+            logger.debug("hook-cryptography: collecting OpenSSL modules directory: %r", str(ossl_modules_dir))
+            binaries.append((str(ossl_modules_dir), 'ossl-modules'))

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1979,3 +1979,19 @@ def test_opentelemetry(pyi_builder):
         with tracer.start_as_current_span("foo"):
             print("Hello world!")
     """)
+
+
+# Basic test for cryptography package
+@importorskip('cryptography')
+def test_cryptography(pyi_builder):
+    pyi_builder.test_source("""
+        from cryptography.fernet import Fernet
+
+        key = Fernet.generate_key()
+        f = Fernet(key)
+
+        token = f.encrypt(b"This is test.")
+        print(f"Encrypted message: {token}")
+
+        print(f"Decrypted message: {f.decrypt(token)}")
+    """)


### PR DESCRIPTION
Have the `cryptography` hook collect OpenSSL >= 3.0.0 modules from `ossl-modules` directory, if available. Add a run-time hook that sets `OPENSSL_MODULES` environment variable to the bundled `ossl-modules` directory.

This is required for `cryptography` to work with recent OpenSSL versions, where legacy algorithms were put into separate legacy module. This module can be a separate shared library (e.g., on Linux in general, on Windows in msys2/MinGW, and on macOS in Homebrew), so we need to make sure we collect it.

Add a basic test for `cryptography`, since thus far we don't have any at all. It is mostly intended to ensure that the hook works at all. Testing that modules are properly collected and used is somewhat tricky, due to their conditional availability and due to the fact that if they are available, they can typically be resolved at run-time as well (i.e., without the first commit, the basic test passes on Linux, but it does not when ran under msys/MinGW python).

Closes #724.