### PR TITLE
tests: update python version markers, part 2

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-duckdb.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-duckdb.py
@@ -1,0 +1,22 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata, is_module_satisfies
+
+# duckdb requires stdlib `inspect` module. On newer python versions (>= 3.10), it is collected as a dependency of other
+# stdlib modules, while on older python versions this is not the case. Therefore, we add it to hidden imports regardless
+# of python version.
+hiddenimports = ['inspect']
+
+# Starting with v1.4.0, `duckdb` uses `importlib.metadata.version()` to determine its version.
+if is_module_satisfies("duckdb >= 1.4.0"):
+    datas = copy_metadata('duckdb')

--- a/news/952.new.rst
+++ b/news/952.new.rst
@@ -1,0 +1,3 @@
+Add hook for ``duckdb`` to ensure that ``inspect`` module is collected
+(might end up missing with python < 3.10 otherwise), and that the
+package's metadata is collected for ``duckdb`` >= 1.4.0.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -35,6 +35,7 @@ python-dateutil==2.9.0.post0
 # We install it via apt-get and brew on ubuntu and macOS CI runners, respectively; on arm64, the Homebrew is
 # installed in /opt/homebrew/lib and does not seem to be visible to non-Homebrew python.
 discid==1.3.0; sys_platform != "win32" and (sys_platform != "darwin" or platform_machine != "arm64") and python_version >= "3.9"
+duckdb==1.4.1; python_version >= "3.9"
 eccodes==2.44.0; python_version >= "3.10"
 eth_typing==5.2.1
 eth_utils==5.3.1

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2936,3 +2936,19 @@ def test_globus_sdk(pyi_builder):
             TransferData,
         )
     """)
+
+
+@importorskip('duckdb')
+def test_duckdb(pyi_builder):
+    pyi_builder.test_source("""
+        import duckdb
+
+        # NOTE: do not try to show the results via `.show()` method
+        # or using `print()`, as it uses characters that are incompatible
+        # with encoding used on Windows for redirected stdout/stderr!
+        r1 = duckdb.sql("SELECT 42 AS i")
+        print(f"r1: {r1.fetchall()}")
+
+        r2 = duckdb.sql("SELECT i * 2 AS k FROM r1")
+        print(f"r2: {r2.fetchall()}")
+    """)


### PR DESCRIPTION
Update python version markers for remaining packages: `thinc` and `pygwalker` (which we had to omit from "part 1" commit due to incompatibility with other libraries).
