### PR TITLE
hooks: add hooks for subpackages of sklearn.externals.array_api_compat

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-sklearn.externals.array_api_compat.cupy.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-sklearn.externals.array_api_compat.cupy.py
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# These hidden imports are required due to the following statements found in the package's `__init__.py`:
+# ```
+# __import__(__package__ + '.linalg')
+# __import__(__package__ + '.fft')
+# ```
+hiddenimports = [
+    'sklearn.externals.array_api_compat.cupy.fft',
+    'sklearn.externals.array_api_compat.cupy.linalg',
+]

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-sklearn.externals.array_api_compat.dask.array.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-sklearn.externals.array_api_compat.dask.array.py
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# These hidden imports are required due to the following statements found in the package's `__init__.py`:
+# ```
+# __import__(__package__ + '.linalg')
+# __import__(__package__ + '.fft')
+# ```
+hiddenimports = [
+    'sklearn.externals.array_api_compat.dask.array.fft',
+    'sklearn.externals.array_api_compat.dask.array.linalg',
+]

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-sklearn.externals.array_api_compat.numpy.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-sklearn.externals.array_api_compat.numpy.py
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# These hidden imports are required due to the following statements found in the package's `__init__.py`:
+# ```
+# __import__(__package__ + '.linalg')
+# __import__(__package__ + '.fft')
+# ```
+hiddenimports = [
+    'sklearn.externals.array_api_compat.numpy.fft',
+    'sklearn.externals.array_api_compat.numpy.linalg',
+]

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-sklearn.externals.array_api_compat.torch.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-sklearn.externals.array_api_compat.torch.py
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# These hidden imports are required due to the following statements found in the package's `__init__.py`:
+# ```
+# __import__(__package__ + '.linalg')
+# __import__(__package__ + '.fft')
+# ```
+hiddenimports = [
+    'sklearn.externals.array_api_compat.torch.fft',
+    'sklearn.externals.array_api_compat.torch.linalg',
+]

--- a/news/915.new.rst
+++ b/news/915.new.rst
@@ -1,0 +1,8 @@
+Extend hooks for ``slearn`` to fix compatibility with ``scikit-learn``
+v1.7.0; add hooks for ``sklearn.externals.array_api_compat.cupy``,
+``sklearn.externals.array_api_compat.dask.array``,
+``sklearn.externals.array_api_compat.numpy``, and
+``sklearn.externals.array_api_compat.torch`` that specify hidden imports
+for corresponding ``.linalg`` and ``.fft`` sub-modules, which are
+imported with using ``__import__()`` function and programmatically-generated
+names.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -190,7 +190,7 @@ spiceypy==6.0.0
 exchangelib==5.5.1; python_version >= '3.9'
 NBT==1.5.1
 minecraft-launcher-lib==7.1; python_version >= '3.10'
-scikit-learn==1.6.1; python_version >= '3.9'
+scikit-learn==1.7.0; python_version >= '3.10'
 scikit-image==0.25.2; python_version >= '3.10'
 customtkinter==5.2.2
 fastparquet==2024.11.0; python_version >= '3.9'


### PR DESCRIPTION
Add hooks for subpackages of `sklearn.externals.array_api_compat`:
- `sklearn.externals.array_api_compat.cupy`
- `sklearn.externals.array_api_compat.dask.array`
- `sklearn.externals.array_api_compat.numpy`
- `sklearn.externals.array_api_compat.torch`

These were introduced in `scikit-learn` v1.7.0 and require hidden imports due to the following programmatic imports:

```
__import__(__package__ + '.linalg')
__import__(__package__ + '.fft')
```

Fixes #914.

<!---
Please review the summary checklist before submitting your pull request
https://github.com/pyinstaller/pyinstaller-hooks-contrib?tab=readme-ov-file#summary
--->
