### PR TITLE
Update pylsl hook

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -115,9 +115,7 @@ jobs:
           # Install libdiscid (dependency of discid python package).
           brew install libdiscid
           # Install lsl library for pylsl
-          # TODO: switch back to labstreaminglayer/tap/lsl once labstreaminglayer/homebrew-tap#1 is merged
-          #brew install labstreaminglayer/tap/lsl
-          brew install rokm/labstreaminglayer-tap/lsl
+          brew install labstreaminglayer/tap/lsl
           # This one is required by eccodes (binary wheels with bundled eccodes
           # library are provided only for macOS 13+).
           brew install eccodes

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-pylsl.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-pylsl.py
@@ -15,18 +15,19 @@ from PyInstaller.utils.hooks import logger, isolated
 
 
 def find_library():
+    # Try importing pylsl - this will fail if the shared library is unavailable.
     try:
-        # the import will fail it the library cannot be found
-        from pylsl import pylsl
+        import pylsl  # noqa: F401
+    except Exception:
+        return None
 
-        # the find_liblsl_libraries() is a generator function that yields multiple possibilities
-        for libfile in pylsl.find_liblsl_libraries():
-            if libfile:
-                break
-    except (ImportError, ModuleNotFoundError, RuntimeError) as error:
-        print(error)
-        libfile = None
-    return libfile
+    # Return the path to shared library that is used by pylsl.
+    try:
+        from pylsl.lib import lib as cdll  # pylsl >= 0.17.0
+    except ImportError:
+        from pylsl.pylsl import lib as cdll  # older versions
+
+    return cdll._name
 
 
 # whenever a hook needs to load a 3rd party library, it needs to be done in an isolated subprocess

--- a/news/924.update.rst
+++ b/news/924.update.rst
@@ -1,0 +1,1 @@
+Update ``pylsl`` hook for compatibility with ``pylsl`` >= 1.17.0.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -283,8 +283,9 @@ pywin32-ctypes==0.2.3; sys_platform == "win32"
 # pymediainfo on linux does not bundle mediainfo shared library, and requires system one.
 pymediainfo==7.0.1; (sys_platform == "darwin" or sys_platform == "win32") and python_version >= "3.9"
 
-# the required library can be installed with "brew install labstreaminglayer/tap/lsl" on macOS, or with "conda install liblsl" on any platform
-pylsl==1.17.6; sys_platform == "darwin" and python_version >= "3.9"
+# The required library can be installed with "brew install labstreaminglayer/tap/lsl" on macOS, or with "conda install liblsl" on any platform.
+# On Windows, the library is bundled with PyPI wheels.
+pylsl==1.17.6; (sys_platform == "darwin" or sys_platform == "win32") and python_version >= "3.9"
 
 # PyTaskbar only runs on Windows
 PyTaskbar==0.1.0; sys_platform == "win32" and python_version >= "3.10"

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -213,10 +213,25 @@ def test_markdown(pyi_builder):
 def test_pylsl(pyi_builder):
     pyi_builder.test_source(
         """
+        import pathlib
         import pylsl
+
         print(f"version: {pylsl.__version__}")
         print(f"library version: {pylsl.library_version()}")
         print(f"library info: {pylsl.library_info()}")
+
+        # Ensure that bundled shared library is used
+        try:
+            from pylsl.lib import lib as cdll  # pylsl >= 0.17.0
+        except ImportError:
+            from pylsl.pylsl import lib as cdll  # older versions
+
+        print(f"cdll: {cdll}")
+        pkg_path = pathlib.Path(pylsl.__file__).parent.resolve()
+        cdll_path = pathlib.Path(cdll._name).resolve()
+        print(f"pkg_path: {pkg_path}")
+        print(f"cdll_path: {cdll_path}")
+        assert pkg_path in cdll_path.parents, "Loaded shared library is not the bundled one!"
         """)
 
 


### PR DESCRIPTION
Update `pylsl` hook for compatibility with `pylsl` >= 1.17.0. 

Have the corresponding test ensure that the bundled copy of shared library is used at run-time, to ensure that test fails if system-provided copy is used due to bundled copy either not being collected or not being loaded.

Install and test PyPI wheels for Windows, which come with bundled copy of `lsl` shared library.