### PR TITLE
hooks: update av hook for compatibility with av 13.0.0

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-av.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-av.py
@@ -32,3 +32,8 @@ if is_module_satisfies("av >= 9.1.1") and is_win:
             (os.path.join(lib_dir, lib_file), 'av.libs')
             for lib_file in os.listdir(lib_dir)
         ]
+
+# With av 13.0.0, one of the cythonized modules (`av.audio.layout`) started using `dataclasses`. Add it to hidden
+# imports to ensure it is collected in cases when it is not referenced from anywhere else.
+if is_module_satisfies("av >= 13.0.0"):
+    hiddenimports += ['dataclasses']

--- a/news/794.update.rst
+++ b/news/794.update.rst
@@ -1,0 +1,1 @@
+Update ``av`` hook for compatibility with ``av`` v13.0.0.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -3,7 +3,7 @@ importlib_resources==6.4.5; python_version < '3.9'
 
 # ------------------ LIBRARIES ------------------ #
 # TODO: Add most of the libraries we have hooks for, and write tests
-av==12.3.0
+av==13.0.0; python_version >= '3.9'
 adbutils==2.8.0
 APScheduler==3.10.4
 backports.zoneinfo==0.2.1; python_version < '3.9'


### PR DESCRIPTION
With `av` 13.0.0, one of the cythonized modules (`av.audio.layout`) started using `dataclasses`. Add it to hidden imports to ensure it is collected in cases when it is not referenced from anywhere else.