### PR TITLE
Exclude bytecode from distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 graft _pyinstaller_hooks_contrib
-global-exclude *.py[cod]
+global-exclude *.pyc
 include LICENSE

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 graft _pyinstaller_hooks_contrib
+global-exclude *.py[cod]
 include LICENSE

--- a/news/1019.process.rst
+++ b/news/1019.process.rst
@@ -1,0 +1,1 @@
+Exclude generated Python bytecode files from source and wheel distributions.


### PR DESCRIPTION
## Summary

- Exclude generated Python bytecode from the source manifest so release builds do not package `__pycache__` artifacts.
- Add the required `process` news fragment for #1019.

## Validation

- Static checks only: `git diff --check` and `git diff --cached --check` passed, with the usual Windows CRLF warning before commit.
- Remote workflows are waiting for maintainer approval on the fork PR and have not published logs:
  - `Lint`: https://github.com/pyinstaller/pyinstaller-hooks-contrib/actions/runs/26157551416
  - `Validate news entries`: https://github.com/pyinstaller/pyinstaller-hooks-contrib/actions/runs/26157551663
- Not run locally