### PR TITLE
tests: disable summary of xpassed/xfailed tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,9 +49,11 @@ extend-ignore = E265
 max-line-length=120
 
 [tool:pytest]
-# Display summary info for (s)skipped, (x)xfailed, (X)xpassed, (f)failed and (E)errored tests
+# Display summary info for (s)skipped, (f)failed and (E)errored tests.
+# Do not enable summary for (x)xfailed and (X)xpassed tests, because as
+# of pytest-dev/pytest#11233, this includes full tracebacks.
 # Skip doctest text files
-addopts=--maxfail=3 -m "not slow" -v -rsxXfE --doctest-glob=
+addopts=--maxfail=3 -m "not slow" -v -rsfE --doctest-glob=
 
 markers =
     darwin: only run on macOS


### PR DESCRIPTION
With pytest-dev/pytest#11233, enabling summaries for xfailed tests also enables their full error tracebacks, which complicates finding the actual test failures. There is no way of disabling just the tracebacks, so disable the summaries of xpassed/xfailed tests altogether.