### PR TITLE
hooks: add hook for pytokens

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-blib2to3.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-blib2to3.py
@@ -10,21 +10,12 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ------------------------------------------------------------------
 from PyInstaller.utils.hooks import collect_submodules, collect_data_files
-from _pyinstaller_hooks_contrib.compat import importlib_metadata
-
-
-# Find the mypyc extension module for `black`, which is called something like `30fcd23745efe32ce681__mypyc`. The prefix
-# changes with each `black` version, so we need to obtain the name by looking at distribution's list of files.
-def _find_mypyc_module():
-    try:
-        dist = importlib_metadata.distribution("black")
-    except importlib_metadata.PackageNotFoundError:
-        return []
-    return [entry.name.split('.')[0] for entry in (dist.files or []) if '__mypyc' in entry.name]
-
+from _pyinstaller_hooks_contrib.utils.mypy import find_mypyc_module_for_dist
 
 hiddenimports = [
-    *_find_mypyc_module(),
+    # `black` (or rather, its `blib2to3` library) uses `mypy`, and includes a top-level module with
+    # dynamically-generated name prefix; for example, `30fcd23745efe32ce681__mypyc`.
+    *find_mypyc_module_for_dist('black'),
     'dataclasses',
     'pkgutil',
     'tempfile',

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-pytokens.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-pytokens.py
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2026 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+from _pyinstaller_hooks_contrib.utils.mypy import find_mypyc_module_for_dist
+
+# pytokens >= 0.4.0 uses `mypy`, and includes a top-level module with dynamically-generated name prefix;
+# for example, `fd7dcdb10166ebd4db98__mypyc`.
+hiddenimports = find_mypyc_module_for_dist('pytokens')

--- a/_pyinstaller_hooks_contrib/utils/mypy.py
+++ b/_pyinstaller_hooks_contrib/utils/mypy.py
@@ -1,0 +1,25 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2026 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from _pyinstaller_hooks_contrib.compat import importlib_metadata
+
+
+# Given the distribution name, find the top-level `mypyc` extension module belonging to that distribution. The said
+# top-level module is called something like `30fcd23745efe32ce681__mypyc`; the prefix changes across different versions
+# of the same distribution (and, of course, across different distributions). Therefore, we need to obtain the name by
+# looking at distribution's list of files.
+def find_mypyc_module_for_dist(dist_name):
+    try:
+        dist = importlib_metadata.distribution(dist_name)
+    except importlib_metadata.PackageNotFoundError:
+        return []
+    return [entry.name.split('.')[0] for entry in (dist.files or []) if '__mypyc' in entry.name]

--- a/news/982.new.rst
+++ b/news/982.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``pytokens`` to automatically discover and collect the
+``{id}__mypyc`` top-level module that was introduced in ``pytokens`` 0.4.0.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -5,7 +5,7 @@ av==16.1.0; python_version >= "3.10"
 adbutils==2.12.0; sys_platform != "darwin" or platform_machine != "arm64"
 APScheduler==3.11.2
 backports.zoneinfo==0.2.1; python_version < "3.9"
-black==25.12.0; python_version >= "3.10"
+black==26.1.0; python_version >= "3.10"
 bokeh==3.8.2; python_version >= "3.10"
 boto==2.49.0
 boto3==1.42.27; python_version >= "3.9"
@@ -112,6 +112,7 @@ pynput==1.8.1
 pymssql==2.3.11; python_version >= "3.9" and (sys_platform != "darwin" or platform_machine != "arm64")
 pystray==0.19.5
 pythonnet==3.0.5; python_version < "3.14"
+pytokens==0.4.0
 pytz==2025.2
 # pyvista depends on vtk, which does not provide wheels for python 3.14 yet. For arm64 macOS, wheels are available only for python >= 3.9.
 pyvista==0.46.4; python_version >= "3.9" and python_version < "3.14"

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -3184,3 +3184,10 @@ def test_ddgs(pyi_builder):
         #for result in results:
         #    print(result)
     """)
+
+
+@importorskip("pytokens")
+def test_pytokens(pyi_builder):
+    pyi_builder.test_source("""
+        import pytokens
+    """)


### PR DESCRIPTION
Looks like `pytokens` 0.4.0 started using `mypy`, and now brings its own `{id}__mypyc` module that we need to discover and collect - similar to `blib2to3` from `black` (which depends on `pytokens >= 0.3.0`, and therefore ended up causing the error in the weekly-update CI run).
