### PR TITLE
Add hook for patoolib

### DIFF
--- a/news/748.new.rst
+++ b/news/748.new.rst
@@ -1,0 +1,1 @@
+add hook for `patoolib` which has a hidden import to its `programs` submodule.

--- a/news/748.new.rst
+++ b/news/748.new.rst
@@ -1,1 +1,2 @@
-add hook for `patoolib` which has a hidden import to its `programs` submodule.
+Add hook for ``patoolib`` to collect dynamically-imported modules from
+the ``patoolib.programs`` sub-package.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -178,7 +178,7 @@ opentelemetry-sdk==1.24.0
 xarray==2024.5.0; python_version >= '3.9'
 tables==3.9.2; python_version >= '3.9'
 schwifty==2024.5.3
-patool==2.2.0
+patool==2.2.0; python_version >= '3.10'
 
 # ------------------- Platform (OS) specifics
 

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -178,6 +178,7 @@ opentelemetry-sdk==1.24.0
 xarray==2024.5.0; python_version >= '3.9'
 tables==3.9.2; python_version >= '3.9'
 schwifty==2024.5.3
+patool==2.2.0
 
 # ------------------- Platform (OS) specifics
 

--- a/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-patoolib.py
+++ b/src/_pyinstaller_hooks_contrib/hooks/stdhooks/hook-patoolib.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2017-2024, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+"""
+patoolib uses importlib and pyinstaller doesn't find it and add it to the list of needed modules
+"""
+
+from PyInstaller.utils.hooks import collect_submodules
+hiddenimports = collect_submodules('patoolib.programs')

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -2102,9 +2102,6 @@ def test_dbus_fast(pyi_builder):
 @importorskip('patoolib')
 def test_patoolib(pyi_builder):
     pyi_builder.test_source("""
-
         import patoolib
-
         patoolib.is_archive(".")
-
     """)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -2103,5 +2103,18 @@ def test_dbus_fast(pyi_builder):
 def test_patoolib(pyi_builder):
     pyi_builder.test_source("""
         import patoolib
-        patoolib.is_archive(".")
+
+        archive = 'archive.zip'
+
+        # The call to `get_archive_cmdlist_func` triggers import of module from `patoolib.programs` via
+        # `importlib.import_module`; the set up below is based on code from `patoolib._extract_archive`.
+        archive_format, compression = patoolib.get_archive_format(archive)
+        print(f"Archive format: {archive_format}")
+        print(f"Compression: compression")
+
+        program = patoolib.find_archive_program(archive_format, 'extract')
+        print(f"Program: {program}")
+
+        cmdlist = patoolib.get_archive_cmdlist_func(program, 'extract', archive_format)
+        print(f"Cmdlist: {cmdlist}")
     """)

--- a/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
+++ b/src/_pyinstaller_hooks_contrib/tests/test_libraries.py
@@ -2097,3 +2097,14 @@ def test_dbus_fast(pyi_builder):
 
         asyncio.run(main())
     """)
+
+
+@importorskip('patoolib')
+def test_patoolib(pyi_builder):
+    pyi_builder.test_source("""
+
+        import patoolib
+
+        patoolib.is_archive(".")
+
+    """)


### PR DESCRIPTION
test run here: https://github.com/mtayeldev/pyinstaller-hooks-contrib/actions/runs/9180607046 (for some reason it fails for unrelated test cases)

original issue: https://github.com/pyinstaller/pyinstaller/issues/3013