### PR TITLE
Replace use of get_installer with backported get_installer_for_dist

### DIFF
--- a/_pyinstaller_hooks_contrib/compat.py
+++ b/_pyinstaller_hooks_contrib/compat.py
@@ -40,3 +40,17 @@ else:
         # Validate the version
         if packaging.version.parse(importlib_metadata.version("importlib-metadata")) < packaging.version.parse("4.6"):
             raise ImportlibMetadataError()
+
+
+# Back-port of `PyInstaller.utils.hooks.get_installer_for_dist` from PyInstaller > 6.12, made available here for
+# compatibility with older PyInstaller versions.
+def get_installer_for_dist(dist_name: str):
+    try:
+        dist = importlib_metadata.distribution(dist_name)
+        installer_text = dist.read_text('INSTALLER')
+        if installer_text is not None:
+            return installer_text.strip()
+    except importlib_metadata.PackageNotFoundError:
+        pass
+
+    return None

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-enchant.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-enchant.py
@@ -18,8 +18,8 @@ Tested with PyEnchant 1.6.6.
 import os
 
 from PyInstaller.compat import is_darwin
-from PyInstaller.utils.hooks import exec_statement, collect_data_files, \
-    collect_dynamic_libs, get_installer
+from PyInstaller.utils.hooks import exec_statement, collect_data_files, collect_dynamic_libs
+from _pyinstaller_hooks_contrib.compat import get_installer_for_dist
 
 # TODO Add Linux support
 # Collect first all files that were installed directly into pyenchant
@@ -42,7 +42,7 @@ if is_darwin:
         print(e._name)
     """).strip()
 
-    installer = get_installer('enchant')
+    installer = get_installer_for_dist('pyenchant')
     if installer != 'pip':
         # Note: Name of detected enchant library is 'libenchant.dylib'. However, it
         #       is just symlink to 'libenchant.1.dylib'.

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-rtree.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-rtree.py
@@ -13,17 +13,14 @@
 import pathlib
 
 from PyInstaller import compat
-from PyInstaller.utils.hooks import collect_dynamic_libs, get_installer, get_package_paths
+from PyInstaller.utils.hooks import collect_dynamic_libs, get_package_paths
+from _pyinstaller_hooks_contrib.compat import get_installer_for_dist
 
 
-# Query the installer of the `rtree` package; in PyInstaller prior to 6.0, this might raise an exception, whereas in
-# later versions, None is returned.
-try:
-    package_installer = get_installer('rtree')
-except Exception:
-    package_installer = None
+# Query the installer of the `rtree` distribution.
+installer = get_installer_for_dist('rtree')
 
-if package_installer == 'conda':
+if installer == 'conda':
     from PyInstaller.utils.hooks import conda
 
     # In Anaconda-packaged `rtree`, `libspatialindex` and `libspatialindex_c` shared libs are packaged in a separate

--- a/news/887.update.rst
+++ b/news/887.update.rst
@@ -1,0 +1,4 @@
+Backport ``PyInstaller.utils.hooks.get_installer_for_dist`` hook utility
+function as ``_pyinstaller_hooks_contrib.compat.get_installer_for_dist``;
+update hooks for ``enchant`` and ``rtree`` to use this new utility function
+to query the installer type directly via dist name.


### PR DESCRIPTION
Backport `get_installer_for_dist` hook utility function from pyinstaller/pyinstaller#9067 into `_pyinstaller_hooks_contrib.compat`, and update hooks for `enchant` and `rtree` to use it instead of the old (and to-be deprecated) `PyInstaller.utils.hooks.get_installer`.