### PR TITLE
hooks: dask: collect template files from dask/widgets/templates

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-dask.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-dask.py
@@ -9,10 +9,11 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #-----------------------------------------------------------------------------
-"""
-Collects in-repo dask.yaml and dask-schema.yaml data files.
-"""
 
 from PyInstaller.utils.hooks import collect_data_files
 
-datas = collect_data_files('dask', includes=['*.yml', '*.yaml'])
+# Collect data files:
+#  - dask.yaml
+#  - dask-schema.yaml
+#  - widgets/templates/*.html.j2 (but avoid collecting files from `widgets/tests/templates`!)
+datas = collect_data_files('dask', includes=['*.yml', '*.yaml', 'widgets/templates/*.html.j2'])

--- a/news/852.update.rst
+++ b/news/852.update.rst
@@ -1,0 +1,3 @@
+Update ``dask`` hook to collect template files from ``dask/widgets/templates``
+directory; these file become mandatory when using ``dask.array`` and
+``jinja2`` is available.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -28,6 +28,7 @@ cryptography==44.0.0
 dash==2.18.2
 dash-bootstrap-components==1.6.0
 dash-uploader==0.6.1
+dask[array,diagnostics]==2024.12.1; python_version >= '3.10'
 # discid requires libdiscid to be provided by the system.
 # We install it via apt-get and brew on ubuntu and macOS CI runners, respectively.
 discid==1.2.0; sys_platform != 'win32'

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2095,6 +2095,18 @@ def test_xarray_chunk(pyi_builder):
     """)
 
 
+# Test that we can import `dask.array` when `jinja2` is also available. In this case, `dask.array.core` ends up loading
+# template files from `dask.widgets.templates`. Requires `numpy` (or `dask[array]`) for `dask.array` to be importable,
+# and `jinja2` (`dask[diagnostics]`) for template files to become mandatory.
+@importorskip('dask')
+@importorskip('jinja2')
+@importorskip('numpy')
+def test_dask_array(pyi_builder):
+    pyi_builder.test_source("""
+        import dask.array
+    """)
+
+
 @importorskip('tables')
 def test_pytables(pyi_builder):
     # NOTE: run_from_path=True prevents `pyi_builder` from completely clearing the `PATH` environment variable. At the


### PR DESCRIPTION
Update `dask` hook to collect template files from `dask/widgets/templates` directory; these file become mandatory when using `dask.array` and `jinja2` is available.

Add a basic import test for `dask.array`, and add `dask[array,diagnostics]` to `requirements-test-libaries.txt` (the `array` extra installs `numpy`, which is required for `dask.array`; the `diagnostics` extra installs `jinja2`, whose presence makes the template files mandatory).