### PR TITLE
hooks: gcloud: suppress errors

### DIFF
--- a/news/731.update.rst
+++ b/news/731.update.rst
@@ -1,0 +1,3 @@
+Suppress errors in ``gcloud`` hook that occur when the hook is triggered
+by the ``gcloud`` namespace package from ``gcloud-aio-*`` and ``gcloud-rest-*``
+dists instead of the ``gcloud`` package from the ``gcloud`` dist.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gcloud.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gcloud.py
@@ -12,4 +12,10 @@
 
 from PyInstaller.utils.hooks import copy_metadata
 
-datas = copy_metadata('gcloud')
+# This hook was written for `gcloud` - https://pypi.org/project/gcloud
+# Suppress package-not-found errors when the hook is triggered by `gcloud` namespace package from `gcloud-aio-*` and
+# `gcloud-rest-*˙ dists (https://github.com/talkiq/gcloud-aio).
+try:
+    datas = copy_metadata('gcloud')
+except Exception:
+    pass


### PR DESCRIPTION
Supress errors raised by `copy_metadata`; these may occur when the hook is triggered by the `gcloud` namespace package from `gcloud-aio-*` and `gcloud-rest-*` dists instead of the `gcloud` package from the `gcloud` dist.

Closes #730.