### PR TITLE
hooks: add hook for onnxruntime

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-onnxruntime.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-onnxruntime.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_dynamic_libs
+
+# Collect provider plugins from onnxruntime/capi.
+binaries = collect_dynamic_libs("onnxruntime")

--- a/news/817.new.rst
+++ b/news/817.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``onnxruntime`` to ensure that provider plugins are
+collected.


### PR DESCRIPTION
Add hook for `onnxruntime` to ensure that provider plugins (located in `onnxruntime/capi` directory) are collected.