### PR TITLE
tests: fix compatibility with PyInstaller 5.x

### DIFF
--- a/tests/test_trame.py
+++ b/tests/test_trame.py
@@ -13,13 +13,13 @@
 import pytest
 
 from PyInstaller.utils.tests import importorskip
-from PyInstaller.utils.hooks import check_requirement
+from PyInstaller.utils.hooks import is_module_satisfies
 
 
 # Pretty much all tests here require `trame.app module` from core `trame` dist, so skip the tests if it is not
 # available (installing other `trame-*` dists does not seem to install `trame` dist itself). We could equivalently
 # check if `trame.app` is importable, but that would require an isolated check.
-pytestmark = pytest.mark.skipif(not check_requirement('trame'), reason="Core 'trame' distribution is not installed.")
+pytestmark = pytest.mark.skipif(not is_module_satisfies('trame'), reason="Core 'trame' distribution is not installed.")
 
 
 @importorskip("trame")


### PR DESCRIPTION
Have `test_trame.py` use the `is_module_satisfies` instead of `check_requirement`, due to latter being available only in PyInstaller >= 6.0.

Closes #801.