### PR TITLE
hooks: update triton hook for compatibility with triton >= 3.0.0

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-triton.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-triton.py
@@ -10,7 +10,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ---------------------------------------------------
 
-from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs
+from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs, collect_submodules, is_module_satisfies
+
+hiddenimports = []
+datas = []
 
 # Ensure that triton/_C/libtriton.so is collected
 binaries = collect_dynamic_libs('triton')
@@ -26,7 +29,19 @@ module_collection_mode = {
     'triton.language': 'py',
 }
 
-# Collect ptxas compiler files from triton/third_party/cuda directory. Strictly speaking, the ptxas executable from bin
-# directory should be collected as a binary, but in this case, it makes no difference (plus, PyInstaller >= 6.0 has
-# automatic binary-vs-data reclassification).
-datas = collect_data_files('triton.third_party.cuda')
+# triton 3.0.0 introduced `triton.backends` sub-package with backend-specific files.
+if is_module_satisfies('triton >= 3.0.0'):
+    # Collect backend sub-modules/packages.
+    hiddenimports += collect_submodules('triton.backends')
+
+    # At the time of writing (triton v3.1.0), `triton.backends.amd` is a namespace package, and is not captured by the
+    # above `collect_submodules` call.
+    hiddenimports += collect_submodules('triton.backends.amd')
+
+    # Collect ptxas compiler files from `triton/backends/nvidia`, and the HIP/ROCm files from `triton/backends/amd`.
+    datas += collect_data_files('triton.backends')
+else:
+    # Collect ptxas compiler files from triton/third_party/cuda directory. Strictly speaking, the ptxas executable from
+    # bin directory should be collected as a binary, but in this case, it makes no difference (plus, PyInstaller >= 6.0
+    # has automatic binary-vs-data reclassification).
+    datas += collect_data_files('triton.third_party.cuda')

--- a/news/848.update.rst
+++ b/news/848.update.rst
@@ -1,0 +1,3 @@
+Update ``triton`` hook for compatibility with ``triton`` >= 3.0.0; the
+hook should now collect backend-specific modules and data files from
+``triton.backends``.


### PR DESCRIPTION
Update `triton` hook to collect backend-specific modules and data files from `triton.backends` sub-package that was introduced in triton v3.0.0.

Should close pyinstaller/pyinstaller#8968.