### PR TITLE
Update and extend the oneshot-test workflow

### DIFF
--- a/.github/workflows/oneshot-test.yml
+++ b/.github/workflows/oneshot-test.yml
@@ -22,10 +22,11 @@ on:
         default: 'numpy==1.19, numpy<1.18'
       os:
         description: |
-          OS(s) to run on. Can be any combinations of ubuntu, windows, macos.
-          (Please use macos sparingly.)'
+          OS(s) to run on. Can be any combination of ubuntu-latest, windows-latest,
+          macos-latest (as well as specific versions, for example macos-15-intel).
+          (Please use macOS runners sparingly.)'
         required: true
-        default: 'ubuntu'
+        default: 'ubuntu-latest'
       python-version:
         description: 'Version(s) of Python'
         required: true
@@ -94,7 +95,7 @@ jobs:
           quote = lambda x: '"{}"'.format(x.replace('"', r'\"'))
 
           matrix = {
-              "os": [i + "-latest" for i in parse_list(inputs["os"])],
+              "os": parse_list(inputs["os"]),
               "python-version": parse_list(inputs["python-version"]),
               "requirements": parse_list(inputs["package"]),
           }

--- a/.github/workflows/oneshot-test.yml
+++ b/.github/workflows/oneshot-test.yml
@@ -35,6 +35,10 @@ on:
         description: 'Terminate all tests if one fails (true/false).'
         required: true
         default: 'false'
+      pyinstaller:
+        description: 'Source URI from which PyInstaller should be installed.'
+        required: true
+        default: 'https://github.com/pyinstaller/pyinstaller/archive/develop.zip'
       commands:
         description: |
           Additional installation commands to run from terminal.
@@ -160,7 +164,7 @@ jobs:
           pip install ${{ matrix.requirements }}
 
           # Install PyInstaller
-          pip install https://github.com/pyinstaller/pyinstaller/archive/develop.zip
+          pip install ${{ github.event.inputs.pyinstaller }}
 
       - name: Run tests
         run: pytest -v -n logical ${{ inputs.pytest_args }}

--- a/.github/workflows/oneshot-test.yml
+++ b/.github/workflows/oneshot-test.yml
@@ -220,5 +220,5 @@ jobs:
         if: ${{ failure() && steps.run-tests.outcome == 'failure' }}
         uses: actions/upload-artifact@v6
         with:
-          name: failed-tests-${{ matrix.os }}-python-${{ matrix.python-version }}
+          name: failed-tests-${{ matrix.os }}-python-${{ matrix.python-version }}-matrix-idx-${{ strategy.job-index }}
           path: '${{ env.PYTEST_DEBUG_TEMPROOT }}/archived-failed-tests.tar'

--- a/.github/workflows/oneshot-test.yml
+++ b/.github/workflows/oneshot-test.yml
@@ -139,7 +139,8 @@ jobs:
 
     # Finally, the usual: setup Python, install dependencies, test.
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout pyinstaller-hooks-contrib code
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
@@ -169,5 +170,55 @@ jobs:
           # Install PyInstaller
           pip install ${{ github.event.inputs.pyinstaller }}
 
+      # Relocate the temporary directory to a fixed location so we can
+      # generate artifacts out of failed tests.
+      - name: Relocate temporary dir
+        shell: bash
+        run: |
+          echo "PYTEST_DEBUG_TEMPROOT=$RUNNER_TEMP" >> $GITHUB_ENV
+
       - name: Run tests
+        id: run-tests
         run: pytest -v -n logical ${{ inputs.pytest_args }}
+
+      # On all platforms, create a tarball to ensure that symlinks are preserved.
+      # Avoid using compression here, as the tarball will end up collected into
+      # artifact zip archive. To simplify this across platforms, run this step
+      # in python and use python's tarfile module.
+      - name: Archive failed tests
+        if: ${{ failure() && steps.run-tests.outcome == 'failure' }}
+        shell: python
+        run: |
+          import os
+          import sys
+          import tarfile
+
+          try:
+            import getpass
+            user = getpass.getuser() or "unknown"
+          except Exception:
+            user = "unknown"
+
+          temproot = os.environ['PYTEST_DEBUG_TEMPROOT']
+
+          pytest_name = f'pytest-of-{user}'
+          pytest_fullpath = os.path.join(temproot, pytest_name)
+          print(f"Input directory: {pytest_fullpath}!", file=sys.stderr)
+
+          output_file = os.path.join(temproot, 'archived-failed-tests.tar')
+          print(f"Output file: {output_file}!", file=sys.stderr)
+
+          assert os.path.isdir(pytest_fullpath)
+          assert not os.path.exists(output_file)
+
+          with tarfile.open(output_file, "w") as tf:
+            tf.add(pytest_fullpath, arcname=pytest_name, recursive=True)
+
+          print(f"Created {output_file}!", file=sys.stderr)
+
+      - name: Create artifact out of archived failed tests
+        if: ${{ failure() && steps.run-tests.outcome == 'failure' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: failed-tests-${{ matrix.os }}-python-${{ matrix.python-version }}
+          path: '${{ env.PYTEST_DEBUG_TEMPROOT }}/archived-failed-tests.tar'

--- a/.github/workflows/oneshot-test.yml
+++ b/.github/workflows/oneshot-test.yml
@@ -113,9 +113,12 @@ jobs:
 
           pprint.pprint(matrix)
 
-          # Outputs are set by printing special ::
-          print("::set-output name=matrix::", json.dumps(matrix), sep="")
-
+          # Outputs are set by appending a {name}={value} line to the
+          # environment file pointed to by GITHUB_OUTPUT environment variable.
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fp:
+            fp.write("matrix=")
+            json.dump(matrix, fp)
+            fp.write("\n")
 
   test:
     permissions:

--- a/scripts/cloud-test.py
+++ b/scripts/cloud-test.py
@@ -89,8 +89,17 @@ def _norm_comma_space(x):
     return re.sub(", *", ", ", x)
 
 
-PYTHONS = ["3.8", "3.9", "3.10", "3.11"]
-OSs = ["ubuntu", "windows", "macos"]
+PYTHONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+OSs = [
+    "ubuntu-latest", "windows-latest", "macos-latest",
+    # NOTE: the list below should be kept in sync with available runners
+    "ubuntu-22.04", "ubuntu-24.04",
+    "ubuntu-22.04-arm", "ubuntu-24.04-arm",
+    "windows-2022", "windows-2025",
+    "windows-11-arm",
+    "macos-14", "macos-15", "macos-26",
+    "macos-15-intel", "macos-26-intel",
+]
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
@@ -100,8 +109,9 @@ OSs = ["ubuntu", "windows", "macos"]
                    "multiple times to test multiple versions. You may specify micro versions such as 3.10.9 although "
                    "this is discouraged as they are not guaranteed to be available. Use 'all' to select {}. "
                    "Defaults to '3.11'.".format(PYTHONS))
-@click.option("--os", multiple=True, default=["ubuntu"], type=click.Choice(OSs + ["all"], case_sensitive=False),
-              help="Which OSs to test on. Use 'all' to specify all three. Defaults to 'ubuntu'.")
+@click.option("--os", multiple=True, default=["ubuntu-latest"], type=click.Choice(OSs + ["all"], case_sensitive=False),
+              help="Which OSs to test on. Use 'all' to specify 'ubuntu-latest', 'windows-latest', and 'macos-latest'. "
+                   "Defaults to 'ubuntu-latest'.")
 @click.option("--fail-fast", default=False, is_flag=True, help="Cancel all other builds if any one of them fails.")
 @click.option("--pytest-args", default="", help="Additional arguments to be passed to pytest.")
 @click.option("--fork", default=None,
@@ -123,7 +133,7 @@ def main(package, py, os, fork, branch, pytest_args, fail_fast, commands, browse
     Basic usage: Launch two jobs to test the ``pycparser`` hooks on linux, Pythons 3.10 and 3.11, using the latest
     version of ``pycparser``. And open the build in a browser window.
 
-        python cloud-test.py --py=3.10,3.11 --os=ubuntu --browser pycparser
+        python cloud-test.py --py=3.10,3.11 --os=ubuntu-latest --browser pycparser
 
     The **package** can be anything you'd put on the right hand side of `pip install`. Multiple packages to install can
     be separated by a space: Launch one job which installs and tests two libraries.
@@ -133,7 +143,7 @@ def main(package, py, os, fork, branch, pytest_args, fail_fast, commands, browse
     Multiple versions to be run in separate jobs should be deliminated by a comma: Launch 4 x 2 = 8 jobs to test the
     ``pycparser`` hooks on windows, with all supported Pythons, against two versions of ``pycparser``.
 
-        python cloud-test.py --py=all --os=windows pycparser==2.20, pycparser==2.16
+        python cloud-test.py --py=all --os=windows-latest pycparser==2.20, pycparser==2.16
 
     When you're absolutely certain your hook is ready for it, you may test everything (please use sparingly - this costs
     Github a lot of $$$). This would create 4 x 3 x 3 = 36 jobs.
@@ -153,7 +163,7 @@ def main(package, py, os, fork, branch, pytest_args, fail_fast, commands, browse
         py = PYTHONS
 
     if "all" in os:
-        os = OSs
+        os = ["ubuntu-latest", "windows-latest", "macos-latest"]
 
     package = " ".join(package)
 

--- a/scripts/cloud-test.py
+++ b/scripts/cloud-test.py
@@ -121,10 +121,12 @@ OSs = [
 @click.option("--commands", multiple=True,
               help="Additional bash installation commands to run. Ran after setting up Python but before pip-installing"
                    "dependencies.")
+@click.option("--pyinstaller", default="https://github.com/pyinstaller/pyinstaller/archive/develop.zip",
+              help="Where to install pyinstaller from. Defaults to the archive generated from upstream develop branch.")
 @click.option("--browser", default=False, is_flag=True,
               help="Open the live build on Github in a browser window.")
 @click.option("--dry-run", is_flag=True, help="Don't launch a build. Just parse and print the parameters.")
-def main(package, py, os, fork, branch, pytest_args, fail_fast, commands, browser, dry_run):
+def main(package, py, os, fork, branch, pytest_args, fail_fast, commands, pyinstaller, browser, dry_run):
     """Launch CI testing of a given package against multiple package or Python versions and OSs.
 
     The **package** specifies only those to install. Which tests should be ran is inferred implicitly by
@@ -174,6 +176,7 @@ def main(package, py, os, fork, branch, pytest_args, fail_fast, commands, browse
         "pytest_args": pytest_args,
         "fail-fast": str(fail_fast).lower(),
         "commands": "; ".join(commands),
+        "pyinstaller": pyinstaller,
     }
 
     print("Configuration options to be passed to CI:")


### PR DESCRIPTION
This PR attempts to make the `oneshot-test` workflow a bit more flexible and accommodating for debugging scenarios that I've encountered lately.

Have the `--os` option accept all (currently) valid runner names and have the `--py` option accept all currently available python versions. This allows us, for example, to use oneshot workflow to look into issues that show up in the weekly-update workflow on the `macos-15-intel` runner.

Add option to specify custom PyInstaller installation source - in cases when we need to test a change that has to be applied to the PyInstaller itself.

Use the environment file instead of `set-output` command to silence a deprecation warning.

Create artifact out of failed test, using same approach as in the main repository.