### PR TITLE
hooks: add hook for rich

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-rich.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-rich.py
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2026 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_submodules, is_module_satisfies
+
+# Starting with v14.3.0, we need to collect modules from `rich._unicode_data`.
+if is_module_satisfies('rich >= 14.3.0'):
+    hiddenimports = collect_submodules('rich._unicode_data')

--- a/news/991.new.rst
+++ b/news/991.new.rst
@@ -1,0 +1,2 @@
+Add hook for ``rich`` to ensure that modules from ``rich._unicode_data``
+are collected for ``rich`` v14.3.0 and later.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -119,6 +119,7 @@ pyvista==0.47.1; python_version >= "3.10" and python_version < "3.14"
 pyzmq==27.1.0
 PyQt5==5.15.11
 qtmodern==0.2.0
+rich==14.3.3
 Rtree==1.4.1; python_version >= "3.9"
 sacremoses==0.1.1
 # Remove after merging https://github.com/pyinstaller/pyinstaller/pull/6587

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -3238,3 +3238,22 @@ def test_adbc_driver_manager_sdk(pyi_builder):
     pyi_builder.test_source("""
         import adbc_driver_manager
     """)
+
+
+@importorskip("rich")
+def test_rich_print(pyi_builder, tmp_path):
+    pyi_builder.test_source(
+        """
+        import sys
+        import rich.console
+
+        # Instead of letting Console write to stdout/stderr, force redirection to a file. Otherwise, the test fails on
+        # Windows, where pytest's redirect of stdout/stderr for capture purposes causes the streams to use local
+        # encoding instead of UTF-8.
+        output_file = sys.argv[1]
+        with open(output_file, 'w', encoding='utf8') as fp:
+            console = rich.console.Console(file=fp)
+            console.print(":green_circle:")
+        """,
+        app_args=[str(tmp_path / 'output.txt')],
+    )


### PR DESCRIPTION
Add hook for `rich` to ensure that modules from `rich._unicode_data` are collected for `rich` v14.3.0 and later.

Closes pyinstaller/pyinstaller#9387.