### PR TITLE
hooks: add hook for yapf_third_party

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-yapf_third_party.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-yapf_third_party.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('yapf_third_party')

--- a/news/792.new.rst
+++ b/news/792.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``yapf_third_party`` (part of ``yapf``) to collect its
+data files.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -217,6 +217,7 @@ xarray==2024.7.0; python_version >= '3.9'
 tables==3.10.1; python_version >= '3.10'
 schwifty==2024.9.0  # pyup: != '2024.8.1'
 patool==2.4.0; python_version >= '3.10'
+yapf==0.40.2
 
 # ------------------- Platform (OS) specifics
 

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2156,8 +2156,6 @@ def test_itk(pyi_builder):
 def test_slixmpp(pyi_builder):
     pyi_builder.test_source("""
         import slixmpp
-
-
         slixmpp.ClientXMPP('username', 'password')
     """)
 
@@ -2167,4 +2165,11 @@ def test_capstone(pyi_builder):
     pyi_builder.test_source("""
         import capstone
         capstone.__version__
+    """)
+
+
+@importorskip('yapf')
+def test_yapf(pyi_builder):
+    pyi_builder.test_source("""
+        import yapf
     """)


### PR DESCRIPTION
Add hook for `yapf_third_party` (part of `yapf`) to collect its data files.

Closes #783.