### PR TITLE
Add TkinterWeb and TkinterWeb-Tkhtml hooks

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-tkinterweb.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-tkinterweb.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+# Collect files from 'resources'
+datas = collect_data_files('tkinterweb')

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-tkinterweb_tkhtml.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-tkinterweb_tkhtml.py
@@ -1,0 +1,19 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs
+
+# Collect files from 'tkhtml'
+datas = collect_data_files('tkinterweb_tkhtml')
+
+# Collect binaries from 'tkhtml'
+binaries = collect_dynamic_libs('tkinterweb_tkhtml')

--- a/news/899.new.rst
+++ b/news/899.new.rst
@@ -1,0 +1,1 @@
+Add hooks for ``tkinterweb``, to collect data files, and ``tkinterweb-tkhtml``, to collect extra data files and binaries.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -258,6 +258,8 @@ selectolax==0.3.28
 ruamel.yaml.string==0.1.1
 niquests==3.14.0
 emoji==2.14.1
+tkinterweb==4.3.0
+tkinterweb-tkhtml==1.0
 
 # ------------------- Platform (OS) specifics
 

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2854,7 +2854,7 @@ def test_tkinterweb_tkhtml(pyi_builder):
 
         folder = tkinterweb_tkhtml.get_tkhtml_folder()
         tkinterweb_tkhtml.load_tkhtml(root, folder)
-    
+
         frame = tkinter.Widget(root, "html")
 
         # Load a test string

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2828,8 +2828,6 @@ def test_pandera(pyi_builder):
 
 @importorskip('tkinterweb')
 def test_tkinterweb(pyi_builder):
-    # Simple TkinterWeb test script
-    # This also tests TkinterWeb-Tkhtml behind the scenes
     pyi_builder.test_source("""
         import tkinter
         import tkinterweb
@@ -2843,4 +2841,22 @@ def test_tkinterweb(pyi_builder):
                             <p>Hello Again!</p> \
                             <select><option>Hi...</option></select>"
                             )
+    """)
+
+
+@importorskip('tkinterweb_tkhtml')
+def test_tkinterweb_tkhtml(pyi_builder):
+    pyi_builder.test_source("""
+        import tkinter
+        import tkinterweb_tkhtml
+
+        root = tkinter.Tk()
+
+        folder = tkinterweb_tkhtml.get_tkhtml_folder()
+        tkinterweb_tkhtml.load_tkhtml(root, folder)
+    
+        frame = tkinter.Widget(root, "html")
+
+        # Load a test string
+        frame.tk.call(frame._w, "parse", "<p>Hello, World!</p>")
     """)

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2824,3 +2824,23 @@ def test_pandera(pyi_builder):
         validated_df = schema(df)
         print(validated_df)
     """)
+
+
+@importorskip('tkinterweb')
+def test_tkinterweb(pyi_builder):
+    # Simple TkinterWeb test script
+    # This also tests TkinterWeb-Tkhtml behind the scenes
+    pyi_builder.test_source("""
+        import tkinter
+        import tkinterweb
+
+        root = tkinter.Tk()
+        frame = tkinterweb.HtmlFrame(root, messages_enabled=False)
+
+        # Load a test string that uses all files that should have been bundled
+        frame.load_html(
+                            "<img src='this path doesn't exist' alt='Hello, World!'/> \
+                            <p>Hello Again!</p> \
+                            <select><option>Hi...</option></select>"
+                            )
+    """)


### PR DESCRIPTION
Hello!

I've been getting complaints about my package TkinterWeb not working with PyInstaller and thought I would add a hook now that the package is more mature.

I included hooks for both TkinterWeb and its child package TkinterWeb-Tkhtml but only included a test for Tkinterweb as it also tests TkinterWeb-Tkhtml indirectly. 

Hopefully this will suffice?

Thanks!