### PR TITLE
Add winloop hook

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-winloop.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-winloop.py
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+#
+# Hook for the winloop (windows version of uvloop) package: https://pypi.python.org/pypi/winloop
+#
+from PyInstaller.utils.hooks import collect_submodules
+
+hiddenimports = collect_submodules('winloop')


### PR DESCRIPTION
As the Founding Developer of the Windows Version of `uvloop` I thought it should be time to finally give pyinstaller the support it deserves for `winloop` since the project has matured since it's creation back in 2023.
 