### PR TITLE
hooks: add hooks for pypdfium2 and pypdfium2_raw

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-pypdfium2.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-pypdfium2.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+# Collect `version.json`.
+datas = collect_data_files("pypdfium2")

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-pypdfium2_raw.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-pypdfium2_raw.py
@@ -1,0 +1,19 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_dynamic_libs, collect_data_files
+
+# Collect the bundled pdfium shared library.
+binaries = collect_dynamic_libs('pypdfium2_raw')
+
+# Collect `version.json`.
+datas = collect_data_files("pypdfium2_raw")

--- a/news/860.new.rst
+++ b/news/860.new.rst
@@ -1,0 +1,1 @@
+Add hooks for ``pypdfium2`` and ``pypdfium2_raw``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -82,6 +82,7 @@ pyexcelerate==0.12.0
 pyexcel_ods==0.6.0
 pylibmagic==0.5.0; sys_platform != 'win32'
 pylint==3.3.3; python_version >= '3.9'
+pypdfium2==4.30.1
 pypemicro==0.1.11
 pyphen==0.17.0; python_version >= '3.9'
 pyppeteer==2.0.0

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2546,3 +2546,10 @@ def test_ruamel_yaml_string_plugin(pyi_builder):
         data  = dict(abc=42, help=['on', 'its', 'way'])
         print(yaml.dump_to_string(data))
     """)
+
+
+@importorskip('pypdfium2')
+def test_pypdfium2(pyi_builder):
+    pyi_builder.test_source("""
+        import pypdfium2
+    """)


### PR DESCRIPTION
Add hooks for `pypdfium2` (collect `version.json` file) and `pypdfium2_raw` (collect `version.json` file and bundled pdfium shared library).