### PR TITLE
hooks: add hooks for black, blib2to3, frictionless

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-black.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-black.py
@@ -1,0 +1,29 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+from PyInstaller.utils.hooks import collect_submodules, collect_data_files
+
+# These are all imported from cythonized extensions.
+hiddenimports = [
+    'json',
+    'platform',
+    'click',
+    'mypy_extensions',
+    'pathspec',
+    '_black_version',
+    'platformdirs',
+    *collect_submodules('black'),
+    # blib2to3.pytree, blib2to3.pygen, various submodules from blib2to3.pgen2; best to just collect all submodules.
+    *collect_submodules('blib2to3'),
+]
+
+# Ensure that `black/resources/black.schema.json` is collected, in case someone tries to call `black.schema.get_schema`.
+datas = collect_data_files('black')

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-blib2to3.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-blib2to3.py
@@ -1,0 +1,35 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+from PyInstaller.utils.hooks import collect_submodules, collect_data_files
+from _pyinstaller_hooks_contrib.compat import importlib_metadata
+
+
+# Find the mypyc extension module for `black`, which is called something like `30fcd23745efe32ce681__mypyc`. The prefix
+# changes with each `black` version, so we need to obtain the name by looking at distribution's list of files.
+def _find_mypyc_module():
+    try:
+        dist = importlib_metadata.distribution("black")
+    except importlib_metadata.PackageNotFoundError:
+        return []
+    return [entry.name.split('.')[0] for entry in dist.files if '__mypyc' in entry.name]
+
+
+hiddenimports = [
+    *_find_mypyc_module(),
+    'dataclasses',
+    'pkgutil',
+    'tempfile',
+    *collect_submodules('blib2to3')
+]
+
+# Ensure that data files, such as `PatternGrammar.txt` and `Grammar.txt`, are collected.
+datas = collect_data_files('blib2to3')

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-frictionless.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-frictionless.py
@@ -1,0 +1,19 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+# Collect data files in frictionless/assets
+datas = collect_data_files('frictionless')
+
+# Collect modules from `frictionless.plugins` (programmatic imports).
+hiddenimports = collect_submodules('frictionless.plugins')

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-pydantic.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-pydantic.py
@@ -23,11 +23,12 @@ else:
     # ('True'), while in PyInstaller 5.x and later, the actual value is returned (True).
     is_compiled = get_module_attribute('pydantic', 'compiled') in {'True', True}
 
+# Collect submodules from pydantic; even if the package is not compiled, contemporary versions (2.11.1 at the time
+# of writing) contain redirections and programmatic imports.
+hiddenimports = collect_submodules('pydantic')
+
 if is_compiled:
-    # Compiled version; we need to manually collect the submodules from
-    # pydantic...
-    hiddenimports = collect_submodules('pydantic')
-    # ... as well as the following modules from the standard library
+    # In compiled version, we need to collect the following modules from the standard library.
     hiddenimports += [
         'colorsys',
         'dataclasses',

--- a/news/897.new.1.rst
+++ b/news/897.new.1.rst
@@ -1,0 +1,2 @@
+Add hook for ``frictionless`` to collect package's data files, and
+programmatically imported modules from ``frictionless.plugins``.

--- a/news/897.new.rst
+++ b/news/897.new.rst
@@ -1,0 +1,2 @@
+Add hooks for ``black`` and ``blikb2to3`` packages from the ``black``
+dist to collect hidden imports and data files.

--- a/news/897.update.rst
+++ b/news/897.update.rst
@@ -1,0 +1,3 @@
+Update hook for ``pydantic`` to always collect submodules from the package,
+in order to properly handle redirections and programmatic imports found
+in contemporary versions of ``pydantic``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -43,6 +43,7 @@ fabric==3.2.2
 falcon==4.0.2
 fiona==1.10.1; sys_platform != 'win32'
 folium==0.19.5; python_version >= '3.9'
+frictionless==5.18.1
 ffpyplayer==4.5.2
 geopandas==1.0.1; sys_platform != 'win32' and python_version >= '3.9'
 google-api-python-client==2.166.0

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -72,6 +72,7 @@ Office365-REST-Python-Client==2.6.1
 openpyxl==3.1.5
 pandas==2.2.3; python_version >= '3.9'
 panel==1.6.2; python_version >= '3.10'
+pandera==0.23.1; python_version >= '3.9'
 passlib==1.7.4
 pendulum==3.0.0
 phonenumbers==9.0.2

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -8,6 +8,7 @@ av==14.2.0; python_version >= '3.9'
 adbutils==2.8.6; sys_platform != 'darwin' or platform_machine != 'arm64'
 APScheduler==3.11.0
 backports.zoneinfo==0.2.1; python_version < '3.9'
+black==25.1.0; python_version >= '3.9'
 bokeh==3.7.2; python_version >= '3.10'
 boto==2.49.0
 boto3==1.37.23

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2792,3 +2792,35 @@ def test_frictionless(pyi_builder, tmp_path):
         output = frictionless.validate(filename)
         pprint.pprint(output)
     """, app_args=[str(csv_file)])
+
+
+@importorskip('pandas')
+@importorskip('pandera')
+def test_pandera(pyi_builder):
+    # Example from pandera's Quick Start
+    pyi_builder.test_source("""
+        import pandas as pd
+        import pandera as pa
+
+        # data to validate
+        df = pd.DataFrame({
+            "column1": [1, 4, 0, 10, 9],
+            "column2": [-1.3, -1.4, -2.9, -10.1, -20.4],
+            "column3": ["value_1", "value_2", "value_3", "value_2", "value_1"]
+        })
+
+        # define schema
+        schema = pa.DataFrameSchema({
+            "column1": pa.Column(int, checks=pa.Check.le(10)),
+            "column2": pa.Column(float, checks=pa.Check.lt(-1.2)),
+            "column3": pa.Column(str, checks=[
+                pa.Check.str_startswith("value_"),
+                # define custom checks as functions that take a series as input and
+                # outputs a boolean or boolean Series
+                pa.Check(lambda s: s.str.split("_", expand=True).shape[1] == 2)
+            ]),
+        })
+
+        validated_df = schema(df)
+        print(validated_df)
+    """)

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2754,3 +2754,41 @@ def test_black_blib2to3_pytree(pyi_builder):
     pyi_builder.test_source("""
         import blib2to3.pytree
     """)
+
+
+@importorskip('frictionless')
+def test_frictionless(pyi_builder, tmp_path):
+    # Example CSV file, taken from upstream example at
+    # https://framework.frictionlessdata.io/docs/getting-started.html
+    csv_file = tmp_path / "example.csv"
+    csv_file.write_text("\n".join([
+        "id,name,,name"
+        "1,english"
+        "1,english"
+        ""
+        "2,german,1,2,3"
+    ]))
+
+    pyi_builder.test_source("""
+        import sys
+        import pprint
+
+        import frictionless
+
+        filename = sys.argv[1]
+
+        # frictionless.describe()
+        print("Testing frictionless.describe...")
+        output = frictionless.describe(filename)
+        pprint.pprint(output)
+
+        # frictionless.extract()
+        print("Testing frictionless.extract...")
+        output = frictionless.extract(filename)
+        pprint.pprint(output)
+
+        # frictionless.validate()
+        print("Testing frictionless.validate...")
+        output = frictionless.validate(filename)
+        pprint.pprint(output)
+    """, app_args=[str(csv_file)])

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2706,3 +2706,51 @@ def test_urllib3_future(pyi_builder):
         except urllib3_future.exceptions.HTTPError:
             pass
     """)
+
+
+@importorskip('black')
+def test_black(pyi_builder):
+    pyi_builder.test_source("""
+        import black
+
+        mode = black.Mode(
+            target_versions=set(),  # auto-detect
+            line_length=120,
+        )
+
+        code = "print ('hello, world') "
+        print("Original code: {code!r}")
+
+        reformatted_code = black.format_file_contents(
+            code,
+            fast=False,
+            mode=mode,
+        )
+        print("Reformatted code: {code!r}")
+
+        # Try reformatting again - this should raise black.NothingChanged
+        try:
+            reformatted_code2 = black.format_file_contents(
+                reformatted_code,
+                fast=False,
+                mode=mode,
+            )
+        except black.NothingChanged:
+            pass
+        else:
+            raise RuntimeError("black.NothingChanged exception was not raised!")
+    """)
+
+
+@importorskip('blib2to3')
+def test_black_blib2to3_pygram(pyi_builder):
+    pyi_builder.test_source("""
+        import blib2to3.pygram
+    """)
+
+
+@importorskip('blib2to3')
+def test_black_blib2to3_pytree(pyi_builder):
+    pyi_builder.test_source("""
+        import blib2to3.pytree
+    """)


### PR DESCRIPTION
Add hooks for `black` / `blib2to3` and `frictionless`, and update `pydantic` hook to always collect package's submodules. Add a test for `pandera` (which does not need its own hook, but needs the other changes from this PR).

Based on https://github.com/orgs/pyinstaller/discussions/9073.

In the case of `black` and `blib2to3`, most of the hidden imports could actually be sorted out by analyzing .py files that are bundled together with the extensions (except for the pesky `<something>__mypyc`, which we find by going through the list of files in the dist's metadata). But for compatibility with existing PyInstaller versions, we do the classic `collect_submodules` approach.