### PR TITLE
hooks: add hook for python-dateutil

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-dateutil.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-dateutil.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files("dateutil")

--- a/news/881.new.rst
+++ b/news/881.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``python-dateutil`` to collect data files from the package.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -29,7 +29,7 @@ dash==2.18.2
 dash-bootstrap-components==1.7.1; python_version >= '3.9'
 dash-uploader==0.6.1
 dask[diagnostics,array,distributed]==2025.2.0; python_version >= '3.10'
-python-dateutil=2.9.0.post0
+python-dateutil==2.9.0.post0
 # discid requires libdiscid to be provided by the system.
 # We install it via apt-get and brew on ubuntu and macOS CI runners, respectively.
 discid==1.2.0; sys_platform != 'win32'

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -29,6 +29,7 @@ dash==2.18.2
 dash-bootstrap-components==1.7.1; python_version >= '3.9'
 dash-uploader==0.6.1
 dask[diagnostics,array,distributed]==2025.2.0; python_version >= '3.10'
+python-dateutil=2.9.0.post0
 # discid requires libdiscid to be provided by the system.
 # We install it via apt-get and brew on ubuntu and macOS CI runners, respectively.
 discid==1.2.0; sys_platform != 'win32'

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2624,6 +2624,7 @@ def test_pypdfium2(pyi_builder):
         import pypdfium2
     """)
 
+
 @importorskip('dateutil')
 def test_dateutil(pyi_builder):
     pyi_builder.test_source("""

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2623,3 +2623,11 @@ def test_pypdfium2(pyi_builder):
     pyi_builder.test_source("""
         import pypdfium2
     """)
+
+@importorskip('dateutil')
+def test_dateutil(pyi_builder):
+    pyi_builder.test_source("""
+        from dateutil.zoneinfo import getzoneinfofile_stream
+
+        assert getzoneinfofile_stream()
+    """)


### PR DESCRIPTION
This contains a data file dateutil-zoneinfo.tar.gz that we need to include for full functionality.