### PR TITLE
rthooks: tensorflow: gracefully handle lack of getsitepackages in site

### DIFF
--- a/_pyinstaller_hooks_contrib/rthooks/pyi_rth_tensorflow.py
+++ b/_pyinstaller_hooks_contrib/rthooks/pyi_rth_tensorflow.py
@@ -34,7 +34,7 @@ def _pyi_rthook():
     # need `sys._MEIPASS` to be among them (to load the plugins from the actual `sys._MEIPASS/tensorflow-plugins`).
     # Therefore, we monkey-patch `site.getsitepackages` to add those two entries to the list of "site directories".
 
-    _orig_getsitepackages = getattr(site, 'getsitepackages')
+    _orig_getsitepackages = getattr(site, 'getsitepackages', None)
 
     def _pyi_getsitepackages():
         return [


### PR DESCRIPTION
Gracefully handle lack of `getsitepackages` in the `site` module. Fixes compatibility with early PyInstaller 5.x versions (< 5.4), and future-proofs the hook in case the `getsitepackages` function ever legitimately ends up being unavailable.

Closes #789. While I don't particularly care for compatibility with outdated PyInstaller versions (< 5.4 that are affected), the code in question already tries to handle the case when `_orig_getsitepackages` is `None`, so it makes sense to add that default value for `getattr`.