### PR TITLE
hook: add hook for zarr

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -164,7 +164,7 @@ jobs:
           pip install ${{ matrix.pyinstaller }}
 
       - name: Run tests
-        run: pytest -v
+        run: pytest -v -s
 
       # Conditionally enable slow tests, so that they are ran only if
       # their corresponding packages are explicitly installed but not

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-intake.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-intake.py
@@ -12,17 +12,16 @@
 
 from PyInstaller.utils.hooks import collect_all, is_module_satisfies
 
-_ , datas, hiddenimports = collect_all('intake')
+_, datas, hiddenimports = collect_all('intake')
 
-
-# Attention: Since PyInstaller basically process the modules that are 
-# imported in the code, and in the case of intake, when the plugin's 
-# drivers are installed, they are automatically get used via the main 
-# intake module. So, we need to check if the plugin's driver is installed 
-# and then process it in PyInstaller construction procedure to get the 
+# Attention: Since PyInstaller basically process the modules that are
+# imported in the code, and in the case of intake, when the plugin's
+# drivers are installed, they are automatically get used via the main
+# intake module. So, we need to check if the plugin's driver is installed
+# and then process it in PyInstaller construction procedure to get the
 # hidden imports and datas of the plugin.
 
-# List of all intake available plugins with their 
+# List of all intake available plugins with their
 # module names on https://github.com/orgs/intake/repositories?type=all
 OPTIONAL_PLUGINS = {
     'intake-xarray': {
@@ -101,6 +100,6 @@ OPTIONAL_PLUGINS = {
 
 for plugin_info in OPTIONAL_PLUGINS.values():
     if is_module_satisfies(plugin_info['import_name']):
-        binaries ,plugin_datas, plugin_imports = collect_all(plugin_info['import_name'])
+        binaries, plugin_datas, plugin_imports = collect_all(plugin_info['import_name'])
         datas.extend(plugin_datas)
         hiddenimports.extend(plugin_imports)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-intake.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-intake.py
@@ -1,0 +1,106 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_all, is_module_satisfies
+
+_ , datas, hiddenimports = collect_all('intake')
+
+
+# Attention: Since PyInstaller basically process the modules that are 
+# imported in the code, and in the case of intake, when the plugin's 
+# drivers are installed, they are automatically get used via the main 
+# intake module. So, we need to check if the plugin's driver is installed 
+# and then process it in PyInstaller construction procedure to get the 
+# hidden imports and datas of the plugin.
+
+# List of all intake available plugins with their 
+# module names on https://github.com/orgs/intake/repositories?type=all
+OPTIONAL_PLUGINS = {
+    'intake-xarray': {
+        'import_name': 'intake_xarray'
+    },
+    'intake-parquet': {
+        'import_name': 'intake_parquet'
+    },
+    'intake-sql': {
+        'import_name': 'intake_sql'
+    },
+    'intake-elasticsearch': {
+        'import_name': 'intake_elasticsearch'
+    },
+    'intake-spark': {
+        'import_name': 'intake_spark'
+    },
+    'intake-accumulo': {
+        'import_name': 'intake_accumulo'
+    },
+    'intake-solr': {
+        'import_name': 'intake_solr'
+    },
+    'intake_geopandas': {
+        'import_name': 'intake_geopandas'
+    },
+    'intake-mongo': {
+        'import_name': 'intake_mongo'
+    },
+    'intake-google-analytics': {
+        'import_name': 'intake_google_analytics'
+    },
+    'intake-streamz': {
+        'import_name': 'intake_streamz'
+    },
+    'intake-postgres': {
+        'import_name': 'intake_postgres'
+    },
+    'intake-hbase': {
+        'import_name': 'intake_hbase'
+    },
+    'intake-sroka': {
+        'import_name': 'intake_sroka'
+    },
+    'intake-avro': {
+        'import_name': 'intake_avro'
+    },
+    'intake-esm': {
+        'import_name': 'intake_esm'
+    },
+    'intake-snappy': {
+        'import_name': 'intake_snappy'
+    },
+    'intake-odbc': {
+        'import_name': 'intake_odbc'
+    },
+    'intake-netflow': {
+        'import_name': 'intake_netflow'
+    },
+    'intake-pcap': {
+        'import_name': 'intake_pcap'
+    },
+    'intake-astro': {
+        'import_name': 'intake_astro'
+    },
+    'intake-splunk': {
+        'import_name': 'intake_splunk'
+    },
+    'intake-dremio': {
+        'import_name': 'intake_dremio'
+    },
+    'intake-duckdb': {
+        'import_name': 'intake_duckdb'
+    }
+}
+
+for plugin_info in OPTIONAL_PLUGINS.values():
+    if is_module_satisfies(plugin_info['import_name']):
+        binaries ,plugin_datas, plugin_imports = collect_all(plugin_info['import_name'])
+        datas.extend(plugin_datas)
+        hiddenimports.extend(plugin_imports)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-intake.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-intake.py
@@ -10,9 +10,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import collect_all, is_module_satisfies
+from PyInstaller.utils.hooks import copy_metadata, collect_submodules, is_module_satisfies
 
-_, datas, hiddenimports = collect_all('intake')
+hiddenimports = collect_submodules('intake')
+datas = copy_metadata('intake')
 
 # Attention: Since PyInstaller basically process the modules that are
 # imported in the code, and in the case of intake, when the plugin's
@@ -23,83 +24,36 @@ _, datas, hiddenimports = collect_all('intake')
 
 # List of all intake available plugins with their
 # module names on https://github.com/orgs/intake/repositories?type=all
-OPTIONAL_PLUGINS = {
-    'intake-xarray': {
-        'import_name': 'intake_xarray'
-    },
-    'intake-parquet': {
-        'import_name': 'intake_parquet'
-    },
-    'intake-sql': {
-        'import_name': 'intake_sql'
-    },
-    'intake-elasticsearch': {
-        'import_name': 'intake_elasticsearch'
-    },
-    'intake-spark': {
-        'import_name': 'intake_spark'
-    },
-    'intake-accumulo': {
-        'import_name': 'intake_accumulo'
-    },
-    'intake-solr': {
-        'import_name': 'intake_solr'
-    },
-    'intake_geopandas': {
-        'import_name': 'intake_geopandas'
-    },
-    'intake-mongo': {
-        'import_name': 'intake_mongo'
-    },
-    'intake-google-analytics': {
-        'import_name': 'intake_google_analytics'
-    },
-    'intake-streamz': {
-        'import_name': 'intake_streamz'
-    },
-    'intake-postgres': {
-        'import_name': 'intake_postgres'
-    },
-    'intake-hbase': {
-        'import_name': 'intake_hbase'
-    },
-    'intake-sroka': {
-        'import_name': 'intake_sroka'
-    },
-    'intake-avro': {
-        'import_name': 'intake_avro'
-    },
-    'intake-esm': {
-        'import_name': 'intake_esm'
-    },
-    'intake-snappy': {
-        'import_name': 'intake_snappy'
-    },
-    'intake-odbc': {
-        'import_name': 'intake_odbc'
-    },
-    'intake-netflow': {
-        'import_name': 'intake_netflow'
-    },
-    'intake-pcap': {
-        'import_name': 'intake_pcap'
-    },
-    'intake-astro': {
-        'import_name': 'intake_astro'
-    },
-    'intake-splunk': {
-        'import_name': 'intake_splunk'
-    },
-    'intake-dremio': {
-        'import_name': 'intake_dremio'
-    },
-    'intake-duckdb': {
-        'import_name': 'intake_duckdb'
-    }
-}
+OPTIONAL_PLUGINS = [
+    'intake_xarray',
+    'intake_parquet',
+    'intake_sql',
+    'intake_elasticsearch',
+    'intake_spark',
+    'intake_accumulo',
+    'intake_solr',
+    'intake_geopandas',
+    'intake_mongo',
+    'intake_google_analytics',
+    'intake_streamz',
+    'intake_postgres',
+    'intake_hbase',
+    'intake_sroka',
+    'intake_avro',
+    'intake_esm',
+    'intake_snappy',
+    'intake_odbc',
+    'intake_netflow',
+    'intake_pcap',
+    'intake_astro',
+    'intake_splunk',
+    'intake_dremio',
+    'intake_duckdb'
+]
 
-for plugin_info in OPTIONAL_PLUGINS.values():
-    if is_module_satisfies(plugin_info['import_name']):
-        binaries, plugin_datas, plugin_imports = collect_all(plugin_info['import_name'])
-        datas.extend(plugin_datas)
-        hiddenimports.extend(plugin_imports)
+for plugin in OPTIONAL_PLUGINS:
+    if is_module_satisfies(plugin):
+        metadata_datas = copy_metadata(plugin)
+        if metadata_datas:
+            datas.extend(metadata_datas)
+        hiddenimports.extend(collect_submodules(plugin))

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-zarr.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-zarr.py
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata, collect_submodules
+
+# Collect everything for intake
+datas = copy_metadata('zarr')
+hiddenimports = collect_submodules('zarr')

--- a/news/853.new.rst
+++ b/news/853.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``intake`` to ensure that package's data and 
+binaries of the drivers plugin are collected.

--- a/news/854.new.rst
+++ b/news/854.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``zarr`` to ensure that package's metadata and 
+plugins of the drivers plugin are collected.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -239,6 +239,7 @@ pysaml2==7.3.0; python_version < '3.9'  # pyup: ignore
 toga==0.4.8; python_version >= '3.9'
 numbers-parser==4.14.2; python_version >= '3.9'
 intake==2.0.7; python_version >= '3.9'
+zarr==3.0.0; python_version >= '3.9'
 h3==4.1.2
 selectolax==0.3.27
  ruamel.yaml.string==0.1.1

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -238,6 +238,7 @@ pysaml2==7.5.0; python_version >= '3.9'
 pysaml2==7.3.0; python_version < '3.9'  # pyup: ignore
 toga==0.4.8; python_version >= '3.9'
 numbers-parser==4.14.2; python_version >= '3.9'
+intake==2.0.7; python_version >= '3.9'
 h3==4.1.2
 selectolax==0.3.27
  ruamel.yaml.string==0.1.1

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2398,6 +2398,7 @@ def test_intake_basic_func(pyi_builder):
         assert isinstance(intake.Catalog(), intake.Catalog), "Failed to create intake Catalog"
     """)
 
+
 @importorskip('intake')
 def test_intake_driver_plugins(pyi_builder):
     pyi_builder.test_source("""

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2386,25 +2386,28 @@ def test_numbers_parser(pyi_builder, tmp_path):
         doc.save(output_filename)
     """, app_args=[str(output_filename)])
 
+
 @importorskip('intake')
 def test_intake(pyi_builder):
     pyi_builder.test_source("""
         import sys
         import intake
-        
+
         # TODO: change my version when updating the requirements
         assert intake.__version__ == '2.0.7', f"Expected intake version 2.0.7, got {intake.__version__}"
         assert isinstance(intake.Catalog(), intake.Catalog), "Failed to create intake Catalog"
-        
+
         # core registry plugins check
         plugins = intake.registry
         assert plugins is not None, "Plugin registry is None"
         plugins = set(plugins)
-        expected_core_plugins = {'jsonfiles', 'ndzarr', 'yaml_files_cat', 'textfiles', 'yaml_file_cat', 'tiled_cat', 'csv'}
+        expected_core_plugins = {'jsonfiles', 'ndzarr', 'yaml_files_cat', 'textfiles',
+                               'yaml_file_cat', 'tiled_cat', 'csv'}
         available_plugins = set(plugins)
-        assert expected_core_plugins.issubset(available_plugins), \
+        assert expected_core_plugins.issubset(available_plugins), (
             f"Missing core plugins. Expected at least {expected_core_plugins}, got {available_plugins}"
-        
+        )
+
         # driver plugin imports availibility check
         plugin_patterns = {
             'intake_xarray': ['xarray', 'netcdf', 'zarr'],
@@ -2417,6 +2420,7 @@ def test_intake(pyi_builder):
             'intake_geopandas': ['geopandas'],
             'intake_mongo': ['mongo']
         }
+
         for plugin_name, patterns in plugin_patterns.items():
             try:
                 __import__(plugin_name)

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2398,24 +2398,6 @@ def test_intake_basic_func(pyi_builder):
         assert isinstance(intake.Catalog(), intake.Catalog), "Failed to create intake Catalog"
     """)
 
-
-@importorskip('intake')
-def test_intake_core_plugins(pyi_builder):
-    pyi_builder.test_source("""
-        import intake
-        # core registry plugins check
-        plugins = intake.registry
-        assert plugins is not None, "Plugin registry is None"
-        plugins = set(plugins)
-        expected_core_plugins = {'jsonfiles', 'ndzarr', 'yaml_files_cat', 'textfiles',
-                               'yaml_file_cat', 'tiled_cat', 'csv'}
-        available_plugins = set(plugins)
-        assert expected_core_plugins.issubset(available_plugins), (
-            f"Missing core plugins. Expected at least {expected_core_plugins}, got {available_plugins}"
-        )
-    """)
-
-
 @importorskip('intake')
 def test_intake_driver_plugins(pyi_builder):
     pyi_builder.test_source("""

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2402,6 +2402,7 @@ def test_intake_basic_func(pyi_builder):
 @importorskip('intake')
 def test_intake_core_plugins(pyi_builder):
     pyi_builder.test_source("""
+        import intake
         # core registry plugins check
         plugins = intake.registry
         assert plugins is not None, "Plugin registry is None"
@@ -2418,6 +2419,8 @@ def test_intake_core_plugins(pyi_builder):
 @importorskip('intake')
 def test_intake_driver_plugins(pyi_builder):
     pyi_builder.test_source("""
+        import intake
+        plugins = intake.registry
         # driver plugin imports availibility check
         plugin_patterns = {
             'intake_xarray': ['xarray', 'netcdf', 'zarr'],

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2388,7 +2388,7 @@ def test_numbers_parser(pyi_builder, tmp_path):
 
 
 @importorskip('intake')
-def test_intake(pyi_builder):
+def test_intake_basic_func(pyi_builder):
     pyi_builder.test_source("""
         import sys
         import intake
@@ -2396,7 +2396,12 @@ def test_intake(pyi_builder):
         # TODO: change my version when updating the requirements
         assert intake.__version__ == '2.0.7', f"Expected intake version 2.0.7, got {intake.__version__}"
         assert isinstance(intake.Catalog(), intake.Catalog), "Failed to create intake Catalog"
+    """)
 
+
+@importorskip('intake')
+def test_intake_core_plugins(pyi_builder):
+    pyi_builder.test_source("""
         # core registry plugins check
         plugins = intake.registry
         assert plugins is not None, "Plugin registry is None"
@@ -2407,7 +2412,12 @@ def test_intake(pyi_builder):
         assert expected_core_plugins.issubset(available_plugins), (
             f"Missing core plugins. Expected at least {expected_core_plugins}, got {available_plugins}"
         )
+    """)
 
+
+@importorskip('intake')
+def test_intake_driver_plugins(pyi_builder):
+    pyi_builder.test_source("""
         # driver plugin imports availibility check
         plugin_patterns = {
             'intake_xarray': ['xarray', 'netcdf', 'zarr'],

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2431,6 +2431,22 @@ def test_intake_driver_plugins(pyi_builder):
     """)
 
 
+@importorskip('zarr')
+def test_zarr(pyi_builder):
+    pyi_builder.test_source("""
+        import zarr
+        import numpy as np
+
+        # minimalist test via an array to check if zarr lib is working
+        z = zarr.zeros((10, 10), chunks=(5, 5))
+
+        z[0:5, 0:5] = np.ones((5, 5))
+
+        data = z[0:5, 0:5]
+        assert (data == np.ones((5, 5))).all()
+    """)
+
+
 @importorskip('h3')
 def test_h3(pyi_builder):
     pyi_builder.test_source("""


### PR DESCRIPTION
Add hook for `zarr` to ensure that package's metadata and submodules of the drivers plugin are collected.