### PR TITLE
hooks: add hook for grapheme

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-grapheme.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-grapheme.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('grapheme')

--- a/news/793.new.rst
+++ b/news/793.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``grapheme`` to collect its data files.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -40,6 +40,7 @@ folium==0.17.0
 ffpyplayer==4.5.1
 geopandas==1.0.1; sys_platform != 'win32' and python_version >= '3.9'
 google-api-python-client==2.144.0
+grapheme==0.6.0
 graphql-query==1.4.0
 python-gitlab==4.10.0
 h5py==3.11.0

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2173,3 +2173,10 @@ def test_yapf(pyi_builder):
     pyi_builder.test_source("""
         import yapf
     """)
+
+
+@importorskip('grapheme')
+def test_grapheme(pyi_builder):
+    pyi_builder.test_source("""
+        import grapheme
+    """)


### PR DESCRIPTION
Add hook for `grapheme` to collect its data files.

See https://github.com/pyinstaller/pyinstaller/issues/8760.