### PR TITLE
hooks: torch: suppress generation of symlinks for shared libs

### DIFF
--- a/news/834.update.rst
+++ b/news/834.update.rst
@@ -1,0 +1,7 @@
+(Linux) Update ``torch`` hook to suppress creation of symbolic links to
+the top-level application directory for the shared libraries discovered
+during binary dependency analysis in ``torch/lib`` directory. This fixes
+issues with ``libtorch_cuda_linalg.so`` not being found in spite of it
+being collected, as observed with certain ``torch`` builds provided by
+https://download.pytorch.org/whl/torch (e.g., ``1.13.1+cu117``,
+``2.0.1+cu117``, and ``2.1.2+cu118``).


### PR DESCRIPTION
On Linux, have the `torch` hook use the`bindepend_symlink_suppression` hook attribute to prevent PyInstaller's binary dependency analysis from creating symlinks to top-level application directory for shared libraries discovered in the `torch/lib` directory during binary dependency analysis.

These symbolic links confuse certain `torch` builds about the location of  `torch`, and prevent `torch/lib/libtorch_cuda_linalg.so` from being (dynamically) loaded. The problematic builds are wheels provided by https://download.pytorch.org/whl/torch for `torch` 1.13.x, 2.0.x, and 2.1.x (tested with 1.13.1+cu117, 2.0.1+cu117, and 2.1.2+cu118). Later versions do not seem to be affected. The wheels provided on PyPI do not seem to be affected either, regardless of the version.

However, these symlinks should be not necessary on linux in general, so there should be no harm in suppressing them for all versions.

Fixes #834.