### PR TITLE
hooks: add hook for psycopg_binary

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-psycopg_binary.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-psycopg_binary.py
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+# The `pyscopg_binary._uuid` module is imported from the `psycopg_binary._psycopg` binary extension when working with
+# data of UUID data type.
+hiddenimports = ['psycopg_binary._uuid']

--- a/news/956.new.rst
+++ b/news/956.new.rst
@@ -1,0 +1,3 @@
+Add hook for ``psycopg_binary`` (binary installation Psycopg 3) to ensure
+that ``psycopg_binary._uuid`` module is collected, in order to prevent
+missing-module error when working with data of UUID data type.


### PR DESCRIPTION
Add hook for `psycopg_binary` (binary installation Psycopg 3) to ensure that `psycopg_binary._uuid` module is collected, in order to prevent missing-module error when working with data of UUID data type.

Closes pyinstaller/pyinstaller#9264.