### PR TITLE
Debian fixes

### DIFF
--- a/_pyinstaller_hooks_contrib/rthooks/pyi_rth_pyqtgraph_multiprocess.py
+++ b/_pyinstaller_hooks_contrib/rthooks/pyi_rth_pyqtgraph_multiprocess.py
@@ -26,9 +26,9 @@ def _setup_pyqtgraph_multiprocess_hook():
     if len(sys.argv) == 2 and sys.argv[1] == os.path.join(sys._MEIPASS, 'pyqtgraph', 'multiprocess', 'bootstrap.py'):
         # Load as module; this requires --hiddenimport pyqtgraph.multiprocess.bootstrap
         try:
-            mod_name = 'pyqtgraph.multiprocess.bootstrap'
-            mod = __import__(mod_name)
-            bootstrap_co = mod.__loader__.get_code(mod_name)
+            import importlib.util
+            spec = importlib.util.find_spec("pyqtgraph.multiprocess.bootstrap")
+            bootstrap_co = spec.loader.get_code("pyqtgraph.multiprocess.bootstrap")
         except Exception:
             bootstrap_co = None
 
@@ -37,6 +37,7 @@ def _setup_pyqtgraph_multiprocess_hook():
             sys.exit(0)
 
         # Load from file; requires pyqtgraph/multiprocess/bootstrap.py collected as data file
+        # This is obsolete for PyInstaller >= v6.10.0
         bootstrap_file = os.path.join(sys._MEIPASS, 'pyqtgraph', 'multiprocess', 'bootstrap.py')
         if os.path.isfile(bootstrap_file):
             with open(bootstrap_file, 'r') as fp:

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-h5py.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-h5py.py
@@ -13,4 +13,6 @@
 Hook for http://pypi.python.org/pypi/h5py/
 """
 
-hiddenimports = ['h5py._proxy', 'h5py.utils', 'h5py.defs', 'h5py.h5ac']
+from PyInstaller.utils.hooks import collect_submodules
+
+hiddenimports = collect_submodules("h5py", lambda x: "tests" not in x)

--- a/news/873.update.1.rst
+++ b/news/873.update.1.rst
@@ -1,0 +1,2 @@
+Update ``pyproj`` hook to handle non pip/PyPI distributions' devendoring its
+data directory.

--- a/news/873.update.2.rst
+++ b/news/873.update.2.rst
@@ -1,0 +1,2 @@
+Update ``h5py`` hook to handle Debian's ``python3-h5py`` distribution of
+``h5py``.

--- a/news/886.update.rst
+++ b/news/886.update.rst
@@ -1,0 +1,1 @@
+Fix ``pyqtgraph.multiprocess`` in combination with PyInstaller >= v6.10.0.


### PR DESCRIPTION
Assorted fixes from #873. The first two are in response to custom Debian repackaging. I don't understand the third – it looks like the `pyqtgraph` one should never have worked before.

[Oneshot](https://github.com/bwoodsend/pyinstaller-hooks-contrib/actions/runs/13981821570) + [pyqtgraph on Linux](https://github.com/bwoodsend/pyinstaller-hooks-contrib/actions/runs/13982044546) (needs xvfb)