### PR TITLE
hooks: torch: fix path matching in MKL DLL collection part of the hook

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-torch.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-torch.py
@@ -125,9 +125,13 @@ if is_module_satisfies("PyInstaller >= 6.0"):
 
                 # Go over files, and match DLLs in <env>/Library/bin directory
                 for dist_file in dist.files:
-                    if not dist_file.match('../../Library/bin/*.dll'):
-                        continue
+                    # NOTE: `importlib_metadata.PackagePath.match()` does not seem to properly normalize the separator,
+                    # and on Windows, RECORD can apparently end up with entries that use either Windows or POSIX-style
+                    # separators (see pyinstaller/pyinstaller-hooks-contrib#879). This is why we first resolve the
+                    # file's location (which yields a `pathlib.Path` instance), and perform matching on resolved path.
                     dll_file = dist.locate_file(dist_file).resolve()
+                    if not dll_file.match('**/Library/bin/*.dll'):
+                        continue
                     mkl_binaries.append((str(dll_file), '.'))
 
             logger.info(

--- a/news/879.update.rst
+++ b/news/879.update.rst
@@ -1,0 +1,3 @@
+Fix path matching for MKL DLLs in ``torch`` hook to work with either
+POSIX-style or Windows-style separators, as either can appear in the
+metadata's RECORD entries.


### PR DESCRIPTION
Fix path matching for MKL DLLs in `torch` hook to work with either POSIX-style or Windows-style separators, as either can appear in the metadata's `RECORD` entries.

The `importlib_metadata.PackagePath.match()` does not seem to properly normalize the separator, so we now first resolve the file's location (which yields a `pathlib.Path`) and perform matching on resolved path.

Fixes #879.