### PR TITLE
Update hook-shapely.py

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-shapely.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-shapely.py
@@ -42,7 +42,7 @@ if compat.is_win:
     original_path = os.environ['PATH']
     try:
         os.environ['PATH'] = os.pathsep.join(lib_paths)
-        dll_path = find_library('geos_c')
+        dll_path = find_library('geos_c') or find_library('libgeos_c')
     finally:
         os.environ['PATH'] = original_path
     if dll_path is not None:

--- a/news/927.update.rst
+++ b/news/927.update.rst
@@ -1,0 +1,3 @@
+`shapely` hook: extend the search for `geos_c` DLL to also look for an
+alternative name with `lib` prefix (i.e., `libgeos_c`), which is used
+in `MSYS2` environment.


### PR DESCRIPTION
Alternative search for the `geos` library with the `lib` prefix (relevant for `MSYS2` distribution on `Windows`)

<!---
Please review the summary checklist before submitting your pull request
https://github.com/pyinstaller/pyinstaller-hooks-contrib?tab=readme-ov-file#summary
--->
