### PR TITLE
rthooks: findlibs: gracefully handle TypeError on findlibs import

### DIFF
--- a/_pyinstaller_hooks_contrib/rthooks/pyi_rth_findlibs.py
+++ b/_pyinstaller_hooks_contrib/rthooks/pyi_rth_findlibs.py
@@ -20,7 +20,14 @@ def _pyi_rthook():
     import os
     import ctypes.util
 
-    import findlibs
+    # findlibs v0.1.0 broke compatibility with python < 3.10; due to incompatible typing annotation, attempting to
+    # import the package raises `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'`. Gracefully
+    # handle this situation by making this run-time hook no-op, in order to avoid crashing the frozen program even
+    # if it would never end up importing/using `findlibs`.
+    try:
+        import findlibs
+    except TypeError:
+        return
 
     _orig_find = getattr(findlibs, 'find', None)
 

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-gribapi.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-gribapi.py
@@ -20,7 +20,7 @@ from PyInstaller.utils.hooks import collect_data_files, logger
 datas = collect_data_files('gribapi')
 
 # Collect the eccodes shared library. Starting with eccodes 2.37.0, binary wheels with bundled shared library are
-# provided for linux and macOS.
+# provided for linux and macOS, and since 2.39.0, also for Windows.
 
 
 # NOTE: custom isolated function is used here instead of `get_module_attribute('gribapi.bindings', 'library_path')`
@@ -71,7 +71,7 @@ if library_path:
     package_parent_path = pathlib.PurePath(package_path).parent
 
     if package_parent_path in library_parent_path.parents:
-        # Should end up being `eccodes.libs` on Linux, and `eccodes/.dylib` on macOS).
+        # Should end up being `eccodes.libs` on Linux, `eccodes/.dylib` on macOS, and `eccodes` on Windows.
         dest_dir = str(library_parent_path.relative_to(package_parent_path))
     else:
         # External copy; collect into top-level application directory.

--- a/news/865.update.rst
+++ b/news/865.update.rst
@@ -1,0 +1,6 @@
+Update the ``findlibs`` run-time hook to gracefully handle ``TypeError``
+when using ``findlibs`` v0.1.0 with python < 3.10. This prevents the
+frozen application from crashing on the run-time hook when the main
+code might never end up using/importing ``findlibs`` at all (for example,
+``gribapi`` module from ``eccodes`` when binary wheel with bundled
+shared libraries is used).

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -32,6 +32,8 @@ dask[array,diagnostics]==2025.1.0; python_version >= '3.10'
 # discid requires libdiscid to be provided by the system.
 # We install it via apt-get and brew on ubuntu and macOS CI runners, respectively.
 discid==1.2.0; sys_platform != 'win32'
+# eccodes does not provide macOS binary wheels for python 3.8
+eccodes==2.40.0; sys_platform != 'darwin' or python_version >= '3.9'
 eth_typing==5.0.1
 eth_utils==5.2.0
 fabric==3.2.2
@@ -247,10 +249,6 @@ selectolax==0.3.27
  ruamel.yaml.string==0.1.1
 
 # ------------------- Platform (OS) specifics
-
-# eccodes package requires the eccodes shared library provided by the environment (linux distribution, homebrew, or Anaconda).
-# Starting with v2.37.0, binary wheels with bundled shared library are provided for linux and macOS 13+.
-eccodes==2.39.2; (sys_platform == 'darwin' or sys_platform == 'linux') and python_version < '3.13'
 
 # dbus-fast has pre-built wheels only for Linux; and D-Bus is available only there, anyway.
 dbus-fast==2.33.0; sys_platform == 'linux' and python_version >= '3.9'


### PR DESCRIPTION
`findlibs` v0.1.0 broke compatibility with python < 3.10; due to incompatible typing annotation, attempting to import the package raises `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'`.

Gracefully handle this situation by making this run-time hook no-op, in order to avoid crashing the frozen program even if it would never end up importing/using `findlibs` (which is the case with `gribapi` from `eccodes` when binary wheel with bundled shared libraries is used).

This one came up in today's pyup-bot update (https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/865).

In addition to adding work-around to run-time hook, also install `eccodes` on Windows and under python 3.13, since wheels for those are available now. Update the comments in the standard hook for `gribapi` to mention Windows.