### PR TITLE
hooks: add hook for setuptools_scm

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-setuptools_scm.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-setuptools_scm.py
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata
+
+# Ensure `metadata of setuptools` dist is collected, to avoid run-time warning about unknown/incompatible `setuptools`
+# version.
+datas = copy_metadata('setuptools')

--- a/news/805.new.rst
+++ b/news/805.new.rst
@@ -1,0 +1,3 @@
+Add hook for ``setuptools_scm`` that collects metadata of ``setuptools``
+dist in order to avoid run-time warning about unknown/incompatible
+``setuptools`` version.


### PR DESCRIPTION
Add hook for `setuptools_scm` to ensure that metadata for `setuptools` dist is collected, in order to avoid the following run-time warning:

```
ERROR: setuptools==0.dev0+unknown is used in combination with setuptools_scm>=8.x

Your build configuration is incomplete and previously worked by accident!
setuptools_scm requires setuptools>=61

Suggested workaround if applicable:
 - migrating from the deprecated setup_requires mechanism to pep517/518
   and using a pyproject.toml to declare build dependencies
   which are reliably pre-installed before running the build tools
```