### PR TITLE
hooks: add hook for dateparser

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-dateparser.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-dateparser.py
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2025 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+# Ensure that `dateparser/data/dateparser_tz_cache.pkl` data file is collected. Applicable to dateparser >= v1.2.2;
+# earlier releases have no data files, so this call returns empty list.
+datas = collect_data_files('dateparser')

--- a/news/958.new.rst
+++ b/news/958.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``dateparser`` to collect the data file that was introduced
+in ``dateparser`` v.1.2.2.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -31,6 +31,7 @@ dash-bootstrap-components==2.0.4; python_version >= "3.9"
 dash-uploader==0.6.1
 dask[array,diagnostics,distributed]==2025.9.1; python_version >= "3.10"
 python-dateutil==2.9.0.post0
+dateparser==1.2.2
 # discid requires libdiscid to be provided by the system.
 # We install it via apt-get and brew on ubuntu and macOS CI runners, respectively; on arm64, the Homebrew is
 # installed in /opt/homebrew/lib and does not seem to be visible to non-Homebrew python.

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2952,3 +2952,43 @@ def test_duckdb(pyi_builder):
         r2 = duckdb.sql("SELECT i * 2 AS k FROM r1")
         print(f"r2: {r2.fetchall()}")
     """)
+
+
+@importorskip('dateparser')
+def test_dateparser(pyi_builder):
+    pyi_builder.test_source("""
+        import datetime
+        import os
+        import sys
+
+        import dateparser
+
+        # The test tries to print the date strings it is testing, and some of them contain Unicode characters. On
+        # Windows, when stdout is redirected (for example, by pytest to capture the output), stdout is configured
+        # to use system locale encoding. So for this to work, we need to force it into utf-8 mode.
+        if os.name == "nt" and sys.stdout.encoding != "utf-8":
+            sys.stdout.reconfigure(encoding="utf-8")
+
+        # Couple of examples from dateparser's "Basic Usage"
+        test_cases = (
+            ('12/12/12', datetime.datetime(2012, 12, 12, 0, 0)),
+            ('Fri, 12 Dec 2014 10:55:50', datetime.datetime(2014, 12, 12, 10, 55, 50)),
+            # Spanish (Tuesday 21 October 2014)
+            ('Martes 21 de Octubre de 2014', datetime.datetime(2014, 10, 21, 0, 0)),
+            # French (11 December 2014 at 09:00)
+            ('Le 11 Décembre 2014 à 09:00', datetime.datetime(2014, 12, 11, 9, 0)),
+            # Russian (13 January 2015 at 13:34)
+            ('13 января 2015 г. в 13:34', datetime.datetime(2015, 1, 13, 13, 34)),
+            # Thai (1 October 2005, 1:00 AM)
+            ('1 เดือนตุลาคม 2005, 1:00 AM', datetime.datetime(2005, 10, 1, 1, 0))
+        )
+
+        for date_string, expected_result in test_cases:
+            print(f"Parsing string: {date_string!r}")
+            print(f"Expected: {expected_result}")
+            dt = dateparser.parse(date_string)
+            print(f"Result:   {dt}")
+
+            assert dt == expected_result
+            print("")
+    """)


### PR DESCRIPTION
Add hook for `dateparser` to collect the data file that was introduced in `dateparser` v.1.2.2.

Closes pyinstaller/pyinstaller#9271.
