### PR TITLE
Fixes for pyinstaller/pyinstaller#9222

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-cumm.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-cumm.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+from PyInstaller.utils.hooks import collect_data_files
+
+# Collect files from cumm/include directory - at import, the package asserts the existence of this directory.
+datas = collect_data_files('cumm')

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-pointcept.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-pointcept.py
@@ -1,0 +1,14 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# Collect source .py files for JIT/torchscript.
+module_collection_mode = 'pyz+py'

--- a/news/941.new.1.rst
+++ b/news/941.new.1.rst
@@ -1,0 +1,1 @@
+Add hook for ``pointcept`` to collect its source .py files for TorchScript/JIT.

--- a/news/941.new.rst
+++ b/news/941.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``cumm`` to ensure that header files from ``cumm/include``
+directory are collected.

--- a/news/941.update.rst
+++ b/news/941.update.rst
@@ -1,0 +1,3 @@
+Update ``torch`` hook to check whether ``torch`` is installed via
+Anaconda ``pytorch`` package, and collect DLLs from Anaconda ``mkl``
+package and its dependencies, if necessary.


### PR DESCRIPTION
Fixes for issues that came up during pyinstaller/pyinstaller#9222:
1. extend MKL collection in `torch` hook to detect Anaconda-packaged `torch`, and collect DLLs from (Anaconda-packaged) `mkl` and its dependencies
2. add hook for `cumm` to collect header files from `cumm/include` directory
3. add hook for `pointcept` to collect source .py files for TorchScript.

Closes pyinstaller/pyinstaller#9222.