### PR TITLE
Add hook for pynng

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-pynng.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-pynng.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+"""
+Hook for https://pypi.org/project/pynng/
+"""
+
+hiddenimports = ['_cffi_backend']

--- a/news/922.new.rst
+++ b/news/922.new.rst
@@ -1,0 +1,1 @@
+Add a hook for ``pynng``, which has a hidden import.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -96,6 +96,7 @@ pyqtgraph==0.13.7; python_version >= "3.9"
 pyusb==1.3.1; python_version >= "3.9"
 pyviz-comms==3.0.6
 pyvjoy==1.0.1; sys_platform == "win32"
+pynng==0.8.1; python_version >= "3.7"
 pynput==1.8.1
 # pymssql provides only x86_64 macOS wheels for python 3.9 and 3.10. But at the time of writing (v2.3.2), the universal2 wheels are broken on arm64 macOS as well.
 pymssql==2.3.6; python_version >= "3.9" and (sys_platform != "darwin" or platform_machine != "arm64")

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -96,7 +96,7 @@ pyqtgraph==0.13.7; python_version >= "3.9"
 pyusb==1.3.1; python_version >= "3.9"
 pyviz-comms==3.0.6
 pyvjoy==1.0.1; sys_platform == "win32"
-pynng==0.8.1; python_version >= "3.7"
+pynng==0.8.1
 pynput==1.8.1
 # pymssql provides only x86_64 macOS wheels for python 3.9 and 3.10. But at the time of writing (v2.3.2), the universal2 wheels are broken on arm64 macOS as well.
 pymssql==2.3.6; python_version >= "3.9" and (sys_platform != "darwin" or platform_machine != "arm64")

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2878,3 +2878,9 @@ def test_narwhals(pyi_builder):
     pyi_builder.test_source("""
         import narwhals
     """)
+
+@importorskip('pynng')
+def test_pynng(pyi_builder):
+    pyi_builder.test_source("""
+        import pynng
+    """)

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2879,6 +2879,7 @@ def test_narwhals(pyi_builder):
         import narwhals
     """)
 
+
 @importorskip('pynng')
 def test_pynng(pyi_builder):
     pyi_builder.test_source("""


### PR DESCRIPTION
<!---
Please review the summary checklist before submitting your pull request
https://github.com/pyinstaller/pyinstaller-hooks-contrib?tab=readme-ov-file#summary
--->

On a PyInstaller application that had `pynng` as a dependency, this error was thrown when the executable started up:

```
  File "PyInstaller/loader/pyimod02_importers.py", line 457, in exec_module
  File "pynng/__init__.py", line 3, in <module>
ModuleNotFoundError: No module named '_cffi_backend'
```

`cffi` is a dependency of `pynng`:

https://github.com/codypiersall/pynng/blob/2179328f8a858bbb3e177f66ac132bde4a5aa859/pyproject.toml#L22

I based this PR off of a similar one for `bcrypt`

- https://github.com/pyinstaller/pyinstaller/pull/4750/