### PR TITLE
hooks: update `numba` hook for changes made in `numba` v0.62.0

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-numba.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-numba.py
@@ -31,7 +31,8 @@ if is_module_satisfies("numba >= 0.59.0"):
 # loaded. All of these seem to be loaded when `numba` is imported, so there is no need for finer granularity. Also,
 # as the config value might be manipulated at run-time (e.g., via environment variable), we need to collect both old
 # and new module variants.
-if is_module_satisfies("numba >= 0.61.0rc1"):
+# numba 0.62 reverted the change, removing the new type system.
+if is_module_satisfies("numba >= 0.61.0rc1, < 0.62.0rc1"):
     # NOTE: `numba.core.typing` is also referenced indirectly via `_RedirectSubpackage`, but we do not need a
     # hidden import entry for it, because we have entries for its submodules.
     modules_old = [

--- a/news/949.update.rst
+++ b/news/949.update.rst
@@ -1,0 +1,2 @@
+Update ``numba`` hook for changes made in ``numba`` v0.62.0 (i.e., removal
+of the new type system that was previously introduced in v0.61 series).

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -66,7 +66,7 @@ msoffcrypto-tool==5.4.2
 narwhals==2.5.0; python_version >= "3.9"
 nest-asyncio==1.6.0
 netCDF4==1.7.2; python_version >= "3.9"
-numba==0.61.2; python_version >= "3.10"
+numba==0.62.0; python_version >= "3.10"
 numcodecs==0.16.2; python_version >= "3.11"
 Office365-REST-Python-Client==2.6.2
 openpyxl==3.1.5

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2044,8 +2044,12 @@ def test_numba_jit(pyi_builder):
 # Basic import test with new type system enabled (numba >= 0.61).
 # Ideally, we would repeat the above `test_numba_jit`, but at the time of writing (numba 0.61.0rc2) it does not seem to
 # work even when unfrozen.
+# In numba 0.62.0, the new type system was removed, so trying to enable it results in an error.
 @importorskip('numba')
-@pytest.mark.skipif(not is_module_satisfies('numba >= 0.61.0rc1'), reason="Requires numba >= 0.61.0.")
+@pytest.mark.skipif(
+    not is_module_satisfies('numba >= 0.61.0rc1, < 0.62.0rc1'),
+    reason="Requires numba >= 0.61.0, < 0.62.0."
+)
 def test_numba_new_type_system(pyi_builder):
     pyi_builder.test_source("""
         import os


### PR DESCRIPTION
`numba` v0.62.0 removed the new type system that was previously introduced in the v0.61 series.

Update the hook accordingly to avoid spamming warnings about missing hidden imports.

Disable `test_numba_new_type_system` if `numba` >= v0.62.0rc1; the new type system can still be enabled via environment variable, but this results in a missing-module-error when `numba` is imported, because the corresponding submodules have been removed from the package.

<!---
Please review the summary checklist before submitting your pull request
https://github.com/pyinstaller/pyinstaller-hooks-contrib?tab=readme-ov-file#summary
--->
