### PR TITLE
cleanup: test requirements

### DIFF
--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -1,6 +1,3 @@
-# Backport of importlib.resources for python 3.8; last version that supports python 3.8 is v6.4.5.
-importlib_resources==6.4.5; python_version < "3.9"  # pyup: ignore
-
 # ------------------ LIBRARIES ------------------ #
 # TODO: Add most of the libraries we have hooks for, and write tests
 av==15.0.0; python_version >= "3.9"
@@ -250,7 +247,6 @@ patool==4.0.1; python_version >= "3.10"
 yapf==0.43.0
 xmlschema==4.1.0; python_version >= "3.9"
 pysaml2==7.5.2; python_version >= "3.9"
-pysaml2==7.3.0; python_version < "3.9"  # pyup: ignore
 toga==0.5.1; python_version >= "3.9"
 numbers-parser==4.15.1; python_version >= "3.9"
 fsspec==2025.5.1; python_version >= "3.9"

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -1,133 +1,133 @@
 # Backport of importlib.resources for python 3.8; last version that supports python 3.8 is v6.4.5.
-importlib_resources==6.4.5; python_version < '3.9'  # pyup: ignore
+importlib_resources==6.4.5; python_version < "3.9"  # pyup: ignore
 
 # ------------------ LIBRARIES ------------------ #
 # TODO: Add most of the libraries we have hooks for, and write tests
-av==15.0.0; python_version >= '3.9'
+av==15.0.0; python_version >= "3.9"
 # adbutils does not provide arm64 macOS wheels.
-adbutils==2.9.3; sys_platform != 'darwin' or platform_machine != 'arm64'
+adbutils==2.9.3; sys_platform != "darwin" or platform_machine != "arm64"
 APScheduler==3.11.0
-backports.zoneinfo==0.2.1; python_version < '3.9'
-black==25.1.0; python_version >= '3.9'
-bokeh==3.7.3; python_version >= '3.10'
+backports.zoneinfo==0.2.1; python_version < "3.9"
+black==25.1.0; python_version >= "3.9"
+bokeh==3.7.3; python_version >= "3.10"
 boto==2.49.0
-boto3==1.39.3; python_version >= '3.9'
-botocore==1.39.3; python_version >= '3.9'
+boto3==1.39.3; python_version >= "3.9"
+botocore==1.39.3; python_version >= "3.9"
 branca==0.8.1
 cairocffi==1.7.1
 # On macOS, CairoSVG requires cairo installed via Homebrew; on arm64, the Homebrew is
 # installed in /opt/homebrew/lib and does not seem to be visible to non-Homebrew python.
-CairoSVG==2.8.2; (sys_platform != 'darwin' or platform_machine != 'arm64') and python_version >= '3.9'
+CairoSVG==2.8.2; (sys_platform != "darwin" or platform_machine != "arm64") and python_version >= "3.9"
 cassandra-driver==3.29.2
 capstone==5.0.6
-cf-units==3.3.0; sys_platform != 'win32' and python_version >= '3.10'
+cf-units==3.3.0; sys_platform != "win32" and python_version >= "3.10"
 cftime==1.6.4.post1
 charset_normalizer==3.4.2
 cloudpickle==3.1.1
 cloudscraper==1.2.71
 cmocean==4.0.3
 # compliance-checker requires cf-units, so same constraints apply.
-compliance-checker==5.3.0; sys_platform != 'win32' and python_version >= '3.10'
+compliance-checker==5.3.0; sys_platform != "win32" and python_version >= "3.10"
 cryptography==45.0.5
 dash==3.1.1
-dash-bootstrap-components==2.0.3; python_version >= '3.9'
+dash-bootstrap-components==2.0.3; python_version >= "3.9"
 dash-uploader==0.6.1
-dask[array,distributed,diagnostics]==2025.5.1; python_version >= '3.10'
+dask[array,diagnostics,distributed]==2025.5.1; python_version >= "3.10"
 python-dateutil==2.9.0.post0
 # discid requires libdiscid to be provided by the system.
 # We install it via apt-get and brew on ubuntu and macOS CI runners, respectively.
-discid==1.2.0; sys_platform != 'win32'
-eccodes==2.42.0; python_version >= '3.9'
+discid==1.2.0; sys_platform != "win32"
+eccodes==2.42.0; python_version >= "3.9"
 eth_typing==5.2.1
 eth_utils==5.3.0
 fabric==3.2.2
 falcon==4.0.2
-fiona==1.10.1; sys_platform != 'win32'
-folium==0.20.0; python_version >= '3.9'
+fiona==1.10.1; sys_platform != "win32"
+folium==0.20.0; python_version >= "3.9"
 frictionless==5.18.1
-ffpyplayer==4.5.3; python_version >= '3.9'
-geopandas==1.1.1; sys_platform != 'win32' and python_version >= '3.10'
+ffpyplayer==4.5.3; python_version >= "3.9"
+geopandas==1.1.1; sys_platform != "win32" and python_version >= "3.10"
 google-api-python-client==2.175.0
 grapheme==0.6.0
 graphql-query==1.4.0
-python-gitlab==6.1.0; python_version >= '3.9'
-h5py==3.14.0; python_version >= '3.9'
-humanize==4.12.3; python_version >= '3.9'
-iminuit==2.31.1; python_version >= '3.9'
-iso639-lang==2.6.1; python_version >= '3.9'
-kaleido==0.4.2; python_version >= '3.9'
+python-gitlab==6.1.0; python_version >= "3.9"
+h5py==3.14.0; python_version >= "3.9"
+humanize==4.12.3; python_version >= "3.9"
+iminuit==2.31.1; python_version >= "3.9"
+iso639-lang==2.6.1; python_version >= "3.9"
+kaleido==0.4.2; python_version >= "3.9"
 langdetect==1.0.9
-mariadb==1.1.12; sys_platform != "darwin" and python_version >= '3.9'
-markdown==3.8.2; python_version >= '3.9'
+mariadb==1.1.12; sys_platform != "darwin" and python_version >= "3.9"
+markdown==3.8.2; python_version >= "3.9"
 # MetPy is no longer runable with PyInstaller since matplotlib made pillow a dependency. See #395.
 # MetPy==1.2.0
 # moviepy depends on imageio-ffmpeg, which does not provide binary wheels for arm64 macOS
-moviepy==2.2.1; python_version >= '3.9' and (sys_platform != 'darwin' or platform_machine != 'arm64')
+moviepy==2.2.1; python_version >= "3.9" and (sys_platform != "darwin" or platform_machine != "arm64")
 mnemonic==0.21
 msoffcrypto-tool==5.4.2
-narwhals==1.45.0; python_version >= '3.9'
+narwhals==1.45.0; python_version >= "3.9"
 nest-asyncio==1.6.0
-netCDF4==1.7.2; python_version >= '3.9'
-numba==0.61.2; python_version >= '3.10'
-numcodecs==0.16.1; python_version >= '3.11'
+netCDF4==1.7.2; python_version >= "3.9"
+numba==0.61.2; python_version >= "3.10"
+numcodecs==0.16.1; python_version >= "3.11"
 Office365-REST-Python-Client==2.6.2
 openpyxl==3.1.5
-pandas==2.3.0; python_version >= '3.9'
-panel==1.7.2; python_version >= '3.10'
-pandera==0.24.0; python_version >= '3.9'
+pandas==2.3.0; python_version >= "3.9"
+panel==1.7.2; python_version >= "3.10"
+pandera==0.24.0; python_version >= "3.9"
 passlib==1.7.4
-pendulum==3.1.0; python_version >= '3.9'
+pendulum==3.1.0; python_version >= "3.9"
 phonenumbers==9.0.8
 pingouin==0.5.5
 pinyin==0.4.0
-platformdirs==4.3.8; python_version >= '3.9'
+platformdirs==4.3.8; python_version >= "3.9"
 plotly==6.2.0
 publicsuffix2==2.20191221
 pycparser==2.22
 pycryptodome==3.23.0
 pycryptodomex==3.23.0
-pydicom==3.0.1; python_version >= '3.10'
+pydicom==3.0.1; python_version >= "3.10"
 pyexcelerate==0.13.0
 pyexcel_ods==0.6.0
-pylibmagic==0.5.0; sys_platform != 'win32'
-pylint==3.3.7; python_version >= '3.9'
+pylibmagic==0.5.0; sys_platform != "win32"
+pylint==3.3.7; python_version >= "3.9"
 pypdfium2==4.30.1
 pypemicro==0.1.11
-pyphen==0.17.2; python_version >= '3.9'
+pyphen==0.17.2; python_version >= "3.9"
 pyppeteer==2.0.0
 pyqtgraph==0.13.7; python_version >= "3.9"
 pyusb==1.3.1; python_version >= "3.9"
 pyviz-comms==3.0.6
-pyvjoy==1.0.1; sys_platform == 'win32'
+pyvjoy==1.0.1; sys_platform == "win32"
 pynput==1.8.1
 # pymssql provides only x86_64 macOS wheels for python 3.9 and 3.10. But at the time of writing (v2.3.2), the universal2 wheels are broken on arm64 macOS as well.
-pymssql==2.3.6; python_version >= "3.9" and (sys_platform != 'darwin' or platform_machine != 'arm64')
+pymssql==2.3.6; python_version >= "3.9" and (sys_platform != "darwin" or platform_machine != "arm64")
 pystray==0.19.5
 pythonnet==3.0.5
 pytz==2025.2
 # pyvista depends on vtk, which does not provide wheels for python 3.13 yet. For arm64 macOS, wheels are available only for python >= 3.9.
-pyvista==0.45.2; python_version >= '3.9'
+pyvista==0.45.2; python_version >= "3.9"
 pyzmq==27.0.0
 PyQt5==5.15.11
 qtmodern==0.2.0
-Rtree==1.4.0; python_version >= '3.9'
+Rtree==1.4.0; python_version >= "3.9"
 sacremoses==0.1.1
 # Remove after merging https://github.com/pyinstaller/pyinstaller/pull/6587
-scipy==1.16.0; python_version >= '3.11'
+scipy==1.16.0; python_version >= "3.11"
 sentry-sdk==2.32.0
 # shotgun-api3 is currently incompatible with python >= 3.12...
-shotgun_api3==3.8.4; python_version < '3.12'
+shotgun_api3==3.8.4; python_version < "3.12"
 slixmpp==1.10.0; python_version >= "3.9"
-spacy==3.8.7; python_version >= '3.9' and python_version < '3.13'
+spacy==3.8.7; python_version >= "3.9" and python_version < "3.13"
 srsly==2.5.1; python_version >= "3.9"
 sv-ttk==2.6.1; python_version >= "3.9"
 swagger-spec-validator==3.0.4
 tableauhyperapi==0.0.22502
-thinc==9.1.1; python_version >= '3.9'
-timezonefinder==6.5.9; python_version > '3.8'
+thinc==9.1.1; python_version >= "3.9"
+timezonefinder==6.5.9; python_version > "3.8"
 tkinterdnd2==0.4.3
-trame==3.10.2; python_version >= '3.9'
-trame-client==3.9.1; python_version >= '3.9'
+trame==3.10.2; python_version >= "3.9"
+trame-client==3.9.1; python_version >= "3.9"
 trame-code==1.0.2
 trame-components==2.5.0
 trame-datagrid==0.2.2
@@ -136,75 +136,75 @@ trame-formkit==0.1.2
 trame-grid-layout==1.0.3
 trame-iframe==1.1.1
 trame-keycloak==0.1.1
-trame-leaflet==1.2.4; python_version >= '3.9'
+trame-leaflet==1.2.4; python_version >= "3.9"
 trame-markdown==3.1.0
 trame-matplotlib==2.0.3
 # Our trame-mesh-streamer test also depends on vtk, which is not available for python 3.13 yet. For arm64 macOS, wheels are available only for python >= 3.9.
-trame-mesh-streamer==0.1.0; python_version < '3.13' and (python_version >= '3.9' or sys_platform != 'darwin' or platform_machine != 'arm64')
+trame-mesh-streamer==0.1.0; python_version < "3.13" and (python_version >= "3.9" or sys_platform != "darwin" or platform_machine != "arm64")
 trame-plotly==3.1.0
 trame-pvui==0.1.1
 trame-quasar==0.2.1
-trame-rca==2.1.3; python_version >= '3.9'
+trame-rca==2.1.3; python_version >= "3.9"
 trame-router==2.3.0
-trame-server==3.4.2; python_version >= '3.9'
+trame-server==3.4.2; python_version >= "3.9"
 trame-simput==2.6.0
 trame-tauri==0.6.2
 trame-tweakpane==0.1.3
 trame-vega==2.1.1
 # Our trame-vtk test also depends on vtk, which is not available for python 3.13 yet.
-trame-vtk==2.9.0; python_version >= '3.9' and python_version < '3.13'
+trame-vtk==2.9.0; python_version >= "3.9" and python_version < "3.13"
 trame-vtk3d==0.1.0
-trame-vtklocal==0.13.2; python_version >= '3.9'
-trame-vuetify==3.0.1; python_version >= '3.9'
+trame-vtklocal==0.13.2; python_version >= "3.9"
+trame-vuetify==3.0.1; python_version >= "3.9"
 trame-xterm==0.2.1
 Twisted==25.5.0
 tzdata==2025.2
 Unidecode==1.4.0
 urllib3-future==2.13.900
 # vtk provides arm64 macOS binary wheels only for python >= 3.9.
-vtk==9.5.0; python_version >= '3.9' or sys_platform != 'darwin' or platform_machine != 'arm64'
+vtk==9.5.0; python_version >= "3.9" or sys_platform != "darwin" or platform_machine != "arm64"
 # On macOS, weasyprint requires pango and glib installed via Homebrew; on arm64, the Homebrew is
 # installed in /opt/homebrew/lib and does not seem to be visible to non-Homebrew python.
-weasyprint==65.1; python_version >= '3.9' and (sys_platform != 'darwin' or platform_machine != 'arm64')
+weasyprint==65.1; python_version >= "3.9" and (sys_platform != "darwin" or platform_machine != "arm64")
 web3==7.12.0
-websockets==15.0.1; python_version >= '3.9'
+websockets==15.0.1; python_version >= "3.9"
 zeep==4.3.1
 pypsexec==0.3.0
 # mimesis 12.x dropped support for python < 3.10
-mimesis==18.0.0; python_version >= '3.10'
-orjson==3.10.18; python_version >= '3.9'
-altair==5.5.0; python_version >= '3.9'
-shapely==2.1.1; python_version >= '3.10'
+mimesis==18.0.0; python_version >= "3.10"
+orjson==3.10.18; python_version >= "3.9"
+altair==5.5.0; python_version >= "3.9"
+shapely==2.1.1; python_version >= "3.10"
 lark==1.2.2
 python-stdnum==2.1
 # On linux, sounddevice and soundfile use system-provided libportaudio
 # and libsndfile, respectively.
-sounddevice==0.5.2; sys_platform != 'linux'
-soundfile==0.13.1; sys_platform != 'linux'
-limits==5.4.0; python_version >= '3.10'
-great-expectations==1.4.3; python_version >= '3.9' and python_version < '3.13'
+sounddevice==0.5.2; sys_platform != "linux"
+soundfile==0.13.1; sys_platform != "linux"
+limits==5.4.0; python_version >= "3.10"
+great-expectations==1.4.3; python_version >= "3.9" and python_version < "3.13"
 # Starting with tensorflow 2.17.0, macOS wheels are provided only for arm64 (x86_64 is deprecated).
-tensorflow==2.19.0; python_version >= '3.9' and python_version < '3.13' and (sys_platform != 'darwin' or platform_machine == 'arm64')
+tensorflow==2.19.0; python_version >= "3.9" and python_version < "3.13" and (sys_platform != "darwin" or platform_machine == "arm64")
 pyshark==0.6.0
 opencv-python==4.11.0.86
 hydra-core==1.3.2
-spiceypy==6.0.1; python_version >= '3.10'
-exchangelib==5.5.1; python_version >= '3.9'
+spiceypy==6.0.1; python_version >= "3.10"
+exchangelib==5.5.1; python_version >= "3.9"
 NBT==1.5.1
-minecraft-launcher-lib==7.1; python_version >= '3.10'
-scikit-learn==1.7.0; python_version >= '3.10'
-scikit-image==0.25.2; python_version >= '3.10'
+minecraft-launcher-lib==7.1; python_version >= "3.10"
+scikit-learn==1.7.0; python_version >= "3.10"
+scikit-image==0.25.2; python_version >= "3.10"
 customtkinter==5.2.2
-fastparquet==2024.11.0; python_version >= '3.9'
+fastparquet==2024.11.0; python_version >= "3.9"
 librosa==0.11.0
-sympy==1.14.0; python_version >= '3.9'
+sympy==1.14.0; python_version >= "3.9"
 xyzservices==2025.4.0
 mistune==3.1.3
-pydantic==2.11.7; python_version >= '3.9'
+pydantic==2.11.7; python_version >= "3.9"
 jsonschema==4.24.0; python_version >= "3.9"
 psutil==7.0.0
-litestar==2.16.0; python_version < '3.13'
-lingua-language-detector==2.1.1; python_version >= '3.10'
+litestar==2.16.0; python_version < "3.13"
+lingua-language-detector==2.1.1; python_version >= "3.10"
 opencc-python-reimplemented==0.1.7
 jieba==0.42.1
 simplemma==1.1.2
@@ -215,49 +215,49 @@ khmer-nltk==1.6
 python-crfsuite==0.9.11
 pymorphy3==2.0.4
 pymorphy3-dicts-uk==2.4.1.1.1663094765
-sudachipy==0.6.10; python_version >= '3.9'
-sudachidict-core==20250515; python_version >= '3.9'
-sudachidict-small==20250515; python_version >= '3.9'
-sudachidict-full==20250515; python_version >= '3.9'
-wxPython==4.2.3; (sys_platform == 'darwin' or sys_platform == 'win32') and python_version >= '3.9'  # PyPI provides binary wheels for Windows and macOS
+sudachipy==0.6.10; python_version >= "3.9"
+sudachidict-core==20250515; python_version >= "3.9"
+sudachidict-small==20250515; python_version >= "3.9"
+sudachidict-full==20250515; python_version >= "3.9"
+wxPython==4.2.3; (sys_platform == "darwin" or sys_platform == "win32") and python_version >= "3.9"  # PyPI provides binary wheels for Windows and macOS
 laonlp==1.2.0
-pythainlp==5.1.2; python_version >= '3.9'
+pythainlp==5.1.2; python_version >= "3.9"
 gmsh==4.14.0
-sspilib==0.3.1; python_version >= '3.9'
+sspilib==0.3.1; python_version >= "3.9"
 rlp==4.1.0
 eth-rlp==2.2.0
-z3c.rml==5.0; python_version >= '3.9'
+z3c.rml==5.0; python_version >= "3.9"
 freetype-py==2.5.1
 vaderSentiment==3.3.2
 # langchain depends on numpy<2.0.0, which does not have binary wheels for python 3.13.
-langchain==0.3.26; python_version >= '3.9' and python_version < '3.13'
+langchain==0.3.26; python_version >= "3.9" and python_version < "3.13"
 seedir==0.5.1
-cel-python==0.3.0; python_version >= '3.9'
+cel-python==0.3.0; python_version >= "3.9"
 # pygwalker depends on quickjs, which at the time of writing (v1.19.4) cannot be built under python 3.13.
 # pygwalker also depends on numpy<2.0.0, which does not have binary wheels for python 3.13.
-pygwalker==0.4.9.15; python_version < '3.13'
+pygwalker==0.4.9.15; python_version < "3.13"
 eth-hash==0.7.1
 # apkutils depends on lxml which doesn't support Python 3.8 on macOS arm64
-apkutils==2.0.1; python_version >= '3.9' or (sys_platform != 'darwin' or platform_machine != 'arm64')
-pypylon==4.1.0; python_version >= '3.9'
+apkutils==2.0.1; python_version >= "3.9" or (sys_platform != "darwin" or platform_machine != "arm64")
+pypylon==4.1.0; python_version >= "3.9"
 python-pptx==1.0.2
-comtypes==1.4.11; sys_platform == 'win32'
-opentelemetry-sdk==1.34.1; python_version >= '3.9'
-xarray==2025.7.0; python_version >= '3.11'
-tables==3.10.2; python_version >= '3.11'
-schwifty==2025.6.0; python_version >= '3.9'
-patool==4.0.1; python_version >= '3.10'
+comtypes==1.4.11; sys_platform == "win32"
+opentelemetry-sdk==1.34.1; python_version >= "3.9"
+xarray==2025.7.0; python_version >= "3.11"
+tables==3.10.2; python_version >= "3.11"
+schwifty==2025.6.0; python_version >= "3.9"
+patool==4.0.1; python_version >= "3.10"
 yapf==0.43.0
-xmlschema==4.1.0; python_version >= '3.9'
-pysaml2==7.5.2; python_version >= '3.9'
-pysaml2==7.3.0; python_version < '3.9'  # pyup: ignore
-toga==0.5.1; python_version >= '3.9'
-numbers-parser==4.15.1; python_version >= '3.9'
-fsspec==2025.5.1; python_version >= '3.9'
-zarr==3.0.10; python_version >= '3.11'
-intake==2.0.8; python_version >= '3.9'
+xmlschema==4.1.0; python_version >= "3.9"
+pysaml2==7.5.2; python_version >= "3.9"
+pysaml2==7.3.0; python_version < "3.9"  # pyup: ignore
+toga==0.5.1; python_version >= "3.9"
+numbers-parser==4.15.1; python_version >= "3.9"
+fsspec==2025.5.1; python_version >= "3.9"
+zarr==3.0.10; python_version >= "3.11"
+intake==2.0.8; python_version >= "3.9"
 h3==4.3.0
-selectolax==0.3.31; python_version >= '3.9'
+selectolax==0.3.31; python_version >= "3.9"
 ruamel.yaml.string==0.1.1
 niquests==3.14.1
 emoji==2.14.1
@@ -268,31 +268,31 @@ pandas_flavor==0.7.0
 # ------------------- Platform (OS) specifics
 
 # dbus-fast has pre-built wheels only for Linux; and D-Bus is available only there, anyway.
-dbus-fast==2.44.1; sys_platform == 'linux' and python_version >= '3.9'
+dbus-fast==2.44.1; sys_platform == "linux" and python_version >= "3.9"
 
 # PyEnchant only pre-builds macOS and Windows
-pyenchant==3.2.2; sys_platform == 'darwin' or sys_platform == 'win32'
+pyenchant==3.2.2; sys_platform == "darwin" or sys_platform == "win32"
 
 # uvloop does not currently support Windows.
-uvloop==0.21.0; sys_platform != 'win32'
+uvloop==0.21.0; sys_platform != "win32"
 
 # pydivert only runs on Windows
-pydivert==2.1.0; sys_platform == 'win32'
+pydivert==2.1.0; sys_platform == "win32"
 
 # pywin32-ctypes runs on Windows
-pywin32-ctypes==0.2.3; sys_platform == 'win32'
+pywin32-ctypes==0.2.3; sys_platform == "win32"
 
 # pymediainfo on linux does not bundle mediainfo shared library, and requires system one.
-pymediainfo==7.0.1; (sys_platform == 'darwin' or sys_platform == 'win32') and python_version >= '3.9'
+pymediainfo==7.0.1; (sys_platform == "darwin" or sys_platform == "win32") and python_version >= "3.9"
 
 # the required library can be installed with "brew install labstreaminglayer/tap/lsl" on macOS, or with "conda install liblsl" on any platform
-pylsl==1.17.6; sys_platform == "darwin" and python_version >= '3.9'
+pylsl==1.17.6; sys_platform == "darwin" and python_version >= "3.9"
 
 # PyTaskbar only runs on Windows
-PyTaskbar==0.1.0; sys_platform == 'win32' and python_version >= '3.10'
+PyTaskbar==0.1.0; sys_platform == "win32" and python_version >= "3.10"
 
 # pygraphviz requires graphviz to be provided by the environment (linux distribution, homebrew, or Anaconda).
-pygraphviz==1.14; (sys_platform == 'darwin' or sys_platform == 'linux') and python_version >= '3.10'
+pygraphviz==1.14; (sys_platform == "darwin" or sys_platform == "linux") and python_version >= "3.10"
 
 # Include the requirements for testing
 -r requirements-test.txt

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,9 +1,9 @@
 # pyup: ignore file
 
 # PyTest
-pytest >= 2.7.3
+pytest>=2.7.3
 pytest-timeout  # Stop hanging tests
 pytest-xdist  # Distributed testing
-execnet >= 1.5.0  # for pytest-xdist
+execnet>=1.5.0  # for pytest-xdist
 pytest-drop-dup-tests  # Don't run tests twice
 psutil


### PR DESCRIPTION
Similarly to https://github.com/pyinstaller/pyinstaller/pull/9181, use double-quotes in markers found in all requirements files (except that this PR will be separate from the actual weekly update, because it should not be ran through our diff-based CI here).

Also, remove the two entries that were marked with `pyup: ignore` - since they were not being updated, they were not being tested, either, and it makes no sense to keep them around.