### PR TITLE
Add PyInstaller >= 5.0 guard in cryptography and pylsl hooks

### DIFF
--- a/news/737.update.1.rst
+++ b/news/737.update.1.rst
@@ -1,0 +1,3 @@
+Allow ``pylsl`` hook to run under PyInstaller versions older
+than 5.0, until support for those PyInstaller versions is formally
+dropped.

--- a/news/737.update.rst
+++ b/news/737.update.rst
@@ -1,0 +1,3 @@
+Allow ``cryptography`` hook to run under PyInstaller versions older
+than 5.0, until support for those PyInstaller versions is formally
+dropped.


### PR DESCRIPTION
Add PyInstaller >= 5.0 guard in `cryptography` and `pylsl` hooks, so that the hooks may be ran (albeit with reduced or no-op functionality) under PyInstaller < 5.0, until support for those PyInstaller versions is formally dropped.

Closes #736.