### PR TITLE
hooks: add hook for fsspec

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-fsspec.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-fsspec.py
@@ -10,7 +10,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import copy_metadata, collect_submodules
+from PyInstaller.utils.hooks import collect_submodules
 
-datas = copy_metadata('fsspec')
 hiddenimports = collect_submodules('fsspec')

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-fsspec.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-fsspec.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2024 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata, collect_submodules
+
+datas = copy_metadata('fsspec')
+hiddenimports = collect_submodules('fsspec')

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-fsspec.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-fsspec.py
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------
-# Copyright (c) 2024 PyInstaller Development Team.
+# Copyright (c) 2025 PyInstaller Development Team.
 #
 # This file is distributed under the terms of the GNU General Public
 # License (version 2.0 or later).

--- a/news/856.new.rst
+++ b/news/856.new.rst
@@ -1,2 +1,2 @@
-Add hook for ``fsspec`` to ensure that package's metadata 
-and submodules are collected.
+Add hook for ``fsspec`` to collect the package's submodules 
+and ensure the protocol plugins are working.

--- a/news/856.new.rst
+++ b/news/856.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``fsspec`` to ensure that package's metadata 
+and submodules are collected.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -238,6 +238,7 @@ pysaml2==7.5.0; python_version >= '3.9'
 pysaml2==7.3.0; python_version < '3.9'  # pyup: ignore
 toga==0.4.8; python_version >= '3.9'
 numbers-parser==4.14.2; python_version >= '3.9'
+fsspec==2024.12.0; python_version >= '3.9'
 h3==4.1.2
 selectolax==0.3.27
  ruamel.yaml.string==0.1.1

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2387,6 +2387,33 @@ def test_numbers_parser(pyi_builder, tmp_path):
     """, app_args=[str(output_filename)])
 
 
+@importorskip('fsspec')
+def test_fsspec(pyi_builder):
+    pyi_builder.test_source("""
+        import fsspec
+
+        # test mem fs via write and read sample txt file
+        mem = fsspec.filesystem('memory')
+        with mem.open('test.txt', 'w') as f:
+            f.write('PyInstaller bundled me, with no argument pass my test!')
+        with mem.open('test.txt', 'r') as f:
+            content = f.read()
+        assert content == 'PyInstaller bundled me, with no argument pass my test!', \
+            f"fs forgot what you wrote!"
+
+        # test local fs
+        local = fsspec.filesystem('file')
+        # basic functionality
+        files = local.ls('.')
+        assert len(files) >= 0
+
+        # test fs registry
+        registry = fsspec.available_protocols()
+        assert 'memory' in registry
+        assert 'file' in registry
+    """)
+
+
 @importorskip('h3')
 def test_h3(pyi_builder):
     pyi_builder.test_source("""

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2433,6 +2433,8 @@ def test_fsspec_protocols(pyi_builder, tmp_path):
     print(f"Frozen protocols: {protocols_frozen}")
 
     assert protocols_frozen == protocols_unfrozen
+
+
 @importorskip('zarr')
 @importorskip('xarray')
 def test_xarray_to_zarr(pyi_builder):


### PR DESCRIPTION
Add hook for `fsspec` to ensure that package's metadata and submodules of the drivers plugin are collected.