### PR TITLE
hooks: fix narwhals hook when typing_extensions is unavailable

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-narwhals.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-narwhals.py
@@ -10,9 +10,13 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import copy_metadata, is_module_satisfies
+import sys
+from PyInstaller.utils.hooks import can_import_module, copy_metadata, is_module_satisfies
 
-# Starting with narwhals 1.35.0, we need to collect metadata for `typing_extensions`.
+# Starting with narwhals 1.35.0, we need to collect metadata for `typing_extensions` if the module is available.
+# The codepath that checks metadata for `typing_extensions` is not executed under python >= 3.13, so we can avoid
+# collection there.
 datas = []
-if is_module_satisfies("narwhals >= 1.35.0"):
-    datas += copy_metadata("typing_extensions")
+if sys.version_info < (3, 13):  # PyInstaller.compat.is_py313 is available only in PyInstaller >= 6.10.0.
+    if is_module_satisfies("narwhals >= 1.35.0") and can_import_module("typing_extensions"):
+        datas += copy_metadata("typing_extensions")

--- a/news/908.update.rst
+++ b/news/908.update.rst
@@ -1,0 +1,3 @@
+Fix error in ``narwhals`` hook when ``typing-extensions`` is not available
+in the build environment (neither stand-alone version is installed
+nor it is provided as part of ``setuptools``).


### PR DESCRIPTION
Have the `narwhals` hook check that `typing_extensions` is importable before trying to collect metadata for `typing_extensions` dist.

This fixes error when `typing-extensions` is unavailable (neither stand-alone dist is installed nor it is provided as part of `setuptools`), and also matches the behavior of `narwhals`, which tries to query the version via metadata only if `typing_extensions` is importable.

In addition, since `narwhals` queries metadata only on python < 3.13, skip the metadata collection when building with python 3.13 or later.

Fixes #907.