### PR TITLE
hooks: cryptography: work-around for Alpine linux

### DIFF
--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cryptography.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cryptography.py
@@ -90,6 +90,11 @@ if uses_openssl3:
             # Linux and other POSIX systems
             lib_name = 'libssl.so.3'
             openssl_lib = bindepend.resolve_library_path(lib_name)
+            if openssl_lib is None and compat.is_musl:
+                # Work-around for bug in `bindepend.resolve_library_path` in PyInstaller 6.x, <= 6.6; for search without
+                # ldconfig cache (for example, with musl libc on Alpine linux), we need library name without suffix.
+                lib_name = 'libssl'
+                openssl_lib = bindepend.resolve_library_path(lib_name)
     else:
         logger.warning(
             "hook-cryptography: full support for cryptography + OpenSSL >= 3.0.0 requires PyInstaller >= 6.0"

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cryptography.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-cryptography.py
@@ -114,6 +114,11 @@ if uses_openssl3:
         if not ossl_modules_dir.is_dir() and openssl_lib_dir.name == 'bin':
             ossl_modules_dir = openssl_lib_dir.parent / 'lib' / 'ossl-modules'
 
+        # On Alpine linux, the true location of shared library is /lib directory, but the modules' directory is located
+        # in /usr/lib instead. Account for that possibility.
+        if not ossl_modules_dir.is_dir() and openssl_lib_dir == pathlib.Path('/lib'):
+            ossl_modules_dir = pathlib.Path('/usr/lib/ossl-modules')
+
         if ossl_modules_dir.is_dir():
             logger.debug("hook-cryptography: collecting OpenSSL modules directory: %r", str(ossl_modules_dir))
             binaries.append((str(ossl_modules_dir), 'ossl-modules'))


### PR DESCRIPTION
Follow-up to #727, with additional work-arounds for Alpine linux: 
- with current version of PyInstaller, we need to call `bindepend.resolve_library_path` with `libssl` (library name without suffix) in order for search to work when `ldconfig` cache is unavailable (Alpine linux and other musl-based systems)
- while the `libssl.so.3` is located in `/lib`, the `ossl-modules` directory is located in `/usr/lib`, so add additional check for that