### PR TITLE
tests: add work-around for regression in fsspec 2025.3.0

### DIFF
--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -242,7 +242,7 @@ pysaml2==7.5.2; python_version >= '3.9'
 pysaml2==7.3.0; python_version < '3.9'  # pyup: ignore
 toga==0.4.9; python_version >= '3.9'
 numbers-parser==4.14.4; python_version >= '3.9'
-fsspec==2025.2.0; python_version >= '3.9'
+fsspec==2025.3.0; python_version >= '3.9'
 zarr==3.0.5; python_version >= '3.11'
 intake==2.0.8; python_version >= '3.9'
 h3==4.2.1

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2462,11 +2462,16 @@ def test_fsspec_protocols(pyi_builder, tmp_path):
                 working_protocols.append(protocol)
             except ImportError:
                 pass
+            except Exception:
+                # Work around for fsspec/filesystem_spec#1805
+                pass
 
         return sorted(working_protocols)
 
     protocols_unfrozen = _get_working_fsspec_protocols()
     print(f"Unfrozen protocols: {protocols_unfrozen}")
+
+    assert protocols_unfrozen, "No working protocols found!"
 
     # Obtain list of working protocols in frozen application.
     output_file = tmp_path / "output.txt"
@@ -2481,6 +2486,9 @@ def test_fsspec_protocols(pyi_builder, tmp_path):
                 obj = fsspec.get_filesystem_class(protocol)
                 working_protocols.append(protocol)
             except ImportError:
+                pass
+            except Exception:
+                # Work-around for fsspec/filesystem_spec#1805
                 pass
 
         with open(sys.argv[1], 'w') as fp:


### PR DESCRIPTION
In fsspec 2025.3.0, a new protocol entry was added to the registry without corresponding error message. This breaks our attempt to list working protocols, because fsspec's import handling code attempts to access non-existing `err` key, which results in a `KeyError` instead of `ImportError`. See https://github.com/fsspec/filesystem_spec/issues/1805.

Robustify the test by adding generic `Exception` handler in addition to the expected `ImportError` one.

Bump `fsspec` version to 2025.3.0.