### PR TITLE
Fix release tag/version management

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,32 +25,32 @@ jobs:
       - name: Install Dependencies
         run: python -m pip install --upgrade -r requirements-release.txt
 
+      - name: Bump version
+        run: python setup.py bump --build
+
+      - name: Build Changelog
+        run: python -m towncrier --yes
+
       - name: Build & Validate Bundles
         run: |
           python setup.py sdist bdist_wheel
           python -m twine check dist/*
-
-      - name: Build Changelog
-        run: python -m towncrier --yes
 
       - name: Upload to PyPI
         env:
           TWINE_PASSWORD: ${{ secrets.TWINETOKEN }}
         run: python -m twine upload dist/* --disable-progress-bar -u __token__ --non-interactive
 
-      - name: Create Git Tag
-        run: git tag v$(python setup.py --version)
-
-      - name: Bump version, and commit changes back into the repository
+      - name: Commit changes and publish to GitHub
         run: |
-          VERSION=$(python setup.py --version)
-          python setup.py bump --build
+          VERSION="v$(python setup.py --version)"
           git config user.email "github-actions@github.com"
           git config user.name "github-actions"
           git add src CHANGELOG.rst
           git status
-          git commit -m "Release v$VERSION"
+          git commit -m "Release $VERSION"
+          git tag "$VERSION"
           git push && git push --tags
-          gh release create $VERSION -n "Please see the [changelog](https://www.github.com/pyinstaller/pyinstaller-hooks-contrib/tree/master/CHANGELOG.rst) for more details"
+          gh release create $VERSION -n "Please see the [changelog](https://www.github.com/pyinstaller/pyinstaller-hooks-contrib/tree/$VERSION/CHANGELOG.rst) for more details"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/news/761.process.rst
+++ b/news/761.process.rst
@@ -1,0 +1,2 @@
+Released sdists and tagged GitHub source archives contain the changelog entries
+for their current release.

--- a/src/_pyinstaller_hooks_contrib/__init__.py
+++ b/src/_pyinstaller_hooks_contrib/__init__.py
@@ -10,6 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-__version__ = '2024.8'
+__version__ = '2024.7'
 __maintainer__ = 'Legorooj, bwoodsend'
 __uri__ = 'https://github.com/pyinstaller/pyinstaller-hooks-contrib'


### PR DESCRIPTION
* Create a release tag after generating the changelog so that `https://github.com/pyinstaller/pyinstaller-hooks-contrib/archive/refs/heads/$version.zip` and `https://github.com/pyinstaller/pyinstaller-hooks-contrib/blob/$version/CHANGELOG.rst` contain the right changelog entries
* Similarly, create sdists after generating the changelog so that they also contain the current release's changelog entries
* Bump the project version immediately before release rather than after (for convenience of implication rather than any functional reason)
* Rename GitHub releases from `XXXX.X` to `vXXXX.X` to match the tags. This in turn fixes GitHub generating additional tags without the `v` suffix

Verification [run](https://github.com/bwoodsend/pyinstaller-hooks-contrib/actions/runs/9946733033) and [mock release](https://github.com/bwoodsend/pyinstaller-hooks-contrib/releases/tag/v2024.8)
