### PR TITLE
hooks: update numcodecs hook for compatibility with numcodecs v0.15.0

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-numcodecs.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-numcodecs.py
@@ -10,5 +10,11 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
+from PyInstaller.utils.hooks import is_module_satisfies
+
 # compat_ext is only imported from pyx files, so it is missed
 hiddenimports = ['numcodecs.compat_ext']
+
+# numcodecs v0.15.0 added an import of `deprecated` (from `Deprecated` dist) in one of its cythonized extension.
+if is_module_satisfies('numcodecs >= 0.15.0'):
+    hiddenimports += ['deprecated']

--- a/news/858.update.rst
+++ b/news/858.update.rst
@@ -1,0 +1,1 @@
+Update ``numcodecs`` hook for compatibility with ``numcodecs`` v0.15.0.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -61,7 +61,7 @@ msoffcrypto-tool==5.4.2
 nest-asyncio==1.6.0
 netCDF4==1.7.2; python_version >= '3.9'
 numba==0.60.0; python_version >= '3.9'
-numcodecs==0.14.1; python_version >= '3.11'
+numcodecs==0.15.0; python_version >= '3.11'
 Office365-REST-Python-Client==2.5.14
 openpyxl==3.1.5
 pandas==2.2.3; python_version >= '3.9'


### PR DESCRIPTION
Add a hidden import for `deprecated` module, which was added to one of cythonized extension in `numcodecs` v0.15.0.

Fixes pyinstaller/pyinstaller#8993.