### PR TITLE
Adjust the automatically-raised recursion limit

### DIFF
--- a/_pyinstaller_hooks_contrib/__init__.py
+++ b/_pyinstaller_hooks_contrib/__init__.py
@@ -32,6 +32,16 @@ def get_hook_dirs():
 # installed in the environment, and their analysis typically requires recursion limit that exceeds the default 1000.
 # Therefore, automatically raise the recursion limit to at least 5000. This alleviates the need to do so on per-hook
 # basis.
-new_recursion_limit = 5000
+if (sys.platform.startswith('win') or sys.platform == 'cygwin') and sys.version_info < (3, 11):
+    # The recursion limit test in PyInstaller main repository seems to push the recursion level to the limit; and if the
+    # limit is set to 5000, this crashes python 3.8 - 3.10 on Windows and 3.9 that is (at the time of writing) available
+    # under Cygwin. Further investigation revealed that Windows builds of python 3.8 and 3.10 handle recursion up to
+    # level ~2075, while the practical limit for 3.9 is between 1950 and 1975. Therefore, for affected combinations of
+    # platforms and python versions, use a conservative limit of 1900 - if only to avoid issues with the recursion limit
+    # test in the main PyInstaller repository...
+    new_recursion_limit = 1900
+else:
+    new_recursion_limit = 5000
+
 if sys.getrecursionlimit() < new_recursion_limit:
     sys.setrecursionlimit(new_recursion_limit)

--- a/news/928.update.rst
+++ b/news/928.update.rst
@@ -1,0 +1,6 @@
+Adjust the value of automatically-raised recursion limit (which :issue:`925`
+set at 5000); for Windows builds of python 3.8 - 3.10 and python
+3.9 available under Cygwin, the value needs to be lowered to 1900, as
+higher values lead to python interpreter crash in scenarios when recursion
+level actually approaches the limit (for example, the recursion limit
+test in the main PyInstaller repository).


### PR DESCRIPTION
The recursion limit test in PyInstaller main repository seems to push the recursion level to the limit; and if the limit is set to 5000, this crashes python 3.8 - 3.10 on Windows and 3.9 that is (at the time of writing) available under Cygwin.

Further investigation revealed that Windows builds of python 3.8 and 3.10 handle recursion up to level ~2075, while the practical limit for 3.9 is between 1950 and 1975. Therefore, for affected combinations of platforms and python versions, use a conservative limit of 1900 - if only to avoid issues with the recursion limit test in the main PyInstaller repository...

For other platforms and python versions, leave the default limit at the 5000 as per earlier commit, although it is likely that it could be lowered as well.