### PR TITLE
Add hook for slixmpp library

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-slixmpp.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-slixmpp.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_submodules
+
+hiddenimports = collect_submodules("slixmpp.features")

--- a/news/784.new.rst
+++ b/news/784.new.rst
@@ -1,0 +1,1 @@
+Add analysis hook for ``slixmpp`` library

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -100,6 +100,7 @@ sacremoses==0.1.1
 scipy==1.14.0; python_version >= '3.10'
 sentry-sdk==2.13.0
 shotgun_api3==3.5.1
+slixmpp==1.8.5
 spacy==3.7.5
 srsly==2.4.8
 swagger-spec-validator==3.0.4

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2150,3 +2150,17 @@ def test_itk(pyi_builder):
     pyi_builder.test_source("""
         import itk
     """)
+
+
+@importorskip('slixmpp')
+def test_slixmpp(pyi_builder):
+    pyi_builder.test_source("""
+        import slixmpp
+
+
+        class JabberClient(slixmpp.ClientXMPP):
+            def __init__(self):
+                super().__init__('username', 'password')
+
+        _ = JabberClient()
+    """)

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2158,9 +2158,5 @@ def test_slixmpp(pyi_builder):
         import slixmpp
 
 
-        class JabberClient(slixmpp.ClientXMPP):
-            def __init__(self):
-                super().__init__('username', 'password')
-
-        _ = JabberClient()
+        slixmpp.ClientXMPP('username', 'password')
     """)


### PR DESCRIPTION
Fix runtime import error for [slixmpp](https://codeberg.org/poezio/slixmpp) Jabber library.

Modules in "features" are dynamically imported in the same way plugins are, however, unlike plugins imports, they are not detected automatically (probably due to the fact that import happens at runtime, when the client class is instantiated), leading to the following error:

```
Unable to load plugin: feature_starttls
Traceback (most recent call last):
  File "slixmpp\plugins\base.py", line 78, in load_plugin
ModuleNotFoundError: No module named 'slixmpp.plugins.feature_starttls'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "slixmpp\plugins\base.py", line 82, in load_plugin
ModuleNotFoundError: No module named 'slixmpp.features'
Unable to load plugin: feature_starttls
Traceback (most recent call last):
  File "slixmpp\plugins\base.py", line 78, in load_plugin
ModuleNotFoundError: No module named 'slixmpp.plugins.feature_starttls'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "slixmpp\plugins\base.py", line 82, in load_plugin
ModuleNotFoundError: No module named 'slixmpp.features'
Traceback (most recent call last):
  File "test_source.py", line 10, in <module>
  File "test_source.py", line 8, in __init__
  File "slixmpp\clientxmpp.py", line 122, in __init__
  File "slixmpp\basexmpp.py", line 269, in register_plugin
  File "slixmpp\plugins\base.py", line 153, in enable
slixmpp.plugins.base.PluginNotFound: feature_starttls
```