### PR TITLE
hooks: update sklearn.tree hook for compatibility with scikit-learn v1.6.0

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-sklearn.tree.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-sklearn.tree.py
@@ -10,4 +10,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-hiddenimports = ['sklearn.tree._utils', ]
+from PyInstaller.utils.hooks import is_module_satisfies
+
+hiddenimports = ['sklearn.tree._utils']
+
+if is_module_satisfies('scikit-learn >= 1.6.0'):
+    hiddenimports += ['sklearn.tree._partitioner']

--- a/news/838.update.rst
+++ b/news/838.update.rst
@@ -1,0 +1,2 @@
+Update ``sklearn.tree`` hook for compatibility with ``scikit-learn`` v1.6.0
+(add ``sklearn.tree._partitioner`` to hidden imports).

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -178,7 +178,7 @@ spiceypy==6.0.0
 exchangelib==5.5.0; python_version >= '3.9'
 NBT==1.5.1
 minecraft-launcher-lib==6.5
-scikit-learn==1.5.2; python_version >= '3.9'
+scikit-learn==1.6.0; python_version >= '3.9'
 scikit-image==0.24.0; python_version >= '3.10'
 customtkinter==5.2.2
 fastparquet==2024.11.0; python_version >= '3.9'


### PR DESCRIPTION
Update the `sklearn.tree` hook for compatibility with `scikit-learn` v1.6.0; we need to add `sklearn.tree._partitioner` to hidden imports.