### PR TITLE
hooks: add hook for backports namespace package

### DIFF
--- a/news/735.new.rst
+++ b/news/735.new.rst
@@ -1,0 +1,3 @@
+Add hook for ``backports`` package, to accommodate the ``pkgutil``-style
+``backports`` namespace package provided by ``backports.functools-lru-cache``
+and the latest release of ``backports.tarfile``.

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-backports.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-backports.py
@@ -1,0 +1,20 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# Some of jaraco's backports packages (backports.functools-lru-cache, backports.tarfile) use pkgutil-style `backports`
+# namespace package, with `__init__.py` file that contains:
+#
+# __path__ = __import__('pkgutil').extend_path(__path__, __name__)
+#
+# This import via `__import__` function slips past PyInstaller's modulegraph analysis; so add a hidden import, in case
+# the user's program (and its dependencies) have no other direct imports of `pkgutil`.
+hiddenimports = ['pkgutil']


### PR DESCRIPTION
Add hook for `backports` package, to accommodate the `pkgutil`-style `backports` namespace package provided by `backports.functools-lru-cache` and the latest release of `backports.tarfile`.

The `__init__.py` file from this `backports` namespace package uses `__import('pkgutil')__`, which slips past PyInstaller's modulegraph analysis, hence we need a hidden import.

This should fix the macOS test failures from yesterday's CI run in the main PyInstaller repository: https://github.com/pyinstaller/pyinstaller/actions/runs/8791000204/job/24124262352 
The culprit `keyring`, which imports `jaraco.context`, which (on python < 3.12) imports `backports.tarfile`, which added `pkgutil`-style namespace package in the recent 1.1.1 release