### PR TITLE
hooks: update `numba` hook for compatibility with upcoming v0.61

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-numba.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-numba.py
@@ -25,3 +25,30 @@ hiddenimports = ["llvmlite"]
 # around for backward compatibility with existing pickled data, but does not import it directly anymore.
 if is_module_satisfies("numba >= 0.59.0"):
     hiddenimports += ["numba.cloudpickle.cloudpickle_fast"]
+
+# numba 0.61 introduced new type system with several dynamic redirects using `numba.core.utils._RedirectSubpackage`;
+# depending on the run-time value of `numba.config.USE_LEGACY_TYPE_SYSTEM`, either "old" or "new" module variant is
+# loaded. All of these seem to be loaded when `numba` is imported, so there is no need for finer granularity. Also,
+# as the config value might be manipulated at run-time (e.g., via environment variable), we need to collect both old
+# and new module variants.
+if is_module_satisfies("numba >= 0.61.0rc1"):
+    # NOTE: `numba.core.typing` is also referenced indirectly via `_RedirectSubpackage`, but we do not need a
+    # hidden import entry for it, because we have entries for its submodules.
+    modules_old = [
+        'numba.core.datamodel.old_models',
+        'numba.core.old_boxing',
+        'numba.core.types.old_scalars',
+        'numba.core.typing.old_builtins',
+        'numba.core.typing.old_cmathdecl',
+        'numba.core.typing.old_mathdecl',
+        'numba.cpython.old_builtins',
+        'numba.cpython.old_hashing',
+        'numba.cpython.old_mathimpl',
+        'numba.cpython.old_numbers',
+        'numba.cpython.old_tupleobj',
+        'numba.np.old_arraymath',
+        'numba.np.random.old_distributions',
+        'numba.np.random.old_random_methods',
+    ]
+    modules_new = [name.replace('.old_', '.new_') for name in modules_old]
+    hiddenimports += modules_old + modules_new

--- a/news/857.update.rst
+++ b/news/857.update.rst
@@ -1,0 +1,1 @@
+Update ``numba`` hook for compatibility with ``numba`` v0.61.0.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -60,7 +60,7 @@ mnemonic==0.21
 msoffcrypto-tool==5.4.2
 nest-asyncio==1.6.0
 netCDF4==1.7.2; python_version >= '3.9'
-numba==0.60.0; python_version >= '3.9'
+numba==0.61.0; python_version >= '3.10'
 numcodecs==0.15.0; python_version >= '3.11'
 Office365-REST-Python-Client==2.5.14
 openpyxl==3.1.5

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -1993,6 +1993,33 @@ def test_iso639(pyi_builder):
     """)
 
 
+# Basic JIT test with numba
+@importorskip('numba')
+def test_numba_jit(pyi_builder):
+    pyi_builder.test_source("""
+        import numba
+
+        @numba.jit
+        def f(x, y):
+            return x + y
+
+        assert f(1, 2) == 3
+    """)
+
+
+# Basic import test with new type system enabled (numba >= 0.61).
+# Ideally, we would repeat the above `test_numba_jit`, but at the time of writing (numba 0.61.0rc2) it does not seem to
+# work even when unfrozen.
+@importorskip('numba')
+@pytest.mark.skipif(not is_module_satisfies('numba >= 0.61.0rc1'), reason="Requires numba >= 0.61.0.")
+def test_numba_new_type_system(pyi_builder):
+    pyi_builder.test_source("""
+        import os
+        os.environ['NUMBA_USE_LEGACY_TYPE_SYSTEM'] = '0'
+        import numba
+    """)
+
+
 # Check that `numba.cloudpickle.cloudpickle_fast` is collected even if it is not directly imported anywhere.
 @importorskip('numba')
 def test_numba_cloudpickle_fast(pyi_builder):


### PR DESCRIPTION
Add hidden imports for dynamically redirected and loaded modules that were introduced as part of the new type system in upcoming `numba` v0.61.0.

Extend `numba` tests with a basic test that uses `numba.jit`, and a basic import test with `NUMBA_USE_LEGACY_TYPE_SYSTEM` set to 0.

Closes pyinstaller/pyinstaller#8989.

Oneshot run (0.60, 0.61rc1, 0.61rc2): https://github.com/rokm/pyinstaller-hooks-contrib/actions/runs/12828775609