### PR TITLE
cleanup: replace occurrences of U+02D9 with backtick character

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,10 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
+    # Prevent @rokm from accidentally adding U+02D9 characters instead of backticks.
+    - name: Ensure that no U+02D9 characters are present
+      run: "! git grep -I $'\u02d9'"
+
     - name: Setup Python
       uses: actions/setup-python@v5
       with:

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-bitsandbytes.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-bitsandbytes.py
@@ -14,7 +14,7 @@ from PyInstaller.utils.hooks import collect_dynamic_libs
 
 # bitsandbytes contains several extensions for CPU and different CUDA versions: libbitsandbytes_cpu.so,
 # libbitsandbytes_cuda110_nocublaslt.so, libbitsandbytes_cuda110.so, etc. At build-time, we could query the
-# `bitsandbytes.cextension.setup` and its `binary_name˙ attribute for the extension that is in use. However, if the
+# `bitsandbytes.cextension.setup` and its `binary_name` attribute for the extension that is in use. However, if the
 # build system does not have CUDA available, this would automatically mean that we will not collect any of the CUDA
 # libs. So for now, we collect them all.
 binaries = collect_dynamic_libs("bitsandbytes")

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-gcloud.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-gcloud.py
@@ -14,7 +14,7 @@ from PyInstaller.utils.hooks import copy_metadata
 
 # This hook was written for `gcloud` - https://pypi.org/project/gcloud
 # Suppress package-not-found errors when the hook is triggered by `gcloud` namespace package from `gcloud-aio-*` and
-# `gcloud-rest-*˙ dists (https://github.com/talkiq/gcloud-aio).
+# `gcloud-rest-*` dists (https://github.com/talkiq/gcloud-aio).
 try:
     datas = copy_metadata('gcloud')
 except Exception:

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-transformers.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-transformers.py
@@ -8,7 +8,7 @@ from PyInstaller.utils.hooks import (
 datas = []
 
 # At run-time, `transformers` queries the metadata of several packages to check for their presence. The list of required
-# (core) packages is stored as `transformers.dependency_versions_check.pkgs_to_check_at_runtime˙. However, there is more
+# (core) packages is stored as `transformers.dependency_versions_check.pkgs_to_check_at_runtime`. However, there is more
 # comprehensive list of dependencies and their versions available in `transformers.dependency_versions_table.deps`,
 # which includes non-core dependencies. Unfortunately, we cannot foresee which of those the user will actually require,
 # so we collect metadata for all listed dists that are available in the build environment, in order to make them visible


### PR DESCRIPTION
Replace occurrences of the "dot above" (U+02D9) character with the intended backtick character.

A counterpart of https://github.com/pyinstaller/pyinstaller/pull/9083.