### PR TITLE
hooks: add a hook for torchao

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-torchao.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-torchao.py
@@ -1,0 +1,14 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# Collect source .py files for JIT/torchscript.
+module_collection_mode = 'pyz+py'

--- a/news/917.new.rst
+++ b/news/917.new.rst
@@ -1,0 +1,1 @@
+Add hook for ``torchao`` to collect its source .py files for TorchScript/JIT.


### PR DESCRIPTION
Add a hook for `torchao`, which ensures that the package's source .py files are collected, as they are required for TorchScript.

Closes https://github.com/pyinstaller/pyinstaller/issues/9169.