### PR TITLE
ci: add python 3.12 and 3.13, and use macos-13 and macos-14

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         pyinstaller: ["https://github.com/pyinstaller/pyinstaller/archive/develop.zip"]
-        os: ["macos-12", "ubuntu-22.04", "windows-latest"]
+        os: ["macos-13", "macos-14", "ubuntu-22.04", "windows-latest"]
       fail-fast: false
 
     env:


### PR DESCRIPTION
Update the CI to cover all supported python versions. Switch from deprecated macos-12 runner to macos-13 (x86_64) and macos-14 (arm64).