### PR TITLE
Improve support for cfgrib

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -100,6 +100,8 @@ jobs:
           # These are dependencies of gmsh
           sudo apt-get install -y libglu1 libgl1 libxrender1 libxcursor1 libxft2 \
             libxinerama1 libgomp1
+          # This one is required by eccodes
+          sudo apt-get install -y libeccodes0
 
       - name: Install brew dependencies
         if: startsWith(matrix.os, 'macos')
@@ -112,6 +114,8 @@ jobs:
           brew install libdiscid
           # Install lsl library for pylsl
           brew install labstreaminglayer/tap/lsl
+          # This one is required by eccodes
+          brew install eccodes
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -43,9 +43,11 @@ jobs:
         run: |
           git fetch origin ${{ github.base_ref }}
           set +e
-          diff --changed-group-format='%>' --unchanged-group-format='' \
+          # NOTE: we need to be compatible with both GNU diff and Apple/FreeBSD diff
+          diff \
             <(git show origin/${{ github.base_ref }}:requirements-test-libraries.txt) \
             <(git show HEAD:requirements-test-libraries.txt) \
+            | grep -E "^>" | sed "s/^> //" \
           > requirements-test-libraries.txt
           set -e
           echo '-r requirements-test.txt' >> requirements-test-libraries.txt

--- a/news/744.new.rst
+++ b/news/744.new.rst
@@ -1,0 +1,3 @@
+Add hook for ``gribapi`` package from ``eccodes`` dist, in order to
+collect bundled headers and ensure that the eccodes shared library is
+collected from the build environment.

--- a/news/744.update.rst
+++ b/news/744.update.rst
@@ -1,0 +1,2 @@
+Extend the ``xarray`` hook to collect additional backend plugins that are
+registered via the ``xarray.backends`` entry-point (e.g., ``cfgrib``).

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -181,6 +181,9 @@ schwifty==2024.5.3
 
 # ------------------- Platform (OS) specifics
 
+# eccodes package requires the eccodes shared library provided by the environment (linux distribution, homebrew, or Anaconda).
+eccodes==1.7.0; sys_platform == 'darwin' or sys_platform == 'linux'
+
 # PyEnchant only pre-builds macOS and Windows
 pyenchant==3.2.2; sys_platform == 'darwin' or sys_platform == 'win32'
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gribapi.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-gribapi.py
@@ -1,0 +1,42 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+import os
+
+from PyInstaller.utils.hooks import collect_data_files, get_module_attribute, logger
+
+# Collect the headers (eccodes.h, gribapi.h) that are bundled with the package.
+datas = collect_data_files('gribapi')
+
+# Collect the eccodes shared library
+binaries = []
+try:
+    library_path = get_module_attribute('gribapi.bindings', 'library_path')
+except Exception:
+    logger.warning("hook-gribapi: failed to query gribapi.bindings.library_path!", exc_info=True)
+    library_path = None
+
+if library_path:
+    if not os.path.isabs(library_path):
+        from PyInstaller.depend.utils import _resolveCtypesImports
+        resolved_binary = _resolveCtypesImports([os.path.basename(library_path)])
+        if resolved_binary:
+            library_path = resolved_binary[0][1]
+        else:
+            logger.warning("hook-gribapi: failed to resolve shared library name %r!", library_path)
+            library_path = None
+else:
+    logger.warning("hook-gribapi: could not determine path to eccodes shared library!")
+
+if library_path:
+    logger.debug("hook-gribapi: collecting eccodes shared library: %r", library_path)
+    binaries.append((library_path, '.'))

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-xarray.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-xarray.py
@@ -10,8 +10,11 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import copy_metadata
+from PyInstaller.utils.hooks import copy_metadata, collect_entry_point
+
+# Collect additional backend plugins that are registered via `xarray.backends` entry-point.
+datas, hiddenimports = collect_entry_point('xarray.backends')
 
 # `xarray` requires `numpy` metadata due to several calls to its `xarray.core.utils.module_available` with specified
 # `minversion` argument, which end up calling `importlib.metadata.version`.
-datas = copy_metadata('numpy')
+datas += copy_metadata('numpy')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -2036,3 +2036,24 @@ def test_schwifty(pyi_builder):
         print(iban.bank_code)
         print(iban.account_code)
     """)
+
+
+@importorskip('gribapi')
+def test_eccodes_gribapi(pyi_builder):
+    pyi_builder.test_source("""
+        import sys
+        import os
+
+        # Basic import test
+        import gribapi
+
+        # Ensure that the eccodes shared library is bundled with the frozen application.
+        import gribapi.bindings
+
+        lib_filename = os.path.join(
+            sys._MEIPASS,
+            os.path.basename(gribapi.bindings.library_path),
+        )
+
+        assert os.path.isfile(lib_filename), f"Shared library {lib_filename!s} not found!"
+    """)


### PR DESCRIPTION
Extend the `xarray` hook to collect additional backend plugins that are registered via the `xarray.backends` entry-point (e.g., `cfgrib`).

Add hook for `gribapi` package from `eccodes` dist, in order to collect bundled headers and ensure that the eccodes shared library is collected from the build environment.

Manually tested on Windows with Anaconda with program that tries to read a grib file. 

The `test_eccodes_gribapi` might pass on linux, but in reality, the collected shared library cannot yet be discovered (and so the system copy is used). For this to properly work, we will need to add an override for POSIX implementation of `ctypes.util.find_library` in PyInstaller's bootstrap/loader, which would explicitly search for matching filenames in `sys._MEIPASS`.

Closes #744.