### PR TITLE
hooks: update pydicom hook for compatibility with pydicom v3.0.0

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-pydicom.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-pydicom.py
@@ -10,8 +10,70 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-hiddenimports = [
-    "pydicom.encoders.gdcm",
-    "pydicom.encoders.pylibjpeg",
-    "pydicom.encoders.native",
-]
+from PyInstaller.utils.hooks import is_module_satisfies, collect_data_files
+
+hiddenimports = []
+datas = []
+
+# In pydicom 3.0.0, the `pydicom.encoders` plugins were renamed to `pydicom.pixels.encoders`, and
+# `pydicom.pixels.decoders` were also added. We need to collect them all, because they are loaded during
+# `pydicom` module initialization. We intentionally avoid using `collect_submodules` here, because that causes
+# import of `pydicom` with logging framework initialized, which results in error tracebacks being logged for all plugins
+# with missing libraries (see https://github.com/pydicom/pydicom/issues/2128).
+if is_module_satisfies('pydicom >= 3.0.0'):
+    hiddenimports += [
+        "pydicom.pixels.decoders.gdcm",
+        "pydicom.pixels.decoders.pylibjpeg",
+        "pydicom.pixels.decoders.pillow",
+        "pydicom.pixels.decoders.pyjpegls",
+        "pydicom.pixels.decoders.rle",
+        "pydicom.pixels.encoders.gdcm",
+        "pydicom.pixels.encoders.pylibjpeg",
+        "pydicom.pixels.encoders.native",
+        "pydicom.pixels.encoders.pyjpegls",
+    ]
+
+    # With pydicom 3.0.0, initialization of `pydicom` (unnecessarily) imports `pydicom.examples`, which attempts to set
+    # up several test datasets: https://github.com/pydicom/pydicom/blob/v3.0.0/src/pydicom/examples/__init__.py#L10-L24
+    additional_data_patterns = [
+        # `pydicom/data/urls.json` and `pydicom/data/hashes.json` are required for data files that need to be downloaded
+        # at run-time. The lack of former results in run-time error, while the lack of latter results in warnings about
+        # dataset download failure.
+        'urls.json',
+        'hashes.json',
+        # Try to collect these from the package, to avoid having to download them at run-time. The `pydicom` searches
+        # for these files via recursive glob (`pathlib.Path.rglob`) to allow them being in sub-directories (for example,
+        # `test_files/dicomdirtests/DICOMDIR`); so let us also assume that there might be sub-directories involved.
+        "test_files/**/CT_small.dcm",
+        "test_files/**/DICOMDIR",
+        "test_files/**/US1_J2KR.dcm",
+        "test_files/**/MR_small.dcm",
+        "test_files/**/no_meta.dcm",
+        "test_files/**/MR-SIEMENS-DICOM-WithOverlays.dcm",
+        "test_files/**/OBXXXX1A.dcm",
+        "test_files/**/US1_UNCR.dcm",
+        "test_files/**/rtdose.dcm",
+        "test_files/**/rtplan.dcm",
+        "test_files/**/rtstruct.dcm",
+        "test_files/**/waveform_ecg.dcm",
+        "test_files/**/color3d_jpeg_baseline.dcm",
+    ]
+else:
+    hiddenimports += [
+        "pydicom.encoders.gdcm",
+        "pydicom.encoders.pylibjpeg",
+        "pydicom.encoders.native",
+    ]
+    additional_data_patterns = []
+
+# Collect data files from `pydicom.data`; charset files and palettes might be needed during processing, so always
+# collect them. Some other data files became required in v3.0.0 - the corresponding patterns are set accordingly in
+# `additional_data_patterns` in the above if/else block.
+datas += collect_data_files(
+    'pydicom.data',
+    includes=[
+        'charset_files/*',
+        'palettes/*',
+        *additional_data_patterns,
+    ],
+)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-pydicom.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-pydicom.py
@@ -35,28 +35,18 @@ if is_module_satisfies('pydicom >= 3.0.0'):
 
     # With pydicom 3.0.0, initialization of `pydicom` (unnecessarily) imports `pydicom.examples`, which attempts to set
     # up several test datasets: https://github.com/pydicom/pydicom/blob/v3.0.0/src/pydicom/examples/__init__.py#L10-L24
+    # Some of those are bundled with the package itself, some are downloaded (into `.pydicom/data` directory in user's
+    # home directory) on he first `pydicom.examples` import.
+    #
+    # The download code requires `pydicom/data/urls.json` and `pydicom/data/hashes.json`; the lack of former results in
+    # run-time error, while the lack of latter results in warnings about dataset download failure.
+    #
+    # The test data files that are bundled with the package are not listed in `urls.json`, so if they are missing, there
+    # is not attempt to download them. Therefore, try to get away without collecting them here - if anyone actually
+    # requires them in the frozen application, let them explicitly collect them.
     additional_data_patterns = [
-        # `pydicom/data/urls.json` and `pydicom/data/hashes.json` are required for data files that need to be downloaded
-        # at run-time. The lack of former results in run-time error, while the lack of latter results in warnings about
-        # dataset download failure.
         'urls.json',
         'hashes.json',
-        # Try to collect these from the package, to avoid having to download them at run-time. The `pydicom` searches
-        # for these files via recursive glob (`pathlib.Path.rglob`) to allow them being in sub-directories (for example,
-        # `test_files/dicomdirtests/DICOMDIR`); so let us also assume that there might be sub-directories involved.
-        "test_files/**/CT_small.dcm",
-        "test_files/**/DICOMDIR",
-        "test_files/**/US1_J2KR.dcm",
-        "test_files/**/MR_small.dcm",
-        "test_files/**/no_meta.dcm",
-        "test_files/**/MR-SIEMENS-DICOM-WithOverlays.dcm",
-        "test_files/**/OBXXXX1A.dcm",
-        "test_files/**/US1_UNCR.dcm",
-        "test_files/**/rtdose.dcm",
-        "test_files/**/rtplan.dcm",
-        "test_files/**/rtstruct.dcm",
-        "test_files/**/waveform_ecg.dcm",
-        "test_files/**/color3d_jpeg_baseline.dcm",
     ]
 else:
     hiddenimports += [

--- a/news/796.update.rst
+++ b/news/796.update.rst
@@ -1,0 +1,1 @@
+Update ``pydicom`` hook for compatibility with ``pydicom`` v.3.0.0.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -75,7 +75,7 @@ publicsuffix2==2.20191221
 pycparser==2.22
 pycryptodome==3.20.0
 pycryptodomex==3.20.0
-pydicom==2.4.4
+pydicom==3.0.0; python_version >= '3.10'
 pyexcelerate==0.12.0
 pyexcel_ods==0.6.0
 pylibmagic==0.5.0; sys_platform != 'win32'


### PR DESCRIPTION
Update the hidden imports for renamed and extended set of plugin modules, and collect the data files that are now required at run-time due to `pydicom.examples` being imported during `pydicom` module initialization.

Closes #795.