### PR TITLE
hooks: add hooks for submodules of vtkmodules from vtk dist

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -194,3 +194,13 @@ jobs:
       - name: Run slow tests (scikit-image)
         if: ${{ steps.check-scikit-image.outputs.AVAILABLE == 'yes' }}
         run: pytest -v -m slow -k skimage
+
+      - name: Check if slow tests are required (vtk)
+        id: check-vtk
+        shell: bash
+        run: |
+          grep -E "^vtk==" requirements-test-libraries.txt && echo "AVAILABLE=yes" >> $GITHUB_OUTPUT || echo "AVAILABLE=no" >> $GITHUB_OUTPUT
+
+      - name: Run slow tests (vtk)
+        if: ${{ steps.check-vtk.outputs.AVAILABLE == 'yes' }}
+        run: pytest -v -m slow -k test_vtkmodules

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkAcceleratorsVTKmCore.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkAcceleratorsVTKmCore.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkAcceleratorsVTKmDataModel.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkAcceleratorsVTKmDataModel.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkAcceleratorsVTKmFilters.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkAcceleratorsVTKmFilters.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkChartsCore.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkChartsCore.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkCommonColor.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkCommonColor.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkCommonComputationalGeometry.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkCommonComputationalGeometry.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkCommonDataModel.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkCommonDataModel.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkCommonExecutionModel.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkCommonExecutionModel.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkCommonMath.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkCommonMath.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkCommonMisc.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkCommonMisc.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkCommonPython.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkCommonPython.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkCommonSystem.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkCommonSystem.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkCommonTransforms.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkCommonTransforms.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkDomainsChemistry.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkDomainsChemistry.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkDomainsChemistryOpenGL2.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkDomainsChemistryOpenGL2.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersAMR.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersAMR.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersCellGrid.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersCellGrid.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersCore.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersCore.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersExtraction.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersExtraction.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersFlowPaths.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersFlowPaths.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersGeneral.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersGeneral.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersGeneric.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersGeneric.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersGeometry.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersGeometry.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersGeometryPreview.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersGeometryPreview.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersHybrid.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersHybrid.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersHyperTree.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersHyperTree.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersImaging.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersImaging.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersModeling.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersModeling.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersParallel.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersParallel.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersParallelDIY2.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersParallelDIY2.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersParallelImaging.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersParallelImaging.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersParallelStatistics.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersParallelStatistics.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersPoints.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersPoints.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersProgrammable.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersProgrammable.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersPython.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersPython.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersReduction.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersReduction.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersSMP.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersSMP.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersSelection.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersSelection.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersSources.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersSources.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersStatistics.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersStatistics.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersTemporal.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersTemporal.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersTensor.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersTensor.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersTexture.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersTexture.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersTopology.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersTopology.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersVerdict.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkFiltersVerdict.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkGeovisCore.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkGeovisCore.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOAMR.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOAMR.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOAsynchronous.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOAsynchronous.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOCGNSReader.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOCGNSReader.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOCONVERGECFD.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOCONVERGECFD.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOCellGrid.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOCellGrid.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOCesium3DTiles.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOCesium3DTiles.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOChemistry.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOChemistry.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOCityGML.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOCityGML.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOCore.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOCore.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOERF.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOERF.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOEnSight.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOEnSight.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOEngys.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOEngys.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOExodus.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOExodus.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOExport.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOExport.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOExportGL2PS.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOExportGL2PS.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOExportPDF.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOExportPDF.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOFDS.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOFDS.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOFLUENTCFF.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOFLUENTCFF.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOGeoJSON.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOGeoJSON.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOGeometry.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOGeometry.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOH5Rage.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOH5Rage.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOH5part.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOH5part.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOHDF.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOHDF.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOIOSS.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOIOSS.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOImage.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOImage.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOImport.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOImport.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOInfovis.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOInfovis.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOLSDyna.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOLSDyna.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOLegacy.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOLegacy.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOMINC.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOMINC.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOMotionFX.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOMotionFX.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOMovie.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOMovie.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIONetCDF.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIONetCDF.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOOMF.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOOMF.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOOggTheora.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOOggTheora.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOPIO.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOPIO.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOPLY.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOPLY.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOParallel.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOParallel.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOParallelExodus.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOParallelExodus.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOParallelLSDyna.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOParallelLSDyna.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOParallelXML.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOParallelXML.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOSQL.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOSQL.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOSegY.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOSegY.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOTRUCHAS.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOTRUCHAS.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOTecplotTable.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOTecplotTable.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOVPIC.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOVPIC.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOVeraOut.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOVeraOut.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOVideo.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOVideo.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOXML.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOXML.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOXMLParser.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOXMLParser.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOXdmf2.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkIOXdmf2.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingColor.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingColor.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingCore.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingCore.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingFourier.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingFourier.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingGeneral.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingGeneral.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingHybrid.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingHybrid.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingMath.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingMath.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingMorphological.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingMorphological.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingOpenGL2.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingOpenGL2.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingSources.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingSources.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingStatistics.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingStatistics.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingStencil.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkImagingStencil.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkInfovisCore.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkInfovisCore.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkInfovisLayout.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkInfovisLayout.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkInteractionImage.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkInteractionImage.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkInteractionStyle.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkInteractionStyle.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkInteractionWidgets.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkInteractionWidgets.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkParallelCore.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkParallelCore.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkPythonContext2D.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkPythonContext2D.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingAnnotation.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingAnnotation.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingCellGrid.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingCellGrid.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingContext2D.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingContext2D.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingContextOpenGL2.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingContextOpenGL2.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingCore.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingCore.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingExternal.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingExternal.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingFreeType.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingFreeType.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingGL2PSOpenGL2.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingGL2PSOpenGL2.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingHyperTreeGrid.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingHyperTreeGrid.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingImage.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingImage.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingLICOpenGL2.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingLICOpenGL2.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingLOD.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingLOD.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingLabel.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingLabel.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingMatplotlib.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingMatplotlib.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingOpenGL2.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingOpenGL2.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingParallel.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingParallel.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingSceneGraph.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingSceneGraph.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingUI.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingUI.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingVR.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingVR.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingVRModels.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingVRModels.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingVolume.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingVolume.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingVolumeAMR.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingVolumeAMR.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingVolumeOpenGL2.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingVolumeOpenGL2.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingVtkJS.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkRenderingVtkJS.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkSerializationManager.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkSerializationManager.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkTestingRendering.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkTestingRendering.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkViewsContext2D.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkViewsContext2D.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkViewsCore.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkViewsCore.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkViewsInfovis.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkViewsInfovis.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkWebCore.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkWebCore.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkWebGLExporter.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-vtkmodules.vtkWebGLExporter.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.utils.vtkmodules import add_vtkmodules_dependencies
+
+hiddenimports = add_vtkmodules_dependencies(__file__)

--- a/_pyinstaller_hooks_contrib/utils/vtkmodules.py
+++ b/_pyinstaller_hooks_contrib/utils/vtkmodules.py
@@ -1,0 +1,588 @@
+import os
+
+# This list of dependencies was obtained via analysis based on code in `vtkmodules/generate_pyi.py` and augmented with
+# missing entries until all tests from `test_vtkmodules` pass. Instead of a pre-computed list, we could dynamically
+# analyze each module when the hook is executed; however, such approach would be slower, and would also not account
+# for all dependencies that had to be added manually.
+#
+# NOTE: `vtkmodules.vtkCommonCore` is a dependency of every module, so do not list it here. Modules with no additional
+# dependencies are also not listed.
+_module_dependencies = {
+    'vtkmodules.vtkAcceleratorsVTKmDataModel': [
+        'vtkmodules.vtkAcceleratorsVTKmCore',
+        'vtkmodules.vtkCommonDataModel',
+    ],
+    'vtkmodules.vtkAcceleratorsVTKmFilters': [
+        'vtkmodules.vtkAcceleratorsVTKmCore',
+        'vtkmodules.vtkAcceleratorsVTKmDataModel',
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkFiltersCore',
+        'vtkmodules.vtkFiltersGeneral',
+        'vtkmodules.vtkFiltersGeometry',
+        'vtkmodules.vtkImagingCore',
+    ],
+    'vtkmodules.vtkChartsCore': [
+        'vtkmodules.vtkRenderingContext2D',
+        'vtkmodules.vtkFiltersGeneral',
+    ],
+    'vtkmodules.vtkCommonColor': [
+        'vtkmodules.vtkCommonDataModel',
+    ],
+    'vtkmodules.vtkCommonComputationalGeometry': [
+        'vtkmodules.vtkCommonDataModel',
+    ],
+    'vtkmodules.vtkCommonDataModel': [
+        'vtkmodules.vtkCommonMath',
+        'vtkmodules.vtkCommonTransforms',
+        'vtkmodules.util.data_model',
+    ],
+    'vtkmodules.vtkCommonExecutionModel': [
+        'vtkmodules.vtkCommonDataModel',
+        'vtkmodules.util.execution_model',
+    ],
+    'vtkmodules.vtkCommonMisc': [
+        'vtkmodules.vtkCommonMath',
+    ],
+    'vtkmodules.vtkCommonTransforms': [
+        'vtkmodules.vtkCommonMath',
+    ],
+    'vtkmodules.vtkDomainsChemistry': [
+        'vtkmodules.vtkCommonDataModel',
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkIOLegacy',
+        'vtkmodules.vtkIOXMLParser',
+        'vtkmodules.vtkRenderingCore',
+    ],
+    'vtkmodules.vtkDomainsChemistryOpenGL2': [
+        'vtkmodules.vtkDomainsChemistry',
+        'vtkmodules.vtkRenderingOpenGL2',
+    ],
+    'vtkmodules.vtkFiltersAMR': [
+        'vtkmodules.vtkCommonDataModel',
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkFiltersCellGrid': [
+        'vtkmodules.vtkCommonDataModel',
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkFiltersCore': [
+        'vtkmodules.vtkCommonDataModel',
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkCommonMisc',
+    ],
+    'vtkmodules.vtkFiltersExtraction': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkFiltersGeneral',
+    ],
+    'vtkmodules.vtkFiltersFlowPaths': [
+        'vtkmodules.vtkCommonComputationalGeometry',
+        'vtkmodules.vtkCommonDataModel',
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkCommonMath',
+    ],
+    'vtkmodules.vtkFiltersGeneral': [
+        'vtkmodules.vtkCommonDataModel',
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkFiltersCore',
+    ],
+    'vtkmodules.vtkFiltersGeneric': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkFiltersGeometry': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkFiltersGeometryPreview': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkFiltersHybrid': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkCommonTransforms',
+        'vtkmodules.vtkFiltersGeometry',
+    ],
+    'vtkmodules.vtkFiltersHyperTree': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkFiltersCore',
+        'vtkmodules.vtkFiltersGeneral',
+    ],
+    'vtkmodules.vtkFiltersImaging': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkFiltersStatistics',
+    ],
+    'vtkmodules.vtkFiltersModeling': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkFiltersGeneral',
+    ],
+    'vtkmodules.vtkFiltersParallel': [
+        'vtkmodules.vtkCommonDataModel',
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkFiltersCore',
+        'vtkmodules.vtkFiltersExtraction',
+        'vtkmodules.vtkFiltersGeneral',
+        'vtkmodules.vtkFiltersGeometry',
+        'vtkmodules.vtkFiltersHybrid',
+        'vtkmodules.vtkFiltersHyperTree',
+        'vtkmodules.vtkFiltersModeling',
+        'vtkmodules.vtkFiltersSources',
+        'vtkmodules.vtkFiltersTexture',
+    ],
+    'vtkmodules.vtkFiltersParallelDIY2': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkFiltersCore',
+        'vtkmodules.vtkFiltersParallel',
+    ],
+    'vtkmodules.vtkFiltersParallelImaging': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkFiltersImaging',
+        'vtkmodules.vtkFiltersParallel',
+        'vtkmodules.vtkImagingCore',
+    ],
+    'vtkmodules.vtkFiltersParallelStatistics': [
+        'vtkmodules.vtkFiltersStatistics',
+    ],
+    'vtkmodules.vtkFiltersPoints': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkFiltersModeling',
+    ],
+    'vtkmodules.vtkFiltersProgrammable': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkFiltersPython': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkFiltersReduction': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkFiltersSMP': [
+        'vtkmodules.vtkCommonDataModel',
+        'vtkmodules.vtkFiltersCore',
+        'vtkmodules.vtkFiltersGeneral',
+    ],
+    'vtkmodules.vtkFiltersSelection': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkFiltersSources': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkFiltersStatistics': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkFiltersTemporal': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkFiltersCore',
+    ],
+    'vtkmodules.vtkFiltersTensor': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkFiltersTexture': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkFiltersTopology': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkFiltersVerdict': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkGeovisCore': [
+        'vtkmodules.vtkCommonTransforms',
+    ],
+    'vtkmodules.vtkIOAMR': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOAsynchronous': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkIOCore',
+        'vtkmodules.vtkIOImage',
+        'vtkmodules.vtkIOXML',
+    ],
+    'vtkmodules.vtkIOCGNSReader': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOCONVERGECFD': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOCellGrid': [
+        'vtkmodules.vtkCommonDataModel',
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkFiltersCellGrid',
+        'vtkmodules.vtkIOCore',
+    ],
+    'vtkmodules.vtkIOCesium3DTiles': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkIOCore',
+    ],
+    'vtkmodules.vtkIOChemistry': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkIOCore',
+    ],
+    'vtkmodules.vtkIOCityGML': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOCore': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOERF': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOEnSight': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOEngys': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOExodus': [
+        'vtkmodules.vtkCommonDataModel',
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkIOCore',
+        'vtkmodules.vtkIOXMLParser',
+    ],
+    'vtkmodules.vtkIOExport': [
+        'vtkmodules.vtkIOCore',
+        'vtkmodules.vtkIOImage',
+        'vtkmodules.vtkIOXML',
+        'vtkmodules.vtkRenderingContext2D',
+        'vtkmodules.vtkRenderingCore',
+        'vtkmodules.vtkRenderingFreeType',
+        'vtkmodules.vtkRenderingVtkJS',
+    ],
+    'vtkmodules.vtkIOExportGL2PS': [
+        'vtkmodules.vtkIOExport',
+        'vtkmodules.vtkRenderingGL2PSOpenGL2',
+    ],
+    'vtkmodules.vtkIOExportPDF': [
+        'vtkmodules.vtkIOExport',
+        'vtkmodules.vtkRenderingContext2D',
+    ],
+    'vtkmodules.vtkIOFDS': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOFLUENTCFF': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOGeoJSON': [
+        'vtkmodules.vtkCommonDataModel',
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkIOCore',
+    ],
+    'vtkmodules.vtkIOGeometry': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkIOCore',
+        'vtkmodules.vtkIOLegacy',
+    ],
+    'vtkmodules.vtkIOH5Rage': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOH5part': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOHDF': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkIOCore',
+    ],
+    'vtkmodules.vtkIOIOSS': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkFiltersCellGrid',
+        'vtkmodules.vtkIOCore',
+    ],
+    'vtkmodules.vtkIOImport': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkRenderingCore',
+    ],
+    'vtkmodules.vtkIOImage': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkImagingCore',
+    ],
+    'vtkmodules.vtkIOInfovis': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkIOLegacy',
+        'vtkmodules.vtkIOXML',
+    ],
+    'vtkmodules.vtkIOLSDyna': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkIOXMLParser',
+    ],
+    'vtkmodules.vtkIOLegacy': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkIOCellGrid',
+        'vtkmodules.vtkIOCore',
+    ],
+    'vtkmodules.vtkIOMINC': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkIOCore',
+        'vtkmodules.vtkIOImage',
+    ],
+    'vtkmodules.vtkIOMotionFX': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOMovie': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIONetCDF': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkIOCore',
+    ],
+    'vtkmodules.vtkIOOMF': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOOggTheora': [
+        'vtkmodules.vtkIOMovie',
+    ],
+    'vtkmodules.vtkIOPIO': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOPLY': [
+        'vtkmodules.vtkIOCore',
+    ],
+    'vtkmodules.vtkIOParallel': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkIOCore',
+        'vtkmodules.vtkIOGeometry',
+        'vtkmodules.vtkIOImage',
+        'vtkmodules.vtkIOLegacy',
+    ],
+    'vtkmodules.vtkIOParallelExodus': [
+        'vtkmodules.vtkIOExodus',
+    ],
+    'vtkmodules.vtkIOParallelLSDyna': [
+        'vtkmodules.vtkIOLSDyna',
+    ],
+    'vtkmodules.vtkIOParallelXML': [
+        'vtkmodules.vtkIOXML',
+    ],
+    'vtkmodules.vtkIOSQL': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkIOCore',
+    ],
+    'vtkmodules.vtkIOSegY': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkIOImage',
+    ],
+    'vtkmodules.vtkIOTRUCHAS': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOTecplotTable': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOVPIC': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOVeraOut': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOVideo': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkIOXML': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkIOXMLParser',
+    ],
+    'vtkmodules.vtkIOXMLParser': [
+        'vtkmodules.vtkCommonDataModel',
+    ],
+    'vtkmodules.vtkIOXdmf2': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkIOLegacy',
+    ],
+    'vtkmodules.vtkImagingColor': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkImagingCore',
+    ],
+    'vtkmodules.vtkImagingCore': [
+        'vtkmodules.vtkCommonDataModel',
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkImagingFourier': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkImagingCore',
+    ],
+    'vtkmodules.vtkImagingGeneral': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkImagingCore',
+    ],
+    'vtkmodules.vtkImagingHybrid': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkImagingMath': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkImagingMorphological': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkImagingCore',
+        'vtkmodules.vtkImagingGeneral',
+    ],
+    'vtkmodules.vtkImagingOpenGL2': [
+        'vtkmodules.vtkImagingGeneral',
+        'vtkmodules.vtkRenderingOpenGL2',
+    ],
+    'vtkmodules.vtkImagingSources': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkImagingStatistics': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkImagingStencil': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkImagingCore',
+    ],
+    'vtkmodules.vtkInfovisCore': [
+        'vtkmodules.vtkCommonColor',
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkImagingSources',
+        'vtkmodules.vtkIOImage',
+        'vtkmodules.vtkRenderingFreeType',
+    ],
+    'vtkmodules.vtkInfovisLayout': [
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkInteractionImage': [
+        'vtkmodules.vtkRenderingCore',
+    ],
+    'vtkmodules.vtkInteractionStyle': [
+        'vtkmodules.vtkRenderingCore',
+    ],
+    'vtkmodules.vtkInteractionWidgets': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkFiltersGeneral',
+        'vtkmodules.vtkFiltersSources',
+        'vtkmodules.vtkRenderingContext2D',
+        'vtkmodules.vtkRenderingCore',
+    ],
+    'vtkmodules.vtkPythonContext2D': [
+        'vtkmodules.vtkRenderingContext2D',
+    ],
+    'vtkmodules.vtkRenderingAnnotation': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkRenderingCore',
+    ],
+    'vtkmodules.vtkRenderingCellGrid': [
+        'vtkmodules.vtkFiltersCellGrid',
+        'vtkmodules.vtkRenderingCore',
+        'vtkmodules.vtkRenderingOpenGL2',
+    ],
+    'vtkmodules.vtkRenderingContext2D': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkRenderingCore',
+    ],
+    'vtkmodules.vtkRenderingContextOpenGL2': [
+        'vtkmodules.vtkRenderingContext2D',
+        'vtkmodules.vtkRenderingFreeType',
+        'vtkmodules.vtkRenderingOpenGL2',
+    ],
+    'vtkmodules.vtkRenderingCore': [
+        'vtkmodules.vtkCommonDataModel',
+        'vtkmodules.vtkCommonExecutionModel',
+    ],
+    'vtkmodules.vtkRenderingExternal': [
+        'vtkmodules.vtkRenderingCore',
+        'vtkmodules.vtkRenderingOpenGL2',
+    ],
+    'vtkmodules.vtkRenderingFreeType': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkRenderingCore',
+    ],
+    'vtkmodules.vtkRenderingGL2PSOpenGL2': [
+        'vtkmodules.vtkRenderingOpenGL2',
+    ],
+    'vtkmodules.vtkRenderingHyperTreeGrid': [
+        'vtkmodules.vtkRenderingCore',
+    ],
+    'vtkmodules.vtkRenderingImage': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkRenderingCore',
+    ],
+    'vtkmodules.vtkRenderingLICOpenGL2': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkRenderingCore',
+        'vtkmodules.vtkRenderingOpenGL2',
+    ],
+    'vtkmodules.vtkRenderingLOD': [
+        'vtkmodules.vtkRenderingCore',
+    ],
+    'vtkmodules.vtkRenderingLabel': [
+        'vtkmodules.vtkCommonDataModel',
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkRenderingCore',
+        'vtkmodules.vtkRenderingFreeType',
+    ],
+    'vtkmodules.vtkRenderingMatplotlib': [
+        'vtkmodules.vtkRenderingFreeType',
+    ],
+    'vtkmodules.vtkRenderingOpenGL2': [
+        'vtkmodules.vtkFiltersGeneral',
+        'vtkmodules.vtkIOImage',
+        'vtkmodules.vtkRenderingCore',
+        'vtkmodules.vtkRenderingHyperTreeGrid',
+        'vtkmodules.vtkRenderingUI',
+    ],
+    'vtkmodules.vtkRenderingParallel': [
+        'vtkmodules.vtkRenderingCore',
+        'vtkmodules.vtkRenderingOpenGL2',
+    ],
+    'vtkmodules.vtkRenderingUI': [
+        'vtkmodules.vtkRenderingCore',
+    ],
+    'vtkmodules.vtkRenderingVR': [
+        'vtkmodules.vtkInteractionStyle',
+        'vtkmodules.vtkInteractionWidgets',
+        'vtkmodules.vtkIOXMLParser',
+        'vtkmodules.vtkRenderingCore',
+        'vtkmodules.vtkRenderingOpenGL2',
+        'vtkmodules.vtkRenderingVolumeOpenGL2',
+        'vtkmodules.vtkRenderingVRModels',
+    ],
+    'vtkmodules.vtkRenderingVRModels': [
+        'vtkmodules.vtkRenderingCore',
+        'vtkmodules.vtkRenderingOpenGL2',
+    ],
+    'vtkmodules.vtkRenderingVolume': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkRenderingCore',
+    ],
+    'vtkmodules.vtkRenderingVolumeAMR': [
+        'vtkmodules.vtkImagingCore',
+        'vtkmodules.vtkRenderingVolume',
+        'vtkmodules.vtkRenderingVolumeOpenGL2',
+    ],
+    'vtkmodules.vtkRenderingVolumeOpenGL2': [
+        'vtkmodules.vtkImagingCore',
+        'vtkmodules.vtkImagingMath',
+        'vtkmodules.vtkRenderingOpenGL2',
+        'vtkmodules.vtkRenderingVolume',
+    ],
+    'vtkmodules.vtkRenderingVtkJS': [
+        'vtkmodules.vtkRenderingSceneGraph',
+    ],
+    'vtkmodules.vtkTestingRendering': [
+        'vtkmodules.vtkImagingColor',
+        'vtkmodules.vtkIOXML',
+        'vtkmodules.vtkRenderingCore',
+    ],
+    'vtkmodules.vtkViewsContext2D': [
+        'vtkmodules.vtkRenderingCore',
+        'vtkmodules.vtkViewsCore',
+    ],
+    'vtkmodules.vtkViewsCore': [
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkInteractionWidgets',
+    ],
+    'vtkmodules.vtkViewsInfovis': [
+        'vtkmodules.vtkCommonDataModel',
+        'vtkmodules.vtkCommonExecutionModel',
+        'vtkmodules.vtkInteractionStyle',
+        'vtkmodules.vtkRenderingContext2D',
+        'vtkmodules.vtkViewsCore',
+    ],
+    'vtkmodules.vtkWebGLExporter': [
+        'vtkmodules.vtkIOExport',
+    ],
+}
+
+
+def add_vtkmodules_dependencies(hook_file):
+    # Find the module underlying this vtkmodules hook: change `/path/to/hook-vtkmodules.blah.py` to `vtkmodules.blah`.
+    hook_name, hook_ext = os.path.splitext(os.path.basename(hook_file))
+    assert hook_ext.startswith('.py')
+    assert hook_name.startswith('hook-')
+    module_name = hook_name[5:]
+
+    # Look up the list of hidden imports.
+    return ["vtkmodules.vtkCommonCore", *_module_dependencies.get(module_name, [])]

--- a/news/896.new.rst
+++ b/news/896.new.rst
@@ -1,0 +1,2 @@
+Add hooks for all submodules of ``vtkmodules`` package, which is
+installed by the ``vtk`` dist (currently targeting v9.4.2).

--- a/tests/test_vtkmodules.py
+++ b/tests/test_vtkmodules.py
@@ -1,0 +1,44 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+import pytest
+
+from PyInstaller import isolated
+from PyInstaller.utils.hooks import can_import_module
+from PyInstaller.utils.tests import importorskip
+
+
+# Run the tests in onedir mode only
+pytestmark = pytest.mark.parametrize('pyi_builder', ['onedir'], indirect=True)
+
+
+@isolated.decorate
+def _list_all_vtkmodules_submodules():
+    try:
+        import vtkmodules
+    except Exception:
+        return []
+
+    return sorted(list(vtkmodules.__all__))
+
+
+# Basic import tests for sub-modules of vtkmodules. Run only on demand, and only in onedir mode.
+@pytest.mark.slow
+@importorskip('vtkmodules')
+@pytest.mark.parametrize('submodule', _list_all_vtkmodules_submodules())
+def test_vtkmodules(pyi_builder, submodule):
+    modname = f"vtkmodules.{submodule}"
+    if not can_import_module(modname):
+        pytest.skip(f"Module '{modname}' cannot be imported.")
+    pyi_builder.test_source(f"""
+        import {modname}
+        """)


### PR DESCRIPTION
Add hooks for all submodules of the `vtkmodules` package, which is installed by the `vtk` dist.

Unfortunately, the `.pyi` files that accompany the extension modules do not provide all dependencies, so we need to maintain per-module list of hidden imports / dependencies ourselves.

Add individual import tests for all said submodules, so that we will know when the said list of dependencies need to be updated.