### PR TITLE
Avoiding error in hook-sentry_sdk.py

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-sentry_sdk.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-sentry_sdk.py
@@ -37,4 +37,4 @@ if hasattr(si, '_AUTO_ENABLING_INTEGRATIONS'):
 print(json.dumps(integrations))
 """
 
-hiddenimports.extend(json.loads(exec_statement(statement)))
+if statement_result := exec_statement(statement): hiddenimports.extend(json.loads(statement_result))


### PR DESCRIPTION
Avoiding error.
 File "C:\Python311x64\Lib\site-packages\_pyinstaller_hooks_contrib\stdhooks\hook-sentry_sdk.py", line 40, in <module>
    hiddenimports.extend(json.loads(exec_statement(statement)))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311x64\Lib\json\__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311x64\Lib\json\decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311x64\Lib\json\decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

<!---
Please review the summary checklist before submitting your pull request
https://github.com/pyinstaller/pyinstaller-hooks-contrib?tab=readme-ov-file#summary
--->
