### PR TITLE
hooks: cryptography: rework the OpenSSL version check

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-cryptography.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-cryptography.py
@@ -57,7 +57,8 @@ try:
     @isolated.decorate
     def _check_cryptography_openssl3():
         from cryptography.hazmat.backends.openssl.backend import backend
-        return bool(backend._lib.CRYPTOGRAPHY_OPENSSL_300_OR_GREATER)
+        openssl_version = backend.openssl_version_number()
+        return openssl_version >= 0x30000000
 
     uses_openssl3 = _check_cryptography_openssl3()
 except Exception:

--- a/news/768.update.rst
+++ b/news/768.update.rst
@@ -1,0 +1,2 @@
+Rework the OpenSSL version check in ``cryptography`` hook to fix
+compatibility with ``cryptography`` 43.0.0.


### PR DESCRIPTION
Instead of trying to infer OpenSSL version by looking at `CRYPTOGRAPHY_OPENSSL_300_OR_GREATER` attribute of `cryptography.hazmat.backends.openssl.backend._lib`, use `cryptography.hazmat.backends.openssl.backend.openssl_version_number()` to obtain full OpenSSL version number.

Fixes compatibility with `cryptography` 43.0.0, where the afore-mentioned attribute does not seem to be available anymore. `openssl_version_number()`, on the other hand, seems to be available in all versions going back to 2.8 (which is the first version that supports python 3.8).

Closes https://github.com/pyinstaller/pyinstaller/issues/8682