### PR TITLE
Add hook for zeroconf

### DIFF
--- a/_pyinstaller_hooks_contrib/stdhooks/hook-zeroconf.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-zeroconf.py
@@ -1,0 +1,17 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2026 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_submodules
+
+# PyPI wheels for zeroconf are cythonized, which prevents PyInstaller's module
+# graph from seeing the imports performed by the extension modules.
+hiddenimports = collect_submodules('zeroconf')

--- a/news/1024.update.rst
+++ b/news/1024.update.rst
@@ -1,0 +1,1 @@
+Update ``zeroconf`` hook to collect cythonized package submodules.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -270,6 +270,7 @@ toga==0.5.4; python_version >= "3.10" and (python_version < "3.14" or sys_platfo
 numbers-parser==4.18.5; python_version >= "3.10"
 fsspec==2026.4.0; python_version >= "3.10"
 zarr==3.2.1; python_version >= "3.12"
+zeroconf==0.149.16; python_version >= "3.10"
 intake==2.0.9; python_version >= "3.10"
 h3==4.4.2
 selectolax==0.4.9; python_version >= "3.9"

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -2678,6 +2678,15 @@ def test_xarray_to_zarr(pyi_builder):
     """)
 
 
+@importorskip('zeroconf')
+def test_zeroconf(pyi_builder):
+    pyi_builder.test_source("""
+        import zeroconf
+
+        print(zeroconf.__name__)
+    """)
+
+
 @importorskip('intake')
 def test_intake(pyi_builder):
     pyi_builder.test_source("""


### PR DESCRIPTION
## Summary

- Add a standard hook for `zeroconf` that collects package submodules hidden behind cythonized wheels.
- Add a frozen import test and pin `zeroconf` in the test-library requirements.
- Add the required news fragment.

Closes #840.

## Validation

- Remote CI passed: `Lint`, `Validate news entries`, and `Pull Request CI` run https://github.com/pyinstaller/pyinstaller-hooks-contrib/actions/runs/26470820095.
- Static checks only: `git diff --check`, `git diff --cached --check`, and `git show --check --stat --oneline HEAD`.
- Not run locally.