### PR TITLE
Add hook for tzwhere (#771)

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-tzwhere.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-tzwhere.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('tzwhere')

--- a/news/772.new.rst
+++ b/news/772.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``tzwhere``, which has data files.

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2121,3 +2121,11 @@ def test_cmocean(pyi_builder):
     pyi_builder.test_source("""
         import cmocean
     """)
+
+
+@importorskip('tzwhere')
+def test_tzwhere(pyi_builder):
+    pyi_builder.test_source("""
+        from tzwhere import tzwhere
+        tzwhere.tzwhere()
+    """)


### PR DESCRIPTION
Add a hook for `tzwhere`, which has data files.

No change to `requirements-test-libraries.txt` per https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/771#issuecomment-2267146235