### PR TITLE
Add hook for cmocean

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-cmocean.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-cmocean.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files("cmocean", subdir="rgb")

--- a/news/769.new.rst
+++ b/news/769.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``cmocean``, which has a text data files.

--- a/news/769.new.rst
+++ b/news/769.new.rst
@@ -1,1 +1,1 @@
-Add a hook for ``cmocean``, which has a text data files.
+Add a hook for ``cmocean``, which has text data files.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -20,6 +20,7 @@ cftime==1.6.4
 charset_normalizer==3.3.2
 cloudpickle==3.0.0
 cloudscraper==1.2.71
+cmocean==4.0.3
 # compliance-checker requires cf-units, so same constraints apply.
 compliance-checker==5.1.1; sys_platform != 'win32'
 cryptography==43.0.0

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2114,3 +2114,10 @@ def test_patoolib(pyi_builder):
         cmdlist = patoolib.get_archive_cmdlist_func(program, 'extract', archive_format)
         print(f"Cmdlist: {cmdlist}")
     """)
+
+
+@importorskip('cmocean')
+def test_cmocean(pyi_builder):
+    pyi_builder.test_source("""
+        import cmocean
+    """)


### PR DESCRIPTION
Manually testing functionality worked perfectly fine, as well as the CI. However, I can't figure out how to make pytest work. It keeps failing with the warning:
```
WARNING: discover_hook_directories: Failed to process hook entry point 'EntryPoint(name='hook-dirs', value='_pyinstaller_hooks_contrib:get_hook_dirs', group='pyinstaller40')': AttributeError: module '_pyinstaller_hooks_contrib' has no attribute 'get_hook_dirs'
```

## Oneshot test
https://github.com/MattTheCuber/pyinstaller-hooks-contrib/actions/runs/10143643881/job/28045459292