### PR TITLE
Fixed issue #912 (USB find_library callback)

### DIFF
--- a/news/913.update.rst
+++ b/news/913.update.rst
@@ -1,1 +1,2 @@
-``usb`` hook: added support for the find_library callback function.
+Have the ``_load_library`` override installed by the ``usb`` run-time
+hook honor the passed ``find_library`` argument.

--- a/news/913.update.rst
+++ b/news/913.update.rst
@@ -1,0 +1,1 @@
+``usb`` hook: added support for the find_library callback function.


### PR DESCRIPTION
With this change, the ``find_library`` argument is now handled properly which fixed custom libusb file loading under pyinstaller. See issue #912 for details.


