### PR TITLE
hooks: update rtree hook compatibility with rtree >= 1.4.0

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-rtree.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-rtree.py
@@ -34,7 +34,13 @@ else:
     binaries = collect_dynamic_libs('rtree')
 
     # With rtree >= 1.1.0, Linux PyPI wheels place the shared library in a `Rtree.libs` top-level directory.
+    # In rtree 1.4.0, the directory was renamed to `rtree.libs`
     if compat.is_linux:
         _, rtree_dir = get_package_paths('rtree')
-        rtree_libs_dir = pathlib.Path(rtree_dir).parent / 'Rtree.libs'
-        binaries += [(str(lib_file), 'Rtree.libs') for lib_file in rtree_libs_dir.glob("libspatialindex*.so*")]
+        for candidate_dir_name in ('rtree.libs', 'Rtree.libs'):
+            rtree_libs_dir = pathlib.Path(rtree_dir).parent / candidate_dir_name
+            if not rtree_libs_dir.is_dir():
+                continue
+            binaries += [
+                (str(lib_file), candidate_dir_name) for lib_file in rtree_libs_dir.glob("libspatialindex*.so*")
+            ]

--- a/news/875.update.rst
+++ b/news/875.update.rst
@@ -1,0 +1,2 @@
+Update ``rtree`` hook for compatibility with ``rtree`` 1.4.0 (renamed
+shared library directory in Linux PyPI wheels).

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -103,7 +103,7 @@ pyvista==0.44.2; python_version < '3.13' and (python_version >= '3.9' or sys_pla
 pyzmq==26.2.1
 PyQt5==5.15.11
 qtmodern==0.2.0
-Rtree==1.3.0
+Rtree==1.4.0; python_version >= '3.9'
 sacremoses==0.1.1
 # Remove after merging https://github.com/pyinstaller/pyinstaller/pull/6587
 scipy==1.15.2; python_version >= '3.10'


### PR DESCRIPTION
In `rtree` 1.4.0, the top-level directory used to store shared libraries on Linux was renamed from `Rtree.libs` to `rtree.libs`. Have the hook check for both directories and use whichever is available.