### PR TITLE
Fix issues with run-time discovery of collected CUDA/cuDNN libraries on linux

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.cublas.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.cublas.py
@@ -10,6 +10,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from _pyinstaller_hooks_contrib.utils.nvidia_cuda import collect_nvidia_cuda_binaries
+from _pyinstaller_hooks_contrib.utils.nvidia_cuda import (
+    collect_nvidia_cuda_binaries,
+    create_symlink_suppression_patterns,
+)
 
 binaries = collect_nvidia_cuda_binaries(__file__)
+bindepend_symlink_suppression = create_symlink_suppression_patterns(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.cuda_cupti.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.cuda_cupti.py
@@ -10,6 +10,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from _pyinstaller_hooks_contrib.utils.nvidia_cuda import collect_nvidia_cuda_binaries
+from _pyinstaller_hooks_contrib.utils.nvidia_cuda import (
+    collect_nvidia_cuda_binaries,
+    create_symlink_suppression_patterns,
+)
 
 binaries = collect_nvidia_cuda_binaries(__file__)
+bindepend_symlink_suppression = create_symlink_suppression_patterns(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.cuda_nvcc.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.cuda_nvcc.py
@@ -11,10 +11,17 @@
 # ------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import collect_data_files
-from _pyinstaller_hooks_contrib.utils.nvidia_cuda import collect_nvidia_cuda_binaries
+from _pyinstaller_hooks_contrib.utils.nvidia_cuda import (
+    collect_nvidia_cuda_binaries,
+    create_symlink_suppression_patterns,
+)
 
 # Ensures that versioned .so files are collected
 binaries = collect_nvidia_cuda_binaries(__file__)
+
+# Prevent binary dependency analysis from creating symlinks to top-level application directory for shared libraries
+# from this package. Requires PyInstaller >= 6.11.0; no-op in earlier versions.
+bindepend_symlink_suppression = create_symlink_suppression_patterns(__file__)
 
 # Collect additional resources:
 #  - ptxas executable (which strictly speaking, should be collected as a binary)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.cuda_nvrtc.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.cuda_nvrtc.py
@@ -10,6 +10,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from _pyinstaller_hooks_contrib.utils.nvidia_cuda import collect_nvidia_cuda_binaries
+from _pyinstaller_hooks_contrib.utils.nvidia_cuda import (
+    collect_nvidia_cuda_binaries,
+    create_symlink_suppression_patterns,
+)
 
 binaries = collect_nvidia_cuda_binaries(__file__)
+bindepend_symlink_suppression = create_symlink_suppression_patterns(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.cuda_runtime.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.cuda_runtime.py
@@ -10,6 +10,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from _pyinstaller_hooks_contrib.utils.nvidia_cuda import collect_nvidia_cuda_binaries
+from _pyinstaller_hooks_contrib.utils.nvidia_cuda import (
+    collect_nvidia_cuda_binaries,
+    create_symlink_suppression_patterns,
+)
 
 binaries = collect_nvidia_cuda_binaries(__file__)
+bindepend_symlink_suppression = create_symlink_suppression_patterns(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.cudnn.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.cudnn.py
@@ -10,6 +10,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from _pyinstaller_hooks_contrib.utils.nvidia_cuda import collect_nvidia_cuda_binaries
+from _pyinstaller_hooks_contrib.utils.nvidia_cuda import (
+    collect_nvidia_cuda_binaries,
+    create_symlink_suppression_patterns,
+)
 
 binaries = collect_nvidia_cuda_binaries(__file__)
+bindepend_symlink_suppression = create_symlink_suppression_patterns(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.cufft.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.cufft.py
@@ -10,6 +10,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from _pyinstaller_hooks_contrib.utils.nvidia_cuda import collect_nvidia_cuda_binaries
+from _pyinstaller_hooks_contrib.utils.nvidia_cuda import (
+    collect_nvidia_cuda_binaries,
+    create_symlink_suppression_patterns,
+)
 
 binaries = collect_nvidia_cuda_binaries(__file__)
+bindepend_symlink_suppression = create_symlink_suppression_patterns(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.curand.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.curand.py
@@ -10,6 +10,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from _pyinstaller_hooks_contrib.utils.nvidia_cuda import collect_nvidia_cuda_binaries
+from _pyinstaller_hooks_contrib.utils.nvidia_cuda import (
+    collect_nvidia_cuda_binaries,
+    create_symlink_suppression_patterns,
+)
 
 binaries = collect_nvidia_cuda_binaries(__file__)
+bindepend_symlink_suppression = create_symlink_suppression_patterns(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.cusolver.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.cusolver.py
@@ -10,6 +10,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from _pyinstaller_hooks_contrib.utils.nvidia_cuda import collect_nvidia_cuda_binaries
+from _pyinstaller_hooks_contrib.utils.nvidia_cuda import (
+    collect_nvidia_cuda_binaries,
+    create_symlink_suppression_patterns,
+)
 
 binaries = collect_nvidia_cuda_binaries(__file__)
+bindepend_symlink_suppression = create_symlink_suppression_patterns(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.cusparse.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.cusparse.py
@@ -10,6 +10,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from _pyinstaller_hooks_contrib.utils.nvidia_cuda import collect_nvidia_cuda_binaries
+from _pyinstaller_hooks_contrib.utils.nvidia_cuda import (
+    collect_nvidia_cuda_binaries,
+    create_symlink_suppression_patterns,
+)
 
 binaries = collect_nvidia_cuda_binaries(__file__)
+bindepend_symlink_suppression = create_symlink_suppression_patterns(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.nccl.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.nccl.py
@@ -10,6 +10,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from _pyinstaller_hooks_contrib.utils.nvidia_cuda import collect_nvidia_cuda_binaries
+from _pyinstaller_hooks_contrib.utils.nvidia_cuda import (
+    collect_nvidia_cuda_binaries,
+    create_symlink_suppression_patterns,
+)
 
 binaries = collect_nvidia_cuda_binaries(__file__)
+bindepend_symlink_suppression = create_symlink_suppression_patterns(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.nvjitlink.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.nvjitlink.py
@@ -10,6 +10,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from _pyinstaller_hooks_contrib.utils.nvidia_cuda import collect_nvidia_cuda_binaries
+from _pyinstaller_hooks_contrib.utils.nvidia_cuda import (
+    collect_nvidia_cuda_binaries,
+    create_symlink_suppression_patterns,
+)
 
 binaries = collect_nvidia_cuda_binaries(__file__)
+bindepend_symlink_suppression = create_symlink_suppression_patterns(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.nvtx.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-nvidia.nvtx.py
@@ -10,6 +10,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from _pyinstaller_hooks_contrib.utils.nvidia_cuda import collect_nvidia_cuda_binaries
+from _pyinstaller_hooks_contrib.utils.nvidia_cuda import (
+    collect_nvidia_cuda_binaries,
+    create_symlink_suppression_patterns,
+)
 
 binaries = collect_nvidia_cuda_binaries(__file__)
+bindepend_symlink_suppression = create_symlink_suppression_patterns(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-tensorflow.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-tensorflow.py
@@ -172,3 +172,17 @@ if is_linux and dist is not None:
 # Collect the tensorflow-plugins (pluggable device plugins)
 hiddenimports += ['tensorflow-plugins']
 binaries += collect_dynamic_libs('tensorflow-plugins')
+
+# On Linux, prevent binary dependency analysis from generating symbolic links for libtensorflow_cc.so.2,
+# libtensorflow_framework.so.2, and _pywrap_tensorflow_internal.so to the top-level application directory. These
+# symbolic links seem to confuse tensorflow about its location (likely because code in one of the libraries looks up the
+# library file's location, but does not fully resolve it), which in turn prevents it from finding the collected CUDA
+# libraries in the nvidia/cu* package directories.
+#
+# The `bindepend_symlink_suppression` hook attribute requires PyInstaller >= 6.11, and is no-op in earlier versions.
+if is_linux:
+    bindepend_symlink_suppression = [
+        '**/libtensorflow_cc.so*',
+        '**/libtensorflow_framework.so*',
+        '**/_pywrap_tensorflow_internal.so',
+    ]

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-ultralytics.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-ultralytics.py
@@ -1,0 +1,19 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+# Collect config .yaml files from ultralytics/cfg directory.
+datas = collect_data_files('ultralytics')
+
+# Collect source .py files for JIT/torchscript. Requires PyInstaller >= 5.3, no-op in older versions.
+module_collection_mode = 'pyz+py'

--- a/_pyinstaller_hooks_contrib/utils/nvidia_cuda.py
+++ b/_pyinstaller_hooks_contrib/utils/nvidia_cuda.py
@@ -13,6 +13,7 @@
 import os
 import re
 
+from PyInstaller import compat
 from PyInstaller.utils.hooks import (
     logger,
     is_module_satisfies,
@@ -60,3 +61,17 @@ def infer_hiddenimports_from_requirements(requirements):
             nvidia_hiddenimports.append(package_name)
 
     return nvidia_hiddenimports
+
+
+def create_symlink_suppression_patterns(hook_file):
+    hook_name, hook_ext = os.path.splitext(os.path.basename(hook_file))
+    assert hook_ext.startswith('.py')
+    assert hook_name.startswith('hook-')
+    module_name = hook_name[5:]
+
+    # Applicable only to Linux
+    if not compat.is_linux:
+        return []
+
+    # Pattern: **/{module_dir}/lib/lib*.so*
+    return [os.path.join('**', *module_name.split('.'), 'lib', 'lib*.so*')]

--- a/news/786.new.rst
+++ b/news/786.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``ultralytics`` package.

--- a/news/786.update.1.rst
+++ b/news/786.update.1.rst
@@ -1,0 +1,12 @@
+(Linux) Update hooks for ``nvidia.cu*`` packages to suppress creation of
+symbolic links to the top-level application directory for all shared
+libraries collected from the packages. This fixes run-time discovery
+of other shared libraries from those packages, which are dynamically
+loaded at run-time (as opposed to being linked against). Specifically,
+this fixes the ``Unable to load any of {libcudnn_engines_precompiled.so.9.1.0,
+libcudnn_engines_precompiled.so.9.1, libcudnn_engines_precompiled.so.9,
+libcudnn_engines_precompiled.so}`` and subsequent
+``RuntimeError: CUDNN_BACKEND_TENSOR_DESCRIPTOR cudnnFinalize failed
+cudnn_status: CUDNN_STATUS_NOT_INITIALIZED`` when trying to use
+``ultralytics`` package. This fix requires PyInstaller >= 6.11 to work,
+and is no-op in earlier PyInstaller versions.

--- a/news/786.update.rst
+++ b/news/786.update.rst
@@ -1,0 +1,7 @@
+(Linux) Update ``tensorflow`` hook to suppress creation of symbolic links
+to the top-level application directory for the following shared libraries
+discovered during binary dependency analysis: ``libtensorflow_cc.so.2``,
+``libtensorflow_framework.so.2``, and ``_pywrap_tensorflow_internal.so``.
+This fixes run-time discovery of CUDA shared libraries from ``nvidia.cu*``
+packages. This fix requires PyInstaller >= 6.11 to work, and is no-op
+in earlier PyInstaller versions.

--- a/tests/test_deep_learning.py
+++ b/tests/test_deep_learning.py
@@ -16,13 +16,12 @@ from PyInstaller.utils.tests import importorskip
 
 
 # Run the tests in onedir mode only
-onedir_only = pytest.mark.parametrize('pyi_builder', ['onedir'], indirect=True)
+pytestmark = pytest.mark.parametrize('pyi_builder', ['onedir'], indirect=True)
 
 
 # Basic transformers test with BERT-based unmasker
 @importorskip('transformers')
 @importorskip('torch')
-@onedir_only
 def test_transformers_bert_pipeline(pyi_builder):
     pyi_builder.test_source("""
         import transformers
@@ -35,7 +34,6 @@ def test_transformers_bert_pipeline(pyi_builder):
 # Trying to import DebertaModel triggers error about missing source files for TorchScript
 @importorskip('transformers')
 @importorskip('torch')
-@onedir_only
 def test_transformers_deberta_import(pyi_builder):
     pyi_builder.test_source("""
         from transformers import DebertaConfig, DebertaModel
@@ -47,7 +45,6 @@ def test_transformers_deberta_import(pyi_builder):
 
 # Building models from tabular data example from https://docs.fast.ai/quick_start.html
 @importorskip('fastai')
-@onedir_only
 def test_fastai_tabular_data(pyi_builder):
     pyi_builder.test_source("""
         from fastai.tabular.all import *
@@ -86,7 +83,6 @@ def test_fastai_tabular_data(pyi_builder):
 
 
 @importorskip('timm')
-@onedir_only
 def test_timm_model_creation(pyi_builder):
     pyi_builder.test_source("""
         import timm
@@ -105,7 +101,6 @@ def test_timm_model_creation(pyi_builder):
 @importorskip('lightning')
 @importorskip('torchvision')
 @importorskip('torch')
-@onedir_only
 def test_lightning_mnist_autoencoder(pyi_builder):
     pyi_builder.test_source("""
         import os
@@ -178,7 +173,6 @@ def test_lightning_mnist_autoencoder(pyi_builder):
 
 
 @importorskip('bitsandbytes')
-@onedir_only
 def test_bitsandbytes(pyi_builder):
     pyi_builder.test_source("""
         import bitsandbytes
@@ -192,7 +186,6 @@ def test_bitsandbytes(pyi_builder):
 
 
 @importorskip('linear_operator')
-@onedir_only
 def test_linear_operator(pyi_builder):
     pyi_builder.test_source("""
         import torch
@@ -210,7 +203,6 @@ def test_linear_operator(pyi_builder):
 
 # Based on https://docs.gpytorch.ai/en/latest/examples/01_Exact_GPs/Simple_GP_Regression.html
 @importorskip('gpytorch')
-@onedir_only
 def test_gpytorch_simple_gp_regression(pyi_builder):
     pyi_builder.test_source("""
         import math
@@ -287,7 +279,6 @@ def test_gpytorch_simple_gp_regression(pyi_builder):
 
 # Basic import test for fvcore.nn, which shows that we need to collect its source .py files for TorchScript/JIT.
 @importorskip('fvcore')
-@onedir_only
 def test_fvcore(pyi_builder):
     pyi_builder.test_source("""
         import fvcore.nn
@@ -296,7 +287,6 @@ def test_fvcore(pyi_builder):
 
 # Basic test for detectron2, which shows that we need to collect its source .py files for TorchScript/JIT.
 @importorskip('detectron2')
-@onedir_only
 def test_detectron2(pyi_builder):
     pyi_builder.test_source("""
         from detectron2 import model_zoo
@@ -314,7 +304,6 @@ def test_detectron2(pyi_builder):
 
 # Hugging Face datasets: Download squad dataset (76 MB train, 10 MB validation)
 @importorskip('datasets')
-@onedir_only
 def test_datasets_download_squad(pyi_builder):
     pyi_builder.test_source("""
         from datasets import load_dataset
@@ -333,7 +322,6 @@ def test_datasets_download_squad(pyi_builder):
 
 # Basic test for Hugging Face accelerate framework
 @importorskip('accelerate')
-@onedir_only
 def test_accelerate(pyi_builder):
     pyi_builder.test_source("""
         import torch
@@ -354,7 +342,6 @@ def test_accelerate(pyi_builder):
 
 # Basic import test for fairscale, which shows that we need to collect its source .py files for TorchScript/JIT.
 @importorskip('fairscale')
-@onedir_only
 def test_fairscale(pyi_builder):
     pyi_builder.test_source("""
         import fairscale

--- a/tests/test_deep_learning.py
+++ b/tests/test_deep_learning.py
@@ -354,3 +354,18 @@ def test_monai(pyi_builder):
     pyi_builder.test_source("""
         import monai
     """)
+
+
+# Basic functional test for ultralytics package. Shows that we need to collect data files from the package.
+# Also shows that on Linux, we need to suppress symbolic links to top-level application directory for shared libraries
+# from nvidia.cu* packages (https://github.com/pyinstaller/pyinstaller/issues/8758).
+#
+# The test requires internet connection (to download model weights and for the test image file).
+@importorskip('ultralytics')
+def test_ultralytics_yolo(pyi_builder):
+    pyi_builder.test_source("""
+        from ultralytics import YOLO
+
+        model = YOLO("yolov8n.pt")  # Download and load pre-trained model
+        results = model("https://ultralytics.com/images/bus.jpg")
+    """)

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -16,11 +16,10 @@ from PyInstaller.utils.tests import importorskip
 
 
 # Run the tests in onedir mode only
-torch_onedir_only = pytest.mark.parametrize('pyi_builder', ['onedir'], indirect=True)
+pytestmark = pytest.mark.parametrize('pyi_builder', ['onedir'], indirect=True)
 
 
 @importorskip('torch')
-@torch_onedir_only
 def test_torch(pyi_builder):
     pyi_builder.test_source("""
         import torch
@@ -32,7 +31,6 @@ def test_torch(pyi_builder):
 # Test with torchaudio transform that uses torchcript, which requires
 # access to transforms' sources.
 @importorskip('torchaudio')
-@torch_onedir_only
 def test_torchaudio_scripted_transforms(pyi_builder):
     pyi_builder.test_source("""
         import numpy as np
@@ -69,7 +67,6 @@ def test_torchaudio_scripted_transforms(pyi_builder):
 # Test with torchtext transform that uses torchcript, which requires
 # access to transforms' sources.
 @importorskip('torchtext')
-@torch_onedir_only
 def test_torchtext_scripted_berta_tokenizer_transform(pyi_builder):
     pyi_builder.test_source("""
         import torch.nn
@@ -106,7 +103,6 @@ def test_torchtext_scripted_berta_tokenizer_transform(pyi_builder):
 
 
 @importorskip('torchvision')
-@torch_onedir_only
 def test_torchvision_nms(pyi_builder):
     pyi_builder.test_source("""
         import torch
@@ -131,7 +127,6 @@ def test_torchvision_nms(pyi_builder):
 
 # Ensure that torchvision.io.image manages to load torchvision.image extension for its ops.
 @importorskip('torchvision')
-@torch_onedir_only
 def test_torchvision_image_io(pyi_builder):
     pyi_builder.test_source("""
         import torch
@@ -149,7 +144,6 @@ def test_torchvision_image_io(pyi_builder):
 # the transforms are combined using torchscript, which requires access to
 # transforms' sources.
 @importorskip('torchvision')
-@torch_onedir_only
 def test_torchvision_scripted_transforms(pyi_builder):
     pyi_builder.test_source("""
         import torch

--- a/tests/test_tensorflow.py
+++ b/tests/test_tensorflow.py
@@ -15,12 +15,13 @@ import pytest
 from PyInstaller.utils.tests import importorskip
 
 
-# Run the tests in onedir mode only
-tensorflow_onedir_only = pytest.mark.parametrize('pyi_builder', ['onedir'], indirect=True)
+pytestmark = [
+    importorskip('tensorflow'),
+    # Run the tests in onedir mode only
+    pytest.mark.parametrize('pyi_builder', ['onedir'], indirect=True)
+]
 
 
-@importorskip('tensorflow')
-@tensorflow_onedir_only
 def test_tensorflow(pyi_builder):
     pyi_builder.test_source(
         """
@@ -31,8 +32,6 @@ def test_tensorflow(pyi_builder):
 
 # Test if tensorflow.keras imports properly result in tensorflow being collected.
 # See https://github.com/pyinstaller/pyinstaller/discussions/6890
-@importorskip('tensorflow')
-@tensorflow_onedir_only
 def test_tensorflow_keras_import(pyi_builder):
     pyi_builder.test_source(
         """
@@ -43,13 +42,9 @@ def test_tensorflow_keras_import(pyi_builder):
     )
 
 
-@importorskip('tensorflow')
-@tensorflow_onedir_only
 def test_tensorflow_layer(pyi_builder):
     pyi_builder.test_script('pyi_lib_tensorflow_layer.py')
 
 
-@importorskip('tensorflow')
-@tensorflow_onedir_only
 def test_tensorflow_mnist(pyi_builder):
     pyi_builder.test_script('pyi_lib_tensorflow_mnist.py')


### PR DESCRIPTION
Fix issues with run-time discovery of collected CUDA/cuDNN libraries on linux when using ``torch`` and/or ``tensorflow``.

Use the symlink suppression mechanism from https://github.com/pyinstaller/pyinstaller/pull/8761 to suppress creation of top-level directory symlinks for `libtensorflow_cc.so.2`, `libtensorflow_framework.so.2`, and  `_pywrap_tensorflow_internal.so` from `tensorflow` package. These symlinks cause `tensorflow` to mis-identify its location, and cause it to search for CUDA libraries in wrong directories. See https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/676#issuecomment-1866440960

For a very similar reason, suppress top-level directory symlink creation for all shared libraries from `nvidia.cu*` packages to fix `Unable to load any of {libcudnn_engines_precompiled.so.9.1.0, libcudnn_engines_precompiled.so.9.1, libcudnn_engines_precompiled.so.9, libcudnn_engines_precompiled.so}` and `RuntimeError: CUDNN_BACKEND_TENSOR_DESCRIPTOR cudnnFinalize failed cudnn_status: CUDNN_STATUS_NOT_INITIALIZED` errors when trying to use `ultralytics` package with `torch`-based model.  See https://github.com/pyinstaller/pyinstaller/issues/8758

Add a hook for `ultralytics` package to ensure that its config .yaml files are collected (and collect source .py files in case a JIT-based model is used).