### PR TITLE
ci: use python from actions/setup-python

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,8 @@ jobs:
 
     - name: Setup Python
       uses: actions/setup-python@v5
+      with:
+        python-version: 3.x
 
     - name: Install dependencies
       run: pip install -U flake8 wheel setuptools

--- a/.github/workflows/validate-new-news.yml
+++ b/.github/workflows/validate-new-news.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
 
       - name: Validate new news items
         run: python scripts/verify-news-fragments.py


### PR DESCRIPTION
Use python from `actions/setup-python` for `lint` and `validate-new-news` workflows, as the latest version of system-provided python/pip guards against pip-installing packages into base system python environment.