### PR TITLE
hooks: add hook for xarray

### DIFF
--- a/news/728.new.rst
+++ b/news/728.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``xarray``, which ensures that metadata for ``numpy``
+(required by ``xarray``) is collected.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -175,6 +175,7 @@ eth-hash==0.7.0
 pypylon==3.0.1
 python-pptx==0.6.23
 opentelemetry-sdk==1.24.0
+xarray==2024.3.0; python_version >= '3.9'
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-xarray.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-xarray.py
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata
+
+# `xarray` requires `numpy` metadata due to several calls to its `xarray.core.utils.module_available` with specified
+# `minversion` argument, which end up calling `importlib.metadata.version`.
+datas = copy_metadata('numpy')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -1995,3 +1995,18 @@ def test_cryptography(pyi_builder):
 
         print(f"Decrypted message: {f.decrypt(token)}")
     """)
+
+
+@importorskip('xarray')
+def test_xarray(pyi_builder):
+    pyi_builder.test_source("""
+        import xarray as xr
+        import numpy as np
+
+        data = xr.DataArray(
+            np.random.randn(2, 3),
+            dims=("x", "y"),
+            coords={"x": [10, 20]},
+        )
+        print(data)
+    """)


### PR DESCRIPTION
Add hook for `xarray`, which ensures that metadata for `numpy` (required by `xarray`) is collected.

Closes pyinstaller/pyinstaller#8392. Closes pyinstaller/pyinstaller#8417.