### PR TITLE
hooks: update tables hook to collect blosc2 shared library

### DIFF
--- a/news/732.update.rst
+++ b/news/732.update.rst
@@ -1,0 +1,3 @@
+Update hook for ``tables`` (PyTables) to collect bundled blosc2
+shared library, if available. On Windows, explicitly collect DLLs and
+load-order file (if present) from ``tables.libs`` directory.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -176,6 +176,7 @@ pypylon==3.0.1
 python-pptx==0.6.23
 opentelemetry-sdk==1.24.0
 xarray==2024.3.0; python_version >= '3.9'
+tables==3.9.2; python_version >= '3.9'
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tables.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-tables.py
@@ -10,5 +10,21 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
+from PyInstaller.compat import is_win
+from PyInstaller.utils.hooks import collect_dynamic_libs, is_module_satisfies
+
 # PyTables is a package for managing hierarchical datasets
 hiddenimports = ["tables._comp_lzo", "tables._comp_bzip2"]
+
+# Collect the bundled copy of blosc2 shared library.
+binaries = collect_dynamic_libs('tables')
+datas = []
+
+# tables 3.7.0 started using `delvewheel` for its Windows PyPI wheels. While contemporary PyInstaller versions
+# automatically pick up DLLs from external `pyproj.libs` directory, this does not work on Anaconda python 3.8 and 3.9
+# due to defunct `os.add_dll_directory`, which forces `delvewheel` to use the old load-order file approach. So we need
+# to explicitly ensure that load-order file as well as DLLs are collected.
+if is_win and is_module_satisfies("tables >= 3.7.0"):
+    if is_module_satisfies("PyInstaller >= 5.6"):
+        from PyInstaller.utils.hooks import collect_delvewheel_libs_directory
+        datas, binaries = collect_delvewheel_libs_directory("tables", datas=datas, binaries=binaries)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -2010,3 +2010,17 @@ def test_xarray(pyi_builder):
         )
         print(data)
     """)
+
+
+@importorskip('tables')
+def test_pytables(pyi_builder):
+    # NOTE: run_from_path=True prevents `pyi_builder` from completely clearing the `PATH` environment variable. At the
+    # time of writing, `cpu_info` (used by PyTables) raises error if `PATH` is missing from `os.environ`.
+    pyi_builder.test_source("""
+        # `tables` uses cpu_info package during initialization, which in turn uses `multiprocessing`, so we need to call
+        # `multiprocessing.freeze_support()` before importing `tables`.
+        import multiprocessing
+        multiprocessing.freeze_support()
+
+        import tables
+    """, run_from_path=True)


### PR DESCRIPTION
Update hook for `tables` (PyTables) to collect blosc2 shared library that may be bundled with the package (PyPI wheels).

Also use the `collect_delvewheel_libs_directory` helper to ensure that DLLs and load-order file (if present) are collected from `tables.libs` directory (Windows PyPI wheels).

Closes pyinstaller/pyinstaller#8419.