### PR TITLE
tests: make test_apscheduler invariant to the TZ environment variable

### DIFF
--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -108,7 +108,10 @@ def test_apscheduler(pyi_builder):
 
 
         async def main():
-            scheduler = AsyncIOScheduler()
+            # Specify the timezone to use, to make the test invariant to TZ environment variable (which might be set
+            # to UCT0 or GMT+12, which is valid but not supported by `tzlocal` that is used by `apscheduler` behind the
+            # scenes.
+            scheduler = AsyncIOScheduler(timezone=datetime.timezone.utc)
             scheduler.add_job(tick, "interval", seconds=1)
             scheduler.start()
 


### PR DESCRIPTION
Make `test_apscheduler` invariant to the `TZ` environment variable, by specifying the timezone when constructing `AsyncIOScheduler`. For the purposes of the test, the timezone itself should not matter, so use UTC.

The `TZ` environment may contain values such as `UTC0` or `GMT+12`, which is valid but not supported by `tzlocal` that is used by `apscheduler` behind the scenes.

Fixes #953.