### PR TITLE
Add hooks for urllib3-future

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-niquests.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-niquests.py
@@ -12,9 +12,4 @@
 
 from PyInstaller.utils.hooks import collect_submodules
 
-
-hiddenimports = [
-    *collect_submodules("niquests"),
-    *collect_submodules("urllib3"),
-    *collect_submodules("urllib3_future"),
-]
+hiddenimports = collect_submodules("niquests")

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-urllib3.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-urllib3.py
@@ -1,0 +1,18 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_submodules, is_module_satisfies
+
+# If this is `urllib3` from `urllib3-future`, collect submodules in order to avoid missing modules due to indirect
+# imports. With `urllib3` from "classic" `urllib3`, this does not seem to be necessary.
+if is_module_satisfies("urllib3-future"):
+    hiddenimports = collect_submodules("urllib3")

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-urllib3_future.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-urllib3_future.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_submodules
+
+# Collect submodules in order to avoid missing modules due to indirect imports.
+hiddenimports = collect_submodules("urllib3_future")

--- a/news/893.new.rst
+++ b/news/893.new.rst
@@ -1,0 +1,3 @@
+Add hooks for ``urllib3`` and ``urllib3_future`` to handle indirect
+imports made by the ``urllib3-future`` implementation of the ``urllib3``
+package and its own ``urllib3_future`` package.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -154,6 +154,7 @@ trame-xterm==0.2.1
 Twisted==24.11.0
 tzdata==2025.2
 Unidecode==1.3.8
+urllib3-future==2.12.914
 # vtk provides arm64 macOS binary wheels only for python >= 3.9.
 vtk==9.4.1; python_version >= '3.9' or sys_platform != 'darwin' or platform_machine != 'arm64'
 # On macOS, weasyprint requires pango and glib installed via Homebrew; on arm64, the Homebrew is

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2667,3 +2667,31 @@ def test_emoji(pyi_builder):
     pyi_builder.test_source("""
         import emoji
     """)
+
+
+# Basic test for urllib3 - either from urllib3 or urllib3-future
+@importorskip('urllib3')
+def test_urllib3(pyi_builder):
+    pyi_builder.test_source("""
+        import urllib3
+
+        http = urllib3.PoolManager()
+        try:
+            resp = http.request("GET", "https://localhost/robots.txt")
+        except urllib3.exceptions.HTTPError:
+            pass
+    """)
+
+
+# Basic test for urllib3_future from urllib3-future
+@importorskip('urllib3_future')
+def test_urllib3_future(pyi_builder):
+    pyi_builder.test_source("""
+        import urllib3_future
+
+        http = urllib3_future.PoolManager()
+        try:
+            resp = http.request("GET", "https://localhost/robots.txt")
+        except urllib3_future.exceptions.HTTPError:
+            pass
+    """)


### PR DESCRIPTION
Add hooks for `urllib3` and `urllib3_future` to handle indirect imports made by the `urllib3-future` implementation of the `urllib3` package and its own `urllib3_future` package. Remove the submodule collection from these two packages from `niquests` hook, as this should be now handled by the newly-added hooks.