### PR TITLE
Disable hiddenimports for pandas_flavor >= 0.7.0

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-pandas_flavor.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-pandas_flavor.py
@@ -10,6 +10,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
+from PyInstaller.utils.hooks import is_module_satisfies
+
 # As of version 0.3.0, pandas_flavor uses lazy loader to import `register` and `xarray` sub-modules. In earlier
-# versions, these used to be imported directly.
-hiddenimports = ['pandas_flavor.register', 'pandas_flavor.xarray']
+# versions, these used to be imported directly. This was removed in 0.7.0.
+if is_module_satisfies("pandas_flavor >= 0.3.0, < 0.7.0"):
+    hiddenimports = ['pandas_flavor.register', 'pandas_flavor.xarray']

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -260,6 +260,7 @@ niquests==3.14.0
 emoji==2.14.1
 tkinterweb==4.3.0
 tkinterweb-tkhtml==1.0
+pandas_flavor==0.7.0
 
 # ------------------- Platform (OS) specifics
 

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -984,6 +984,17 @@ def test_panel(pyi_builder):
         """)
 
 
+@importorskip("pandas_flavor")
+def test_pandas_flavor(pyi_builder):
+    pyi_builder.test_source("""
+        from pandas_flavor import register_dataframe_accessor
+
+        @register_dataframe_accessor("dummy")
+        class DummyAccessor:
+            pass
+    """)
+
+
 @importorskip("pyviz_comms")
 def test_pyviz_comms(pyi_builder):
     pyi_builder.test_source("""


### PR DESCRIPTION
Its lazy loader has been removed.

<!---
Please review the summary checklist before submitting your pull request
https://github.com/pyinstaller/pyinstaller-hooks-contrib?tab=readme-ov-file#summary
--->
