### PR TITLE
hooks: update eccodes-related hooks for compatibility with eccodes 2.43.0

### DIFF
--- a/_pyinstaller_hooks_contrib/rthooks/pyi_rth_findlibs.py
+++ b/_pyinstaller_hooks_contrib/rthooks/pyi_rth_findlibs.py
@@ -31,8 +31,7 @@ def _pyi_rthook():
 
     _orig_find = getattr(findlibs, 'find', None)
 
-    def _pyi_find(lib_name, pkg_name=None):
-        pkg_name = pkg_name or lib_name
+    def _pyi_find(lib_name, *args, **kwargs):
         extension = findlibs.EXTENSIONS.get(sys.platform, ".so")
 
         # First check sys._MEIPASS
@@ -48,7 +47,7 @@ def _pyi_rthook():
 
         # Finally, fall back to original implementation
         if _orig_find is not None:
-            return _orig_find(lib_name, pkg_name)
+            return _orig_find(lib_name, *args, **kwargs)
 
         return None
 

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-eccodeslib.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-eccodeslib.py
@@ -1,0 +1,20 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_dynamic_libs
+
+# Collect bundled dynamic libraries.
+binaries = collect_dynamic_libs('eccodeslib')
+
+# `eccodeslib` depends on `eckitlib` and `fckitlib`, and when libraries are being imported at run-time by
+# `findlibs.find()` user warnings are emitted if these packages cannot be imported.
+hiddenimports = ['eckitlib', 'fckitlib']

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-eckitlib.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-eckitlib.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_dynamic_libs
+
+# Collect bundled dynamic libraries.
+binaries = collect_dynamic_libs('eckitlib')

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-fckitlib.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-fckitlib.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_dynamic_libs
+
+# Collect bundled dynamic libraries.
+binaries = collect_dynamic_libs('fckitlib')

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-gribapi.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-gribapi.py
@@ -41,6 +41,7 @@ def get_eccodes_library_path():
 
 
 binaries = []
+hiddenimports = []
 
 try:
     library_path, package_path = get_eccodes_library_path()
@@ -81,3 +82,8 @@ if library_path:
         "hook-gribapi: collecting eccodes shared library %r to destination directory %r", library_path, dest_dir
     )
     binaries.append((library_path, dest_dir))
+
+    # If the shared library is available in the stand-alone `eccodeslib` package, add this package to to hidden imports,
+    # so that `findlibs.find()` can import it and query its `__file__` attribute.
+    if 'eccodeslib' in library_parent_path.parts:
+        hiddenimports += ['eccodeslib']

--- a/news/930.update.1.rst
+++ b/news/930.update.1.rst
@@ -1,0 +1,3 @@
+Update ``gribapi`` hook for compatibility with ``eccodes`` 2.43.0; add
+hooks for ``eccodeslib``, ``eckitlib``, and ``fckitlib``, which now
+provide the bundled shared libraries on non-Windows systems.

--- a/news/930.update.rst
+++ b/news/930.update.rst
@@ -1,0 +1,5 @@
+Update the run-time hook for ``findlibs`` for improved compatibility
+with ``findlibs`` > 1.0.0; avoid providing a default value for
+``pkg_name`` argument in our ``findlibs.find()`` override, and instead
+forward the original value (i.e., ``None``) to the original ``find()``
+implementation.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -34,7 +34,7 @@ python-dateutil==2.9.0.post0
 # discid requires libdiscid to be provided by the system.
 # We install it via apt-get and brew on ubuntu and macOS CI runners, respectively.
 discid==1.2.0; sys_platform != "win32"
-eccodes==2.42.0; python_version >= "3.9"
+eccodes==2.43.0; python_version >= "3.10"
 eth_typing==5.2.1
 eth_utils==5.3.0
 fabric==3.2.2


### PR DESCRIPTION
The non-Windows PyPI wheels for `eccodes` 2.43.0 do not provide the bundled shared libraries anymore, but instead depend on `eccodeslib` wheels for that.

First, we need to fix the override for `findlibs.find()` in the run-time hook for `findlibs` to avoid providing the default value for `pkg_name` argument; instead, pass the original (`None`) value when calling the original implementation. The older versions of `findlibs` (e.g., 0.0.5) used `lib_name` as default for `pkg_name`, while the recent versions (>= 1.0.0) use `lib_name` + `'lib'` (i.e., `eccodes` -> `eccodeslib`).

Second, `findlibs.find()` needs to be able to import `eccodeslib` to query its `__file__` attribute, so add a hidden import to ensure that module is always collected (otherwise, `eccodeslib` might become a namespace package without `__file__` attribute).

Finally, `eccodeslib` declares transitive dependencies on `eckitlib` and `fckitlib` to `findlibs`, so `findlibs.find()` also attempts to import these packages to query their `__file__` attribute; if the packages are not importable, a `UserWarning` is emitted at run time. Add a hook for `eccodeslib` that adds hidden imports for `eckitlib` and `fckitlib`.

Just in case there is any dynamic loading going on (now or in the future), have the hooks for `eccodeslib`, `eckitlib`, and `fckitlib` collect all their bundled shared libraries.
