### PR TITLE
hooks: cryptography: revise discovery and collection of the ossl-modules directory

### DIFF
--- a/news/846.update.rst
+++ b/news/846.update.rst
@@ -1,0 +1,6 @@
+Revise the search for OpenSSL shared library and ``ossl-modules`` directory
+in the ``cryptography`` hook, in order to mitigate issues with unrelated
+copies of OpenSSL ending up being pulled into the build. Most notably,
+the hook should not be searching for OpenSSL shared library when
+``cryptography`` PyPI wheel is installed, because those ship with
+extensions that are statically linked against OpenSSL.


### PR DESCRIPTION
Revise the code for discovery and collection of the `ossl-modules` directory in the `cryptography` hook. We should be looking for this directory with OpenSSL plugins only if the OpenSSL bindings extension module in the `cryptography` package is dynamically linked against the OpenSSL shared library. Therefore, perform binary dependency analysis on the extension module, and use the obtained records to infer location of the OpenSSL shared library (if applicable).

PyPI wheels for `cryptography` have their bindings extension statically linked against OpenSSL, so we can avoid looking for the OpenSSL library and its corresponding `ossl-modules` directory altogether. This also reduces risk of collecting unrelated instance of the OpenSSL shared library that happens to be in search path.

Anaconda-packaged `cryptography` is dynamically linked against Anaconda-packaged OpenSSL libraries (as in Anaconda-packaged python). Inferring OpenSSL library from records obtained by binary dependency analysis ensures that we end up collecting the correct instance of the shared library (on linux and macOS, run-path is used; on Windows, the Anaconda library directory is in `PATH`). This prevents the issue on linux, where trying to resolve OpenSSL shared library just using its basename would end up collecting the system-provided copy of the library.

Similarly, linux distributions also package `cryptography` that has extensions dynamically linked against system copy of OpenSSL; although this is usually the least problematic scenario, because this copy ends up being the only one in the search path.

Fixes pyinstaller/pyinstaller#8797. Fixes pyinstaller/pyinstaller#8956.