### PR TITLE
Fix bug setting GDAL_DATA in `osgeo` runtime hook

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,15 @@
+Unreleased Changes
+------------------
+
+Updated hooks
+~~~~~~~~~~~~~
+
+* Fix bug in ``pyi_rth_osgeo.py`` where the "GDAL_DATA" environment variable
+  would not get set on Windows when building from a conda environment.
+  (`#1020
+  <https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/1020>`_)
+
+
 2026.5 (2026-05-04)
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,15 +1,3 @@
-Unreleased Changes
-------------------
-
-Updated hooks
-~~~~~~~~~~~~~
-
-* Fix bug in ``pyi_rth_osgeo.py`` where the "GDAL_DATA" environment variable
-  would not get set on Windows when building from a conda environment.
-  (`#1020
-  <https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/1020>`_)
-
-
 2026.5 (2026-05-04)
 -------------------
 

--- a/_pyinstaller_hooks_contrib/rthooks/pyi_rth_osgeo.py
+++ b/_pyinstaller_hooks_contrib/rthooks/pyi_rth_osgeo.py
@@ -27,7 +27,7 @@ if is_win:
             generic_folder = os.path.join(sys._MEIPASS, 'Library', 'data')
             # 'gcs.csv' is included by gdal <= 2.4.4
             # 'gdalicon.png' is included by gdal >= 2.4.4 (and presumeably earlier)
-            if os.path.exists(os.path.join(generic_folder, 'gcs.csv')) | \
+            if os.path.exists(os.path.join(generic_folder, 'gcs.csv')) or \
                     os.path.exists(os.path.join(generic_folder, 'gdalicon.png')):
                 gdal_data = generic_folder
 

--- a/_pyinstaller_hooks_contrib/rthooks/pyi_rth_osgeo.py
+++ b/_pyinstaller_hooks_contrib/rthooks/pyi_rth_osgeo.py
@@ -21,9 +21,13 @@ if is_win:
     if not os.path.exists(gdal_data):
 
         gdal_data = os.path.join(sys._MEIPASS, 'Library', 'share', 'gdal')
-        # last attempt, check if one of the required file is in the generic folder Library/data
-        if not os.path.exists(os.path.join(gdal_data, 'gcs.csv')):
-            gdal_data = os.path.join(sys._MEIPASS, 'Library', 'data')
+        if not os.path.exists(gdal_data):
+            # last attempt, check if one of the required files is in the
+            # generic folder Library/data
+            generic_folder = os.path.join(sys._MEIPASS, 'Library', 'data')
+            if os.path.exists(os.path.join(
+                    generic_folder, 'gdalinfo_output.schema.json')):
+                gdal_data = generic_folder
 
 else:
     gdal_data = os.path.join(sys._MEIPASS, 'share', 'gdal')

--- a/_pyinstaller_hooks_contrib/rthooks/pyi_rth_osgeo.py
+++ b/_pyinstaller_hooks_contrib/rthooks/pyi_rth_osgeo.py
@@ -23,10 +23,12 @@ if is_win:
         gdal_data = os.path.join(sys._MEIPASS, 'Library', 'share', 'gdal')
         if not os.path.exists(gdal_data):
             # last attempt, check if one of the required files is in the
-            # generic folder Library/data
+            # generic folder Library/data.
             generic_folder = os.path.join(sys._MEIPASS, 'Library', 'data')
-            if os.path.exists(os.path.join(
-                    generic_folder, 'gdalinfo_output.schema.json')):
+            # 'gcs.csv' is included by gdal <= 2.4.4
+            # 'gdalicon.png' is included by gdal >= 2.4.4 (and presumeably earlier)
+            if os.path.exists(os.path.join(generic_folder, 'gcs.csv')) | \
+                    os.path.exists(os.path.join(generic_folder, 'gdalicon.png')):
                 gdal_data = generic_folder
 
 else:

--- a/news/1021.update.rst
+++ b/news/1021.update.rst
@@ -1,0 +1,2 @@
+Fix bug in ``pyi_rth_osgeo.py`` where the "GDAL_DATA" environment variable
+would not get set on Windows when building from a conda environment.

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2092,11 +2092,13 @@ def test_pypylon(pyi_builder):
 
 @importorskip('osgeo')
 def test_osgeo(pyi_builder):
+    # Setting GDAL_DATA is the job of the rthook
     pyi_builder.test_source("""
-        from osgeo import osr
+        from osgeo import osr, gdal
         sr = osr.SpatialReference()
         sr.ImportFromEPSG(4326)
         assert(sr.EPSGTreatsAsLatLong())
+        assert(gdal.GetConfigOption('GDAL_DATA'))
     """)
 
 


### PR DESCRIPTION
Fixes bug in `osgeo` runtime hook where the `GDAL_DATA` environment variable was not being set on Windows with a conda environment.

Fixes #1020 

I tested these changes locally by building my project and running its exe with this hook.

I also added an assertion to the existing `osgeo` test in `test_libraries.py`, but `gdal` is missing from `requirements-test-libraries.txt`, so I'm not sure if/when that test will run. GDAL is tough to `pip install` so perhaps that's why it is not in the requirements.

<!---
Please review the summary checklist before submitting your pull request
https://github.com/pyinstaller/pyinstaller-hooks-contrib?tab=readme-ov-file#summary
--->
