### PR TITLE
hooks: add hook for (dask) distributed

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-distributed.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-distributed.py
@@ -1,0 +1,29 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2025, PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+# Collect submodules of distributed.http, many of which are imported indirectly.
+hiddenimports = collect_submodules("distributed.http")
+
+# Collect data files (distributed.yaml, distributed-schema.yaml, templates).
+datas = collect_data_files("distributed")
+
+# `distributed.dashboard.components.scheduler` attempts to refer to data files relative to its parent directory, but
+# with non-normalized '..' elements in the path (e.g., `_MEIPASS/distributed/dashboard/components/../theme.yaml`). On
+# POSIX systems, such paths are treated as non-existent if a component does not exist, even if the file exists at the
+# normalized location (i.e., if `_MEIPASS/distributed/dashboard/theme.yaml` file exists but
+# `_MEIPASS/distributed/dashboard/components` directory does not). As a work around, collect source .py files from
+# `distributed.dashboard.components` to ensure existence of the `components` directory.
+module_collection_mode = {
+    'distributed.dashboard.components': 'pyz+py',
+}

--- a/news/877.new.rst
+++ b/news/877.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``distributed`` package (i.e., ``dask.distributed``) to
+collect its data files and modules from ``distributed.http``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -28,7 +28,7 @@ cryptography==44.0.2
 dash==2.18.2
 dash-bootstrap-components==1.7.1; python_version >= '3.9'
 dash-uploader==0.6.1
-dask[diagnostics,array]==2025.2.0; python_version >= '3.10'
+dask[diagnostics,array,distributed]==2025.2.0; python_version >= '3.10'
 # discid requires libdiscid to be provided by the system.
 # We install it via apt-get and brew on ubuntu and macOS CI runners, respectively.
 discid==1.2.0; sys_platform != 'win32'

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2135,6 +2135,35 @@ def test_dask_array(pyi_builder):
     """)
 
 
+# Basic test for dask's `distributed` package, based on quickstart example from their documentation.
+@importorskip('distributed')
+def test_dask_distributed(pyi_builder):
+    pyi_builder.test_source("""
+        import multiprocessing
+        from dask.distributed import Client
+
+        def process():
+            client = Client()
+
+            def square(x):
+                return x ** 2
+
+            def neg(x):
+                return -x
+
+            A = client.map(square, range(10))
+            B = client.map(neg, A)
+
+            total = client.submit(sum, B)
+            return total.result()
+
+        if __name__ == '__main__':
+            multiprocessing.freeze_support()
+            result = process()
+            assert result == -285
+    """)
+
+
 @importorskip('tables')
 def test_pytables(pyi_builder):
     # NOTE: run_from_path=True prevents `pyi_builder` from completely clearing the `PATH` environment variable. At the


### PR DESCRIPTION
Add hook for `distributed` package (i.e., `dask.distributed`) to collect its data files and modules from `distributed.http`.