### PR TITLE
rthooks: revise the findlibs run-time hook

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -112,6 +112,9 @@ jobs:
             libgirepository-2.0-dev gir1.2-girepository-3.0
           # Required by pygraphviz
           sudo apt-get install -y graphviz graphviz-dev
+          # Contemporary versions of eccodes PyPI wheels provide bundled copies of eccodes library; install a system
+          # copy to ensure that the bundled copy is properly collected and used at run-time.
+          sudo apt-get install -y libeccodes0
 
       - name: Install brew dependencies
         if: startsWith(matrix.os, 'macos')
@@ -135,8 +138,8 @@ jobs:
           brew install libdiscid
           # Install lsl library for pylsl
           brew install labstreaminglayer/tap/lsl
-          # This one is required by eccodes (binary wheels with bundled eccodes
-          # library are provided only for macOS 13+).
+          # This one is required by eccodes. Binary wheels with bundled eccodes library are provided for macOS 13+,
+          # but we install system package to ensure that the bundled copy is properly collected and used at run-time.
           brew install eccodes
           # Requires by pygraphviz
           brew install graphviz

--- a/_pyinstaller_hooks_contrib/rthooks/pyi_rth_findlibs.py
+++ b/_pyinstaller_hooks_contrib/rthooks/pyi_rth_findlibs.py
@@ -9,16 +9,15 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-# Override the findlibs.find() function to give precedence to sys._MEIPASS, followed by `ctypes.util.find_library`,
-# and only then the hard-coded paths from the original implementation. The main aim here is to avoid loading libraries
-# from Homebrew environment on macOS when it happens to be present at run-time and we have a bundled copy collected from
-# the build system. This happens because we (try not to) modify `DYLD_LIBRARY_PATH`, and the original `findlibs.find()`
-# implementation gives precedence to environment variables and several fixed/hard-coded locations, and uses
-# `ctypes.util.find_library` as the final fallback...
+# Override the `findlibs.find()` function with custom implementation that checks whether the original implementation
+# resolves the copy of a library that is bundled with the frozen application. If the original implementation fails to
+# resolve the shared library or resolves a system copy, explicitly check if a copy exists in the top-level application
+# directory and if it does, return it instead. This aims to mitigate issues with older versions of `findlibs` (< 0.1.0)
+# that failed to pick up bundled copy from top-level application directory due to hard-coded search paths.
 def _pyi_rthook():
     import sys
     import os
-    import ctypes.util
+    import pathlib
 
     # findlibs v0.1.0 broke compatibility with python < 3.10; due to incompatible typing annotation, attempting to
     # import the package raises `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'`. Gracefully
@@ -30,26 +29,26 @@ def _pyi_rthook():
         return
 
     _orig_find = getattr(findlibs, 'find', None)
+    if _orig_find is None:
+        return
 
     def _pyi_find(lib_name, *args, **kwargs):
-        extension = findlibs.EXTENSIONS.get(sys.platform, ".so")
+        # Try resolving with the original implementation. If resolved, check that a bundled copy was resolved.
+        orig_lib = _orig_find(lib_name, *args, **kwargs)
+        if orig_lib is not None:
+            application_dir = pathlib.Path(sys._MEIPASS).resolve()
+            lib_path = pathlib.Path(orig_lib).resolve()
+            if application_dir in lib_path.parents:
+                return orig_lib
 
-        # First check sys._MEIPASS
-        fullname = os.path.join(sys._MEIPASS, "lib{}{}".format(lib_name, extension))
+        # Look for a copy in top-level application directory.
+        extension = findlibs.EXTENSIONS.get(sys.platform, ".so")
+        fullname = os.path.join(sys._MEIPASS, f"lib{lib_name}{extension}")
         if os.path.isfile(fullname):
             return fullname
 
-        # Fall back to `ctypes.util.find_library` (to give it precedence over hard-coded paths from original
-        # implementation).
-        lib = ctypes.util.find_library(lib_name)
-        if lib is not None:
-            return lib
-
-        # Finally, fall back to original implementation
-        if _orig_find is not None:
-            return _orig_find(lib_name, *args, **kwargs)
-
-        return None
+        # As a last resort, return the result of original resolution attempt.
+        return orig_lib
 
     findlibs.find = _pyi_find
 

--- a/news/1014.update.rst
+++ b/news/1014.update.rst
@@ -1,0 +1,3 @@
+Rework the ``findlibs`` run-time hook to improve compatibility with
+``findlibs`` >= 0.1.0 and avoid problems with contemporary versions
+of ``eccodes`` / ``eccodeslib``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -39,8 +39,8 @@ ddgs==9.14.1; python_version >= "3.10"
 # installed in /opt/homebrew/lib and does not seem to be visible to non-Homebrew python.
 discid==1.4.0; sys_platform != "win32" and (sys_platform != "darwin" or platform_machine != "arm64") and python_version >= "3.10"
 duckdb==1.5.2; python_version >= "3.10"
-# eccodes does not provide win64 wheels for python 3.14 yet
-eccodes==2.46.0; python_version >= "3.10" and (sys_platform != "win32" or python_version < "3.14")
+# eccodes does not provide win64 wheels for python 3.14 yet; on other platforms, python >= 3.10 is required due to use of findlibs.
+eccodes==2.47.0; (sys_platform == "win32" and python_version >= "3.9" and python_version < "3.14") or (sys_platform != "win32" and python_version >= "3.10")
 eth_typing==6.0.0; python_version >= "3.10"
 eth_utils==6.0.0; python_version >= "3.10"
 fabric==3.2.3


### PR DESCRIPTION
Turns out that failures in `eccodes` test on `macos-15-intel` that we saw in [yesterday's weekly dependency update](https://github.com/pyinstaller/pyinstaller-hooks-contrib/actions/runs/25016601863) was caused by our `findlibs` run-time hook, which ended up resolving a system copy of the library - the one thing it was explicitly trying to prevent...

The override for `findlibs.find()` was somewhat broken ever since `findlibs` 0.1.0 revised their search order and `eccodes` PyPI wheels moved the bundled shared library to separate `eccodeslib` wheel; but we failed to notice that because binary dependency analysis created symlink to the (package-bundled) `eccodes` shared library, which was picked up by our `findlibs.find()` override. This symlink now seems to be gone when building with contemporary versions of `eccodes` wheels for x86_64 macOS, which exposed the problem.

Therefore, revise the `findlibs.find()` override in `findlibs` run-time hook to first resolve the library with original implementation, and only if that fails (returns `None` or resolves a non-bundled copy of the library) try to check for a copy in top-level application directory. This should be largely unnecessary with contemporary PyPI wheels of `eccodes` / `eccodeslib` (due to libs being bundled in the latter), but it might still be necessary with versions that do not bundle the shared libraries (or older versions used in combination with old `findlibs` that had problem with fixed search paths).

Repin the `eccodes` in requirements file, as per yesterday's update attempt.

Have the `pr-test` workflow on `ubuntu` runners install `libeccodes0`, so that the system copy of the library is provided for interference purposes - i.e., to ensure that copy provided by wheels is properly collected and used at run-time. (Similarly to how we have a Homebrew-installed copy available, which we forgot to remove when the runners were upgraded to macOS >= 13.0...)