### PR TITLE
hooks: update falcon hook for compatibility with falcon v4.0.0

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-falcon.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-falcon.py
@@ -10,6 +10,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
+from PyInstaller.compat import is_py311
+from PyInstaller.utils.hooks import is_module_satisfies
+
 hiddenimports = [
     'cgi',
     'falcon.app_helpers',
@@ -25,3 +28,14 @@ hiddenimports = [
     'xml.etree.ElementTree',
     'xml.etree'
 ]
+
+# falcon v4.0.0 added couple of more cythonized modules that depend on the following stdlib modules.
+if is_module_satisfies('falcon >= 4.0.0'):
+    hiddenimports += [
+        'dataclasses',
+        'json',
+    ]
+
+    # `wsgiref.types` is available (and thus referenced) only under python >= 3.11.
+    if is_py311:
+        hiddenimports += ['wsgiref.types']

--- a/news/820.update.rst
+++ b/news/820.update.rst
@@ -1,0 +1,1 @@
+Update ``falcon`` hook for compatibility with ``falcon`` v4.0.0.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -34,7 +34,7 @@ discid==1.2.0; sys_platform != 'win32'
 eth_typing==5.0.0
 eth_utils==5.0.0
 fabric==3.2.2
-falcon==3.1.3
+falcon==4.0.0
 fiona==1.10.1; sys_platform != 'win32'
 folium==0.17.0
 ffpyplayer==4.5.1


### PR DESCRIPTION
`falcon` v4.0.0 added couple of more cythonized modules that depend on `dataclasses`, `json`, and `wsgiref` modules from stdlib; so we need to add those to `hiddenimports`.