### PR TITLE
hooks: add hook for dbus_fast

### DIFF
--- a/news/600.new.rst
+++ b/news/600.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``dbus_fast`` in order to collect submodules that are imported
+from cythonized extensions.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -184,6 +184,9 @@ schwifty==2024.5.3
 # eccodes package requires the eccodes shared library provided by the environment (linux distribution, homebrew, or Anaconda).
 eccodes==1.7.0; sys_platform == 'darwin' or sys_platform == 'linux'
 
+# dbus-fast has pre-built wheels only for Linux; and D-Bus is available only there, anyway.
+dbus-fast==2.21.2; sys_platform == 'linux'
+
 # PyEnchant only pre-builds macOS and Windows
 pyenchant==3.2.2; sys_platform == 'darwin' or sys_platform == 'win32'
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dbus_fast.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-dbus_fast.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_submodules
+
+# Collect all submodules to handle imports made from cythonized extensions.
+hiddenimports = collect_submodules('dbus_fast')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -2057,3 +2057,43 @@ def test_eccodes_gribapi(pyi_builder):
 
         assert os.path.isfile(lib_filename), f"Shared library {lib_filename!s} not found!"
     """)
+
+
+@importorskip('dbus_fast')
+def test_dbus_fast(pyi_builder):
+    pyi_builder.test_source("""
+        import os
+        import sys
+        import asyncio
+        import json
+
+        from dbus_fast import Message, MessageType
+        from dbus_fast.aio import MessageBus
+
+
+        async def main():
+            # Connect to bus
+            try:
+                bus = await MessageBus().connect()
+            except Exception as e:
+                print(f"Could not connect to bus: {e}")
+                return
+
+            # List all available names
+            reply = await bus.call(
+                Message(
+                    destination="org.freedesktop.DBus",
+                    path="/org/freedesktop/DBus",
+                    interface="org.freedesktop.DBus",
+                    member="ListNames",
+                )
+            )
+
+            if reply.message_type == MessageType.ERROR:
+                raise Exception(reply.body[0])
+
+            print(json.dumps(reply.body[0], indent=2))
+
+
+        asyncio.run(main())
+    """)


### PR DESCRIPTION
Add hook for `dbus_fast` in order to collect submodules that are imported from cythonized extensions.

Closes #660.