### PR TITLE
hooks: add hook for numbers_parser

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-numbers_parser.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-numbers_parser.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+# Ensure that `numbers_parser/data/empty.numbers` is collected.
+datas = collect_data_files('numbers_parser')

--- a/news/823.new.rst
+++ b/news/823.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``numbers_parser`` to ensure that package's data file is
+collected.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -224,6 +224,7 @@ xmlschema==3.4.1
 pysaml2==7.5.0; python_version >= '3.9'
 pysaml2==7.3.0; python_version < '3.9'  # pyup: ignore
 toga==0.4.8; python_version >= '3.9'
+numbers-parser==4.14.1; python_version >= '3.9'
 
 # ------------------- Platform (OS) specifics
 

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2262,3 +2262,23 @@ def test_toga(pyi_builder):
         app_args=['--automatic-shutdown', '5'],
         pyi_args=['--windowed'] if is_darwin else [],
     )
+
+
+@importorskip('numbers_parser')
+def test_numbers_parser(pyi_builder, tmpdir):
+    output_filename = tmpdir / "output.numbers"
+    pyi_builder.test_source("""
+        import sys
+        import numbers_parser
+
+        output_filename = sys.argv[1]
+
+        doc = numbers_parser.Document()
+        doc.add_sheet("New Sheet", "New Table")
+        sheet = doc.sheets["New Sheet"]
+        table = sheet.tables["New Table"]
+        table.write(1, 1, 1000)
+        table.write(1, 2, 2000)
+        table.write(1, 3, 3000)
+        doc.save(output_filename)
+    """, app_args=[str(output_filename)])


### PR DESCRIPTION
Add hook for `numbers_parser` to ensure that the package's data file (`numbers_parser/data/empty.numbers`) is collected.

Closes #822.