### PR TITLE
hooks: xarray: collect xarray.chunkmanagers entry-points

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -70,6 +70,8 @@ jobs:
             echo trame-vuetify >> requirements-test-libraries.txt;
           fi
           if grep -q trame-mesh-streamer requirements-test-libraries.txt; then echo vtk >> requirements-test-libraries.txt; fi
+          # test_xarray_chunk requires dask in addition to xarray
+          if grep -q xarray requirements-test-libraries.txt; then echo dask >> requirements-test-libraries.txt; fi
           cat requirements-test-libraries.txt
 
       - name: Set up .NET Core for pythonnet tests

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-xarray.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-xarray.py
@@ -12,8 +12,18 @@
 
 from PyInstaller.utils.hooks import copy_metadata, collect_entry_point
 
+datas = []
+hiddenimports = []
+
 # Collect additional backend plugins that are registered via `xarray.backends` entry-point.
-datas, hiddenimports = collect_entry_point('xarray.backends')
+ep_datas, ep_hiddenimports = collect_entry_point('xarray.backends')
+datas += ep_datas
+hiddenimports += ep_hiddenimports
+
+# Similarly, collect chunk manager entry-points.
+ep_datas, ep_hiddenimports = collect_entry_point('xarray.chunkmanagers')
+datas += ep_datas
+hiddenimports += ep_hiddenimports
 
 # `xarray` requires `numpy` metadata due to several calls to its `xarray.core.utils.module_available` with specified
 # `minversion` argument, which end up calling `importlib.metadata.version`.

--- a/news/800.update.rst
+++ b/news/800.update.rst
@@ -1,0 +1,1 @@
+Update ``xarray`` hook to collect ``xarray.chunkmanagers`` entry-points.

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2008,6 +2008,19 @@ def test_xarray(pyi_builder):
     """)
 
 
+# Shows that we need to collect `xarray.chunkmanagers` entry point.
+# See: https://github.com/pyinstaller/pyinstaller/issues/8786
+@importorskip('xarray')
+@importorskip('dask')  # requires dask for default 'dask' chunk manager to become available
+def test_xarray_chunk(pyi_builder):
+    pyi_builder.test_source("""
+        import xarray as xr
+        import numpy as np
+
+        v = xr.Variable(dims=("T",), data=np.random.randn(10)).chunk()
+    """)
+
+
 @importorskip('tables')
 def test_pytables(pyi_builder):
     # NOTE: run_from_path=True prevents `pyi_builder` from completely clearing the `PATH` environment variable. At the


### PR DESCRIPTION
Have the `xarray` hook collect `xarray.chunkmanagers` entry-points; this ensures that at least the default (`dask`) chunk manager is detected as present at the run-time.

Closes https://github.com/pyinstaller/pyinstaller/issues/8786.