### PR TITLE
hooks: update imageio_ffmpeg hook for compatibility with imageio-ffmpeg >= 0.5.0

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-imageio_ffmpeg.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-imageio_ffmpeg.py
@@ -12,6 +12,11 @@
 
 # Hook for imageio: http://imageio.github.io/
 
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, is_module_satisfies
 
 datas = collect_data_files('imageio_ffmpeg', subdir="binaries")
+
+# Starting with imageio_ffmpeg 0.5.0, `imageio_ffmpeg.binaries` is a package accessed via `importlib.resources`. Since
+# it is not directly imported anywhere, we need to add it to hidden imports.
+if is_module_satisfies('imageio_ffmpeg >= 0.5.0'):
+    hiddenimports = ['imageio_ffmpeg.binaries']

--- a/news/766.update.rst
+++ b/news/766.update.rst
@@ -1,0 +1,2 @@
+Update ``imageio_ffmpeg`` hook for compatibility with ``imageio-ffmpeg``
+0.5.0 and later.


### PR DESCRIPTION
Starting with `imageio-ffmpeg` 0.5.0, `imageio_ffmpeg.binaries` is a package that is acccessed via `importlib.resources`. Since it is not directly imported anywhere, we need to add it to hidden imports.

Closes https://github.com/pyinstaller/pyinstaller/issues/8664.