### PR TITLE
hooks: update pygrapvhiz hook for compatibility with pygraphviz >= 2.0

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -80,7 +80,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y wget apt-transport-https
           wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
-          echo "96d4ce68b93dc10afc6189bb01a90043bebbd2b8bdc1b62065e12c87a0757b25  mariadb_repo_setup" | sha256sum -c -
+          echo "7325ac7755809ca3312b446bd832542421699298f25b701f9a111bb42df0c7c1  mariadb_repo_setup" | sha256sum -c -
           chmod +x mariadb_repo_setup
           sudo ./mariadb_repo_setup --skip-maxscale
           sudo apt-get install -y libmariadb3 libmariadb-dev

--- a/_pyinstaller_hooks_contrib/rthooks/pyi_rth_pygraphviz.py
+++ b/_pyinstaller_hooks_contrib/rthooks/pyi_rth_pygraphviz.py
@@ -9,24 +9,36 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import pygraphviz
+def _pyi_rthook():
+    import pygraphviz
 
-# Override pygraphviz.AGraph._which method to search for graphviz executables inside sys._MEIPASS
-if hasattr(pygraphviz.AGraph, '_which'):
+    # Override pygraphviz.AGraph._which method to search for graphviz executables inside sys._MEIPASS
+    if hasattr(pygraphviz.AGraph, '_which'):
 
-    def _pygraphviz_override_which(self, name):
-        import os
-        import sys
-        import platform
+        def _pygraphviz_override_which(self, name):
+            import os
+            import sys
+            import platform
 
-        program_name = name
-        if platform.system() == "Windows":
-            program_name += ".exe"
+            program_name = name
+            if platform.system() == "Windows":
+                program_name += ".exe"
 
-        program_path = os.path.join(sys._MEIPASS, program_name)
-        if not os.path.isfile(program_path):
+            # First, check pygraphviz/bin directory (used by pygraphviz >= 2.0 PyPI wheels to bundle executables).
+            program_path = os.path.join(sys._MEIPASS, 'pygraphviz', 'bin', program_name)
+            if os.path.isfile(program_path):
+                return program_path
+
+            # Try top-level application directory
+            program_path = os.path.join(sys._MEIPASS, program_name)
+            if os.path.isfile(program_path):
+                return program_path
+
+            # Not found - instead of falling back to system copy, raise an error
             raise ValueError(f"Prog {name} not found in the PyInstaller-frozen application bundle!")
 
-        return program_path
+        pygraphviz.AGraph._which = _pygraphviz_override_which
 
-    pygraphviz.AGraph._which = _pygraphviz_override_which
+
+_pyi_rthook()
+del _pyi_rthook

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-pygraphviz.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-pygraphviz.py
@@ -11,135 +11,236 @@
 # ------------------------------------------------------------------
 import os
 import pathlib
-import shutil
 
-from PyInstaller import compat
+from PyInstaller import compat, isolated
 from PyInstaller.depend import bindepend
-from PyInstaller.utils.hooks import logger
+from PyInstaller.utils.hooks import get_module_file_attribute, is_module_satisfies, logger
 
 
-def _collect_graphviz_files():
-    binaries = []
-    datas = []
-
-    # A working `pygraphviz` installation requires graphviz programs in PATH. Attempt to resolve the `dot` executable to
-    # see if this is the case.
-    dot_binary = shutil.which('dot')
-    if not dot_binary:
-        logger.warning(
-            "hook-pygraphviz: 'dot' program not found in PATH!"
+def _find_graphviz_programs(is_pygraphviz2):
+    # Collect graphviz programs that might be called from `pygaphviz.agraph.AGraph`
+    # In system installations on macOS and Linux, several of these are commonly symbolic links to a single executable.
+    if is_pygraphviz2:
+        # https://github.com/pygraphviz/pygraphviz/blob/pygraphviz-2.0/pygraphviz/agraph.py#L1334-L1343
+        program_names = (
+            "gc",
+            "acyclic",
+            "gvpr",
+            "gvcolor",
+            "ccomps",
+            "sccmap",
+            "tred",
+            "unflatten",
         )
-        return binaries, datas
-    logger.info("hook-pygraphviz: found 'dot' program: %r", dot_binary)
-    bin_dir = pathlib.Path(dot_binary).parent
+        logger.info("hook-pygraphviz: collecting graphviz executables for pygraphviz >= 2.0...")
+    else:
+        # https://github.com/pygraphviz/pygraphviz/blob/pygraphviz-1.14/pygraphviz/agraph.py#L1330-L1348
+        program_names = (
+            "neato",
+            "dot",
+            "twopi",
+            "circo",
+            "fdp",
+            "nop",
+            "osage",
+            "patchwork",
+            "gc",
+            "acyclic",
+            "gvpr",
+            "gvcolor",
+            "ccomps",
+            "sccmap",
+            "tred",
+            "sfdp",
+            "unflatten",
+        )
+        logger.info("hook-pygraphviz: collecting graphviz executables for pygraphviz < 2.0...")
 
-    # Collect graphviz programs that might be called from `pygaphviz.agraph.AGraph`:
-    # https://github.com/pygraphviz/pygraphviz/blob/pygraphviz-1.14/pygraphviz/agraph.py#L1330-L1348
-    # On macOS and on Linux, several of these are symbolic links to a single executable.
-    progs = (
-        "neato",
-        "dot",
-        "twopi",
-        "circo",
-        "fdp",
-        "nop",
-        "osage",
-        "patchwork",
-        "gc",
-        "acyclic",
-        "gvpr",
-        "gvcolor",
-        "ccomps",
-        "sccmap",
-        "tred",
-        "sfdp",
-        "unflatten",
+    @isolated.decorate
+    def _get_executables_info(program_names):
+        import pathlib
+
+        import pygraphviz
+
+        # Check if pygraphviz/bin directory exists
+        try:
+            import pygraphviz.bin
+            bin_dir = pygraphviz.bin.__path__[0]
+            bin_dir = pathlib.Path(bin_dir).resolve()
+        except ImportError:
+            bin_dir = None
+
+        # Resolve every program using pygraphviz's own resolver, and determine if executable is bundled with package
+        # (PyPI wheel) or taken from system.
+        program_info = {}
+        g = pygraphviz.agraph.AGraph()
+        for program_name in program_names:
+            try:
+                program_executable = g._get_prog(program_name)
+            except Exception:
+                continue
+
+            program_path = pathlib.Path(program_executable).resolve()
+            is_bundled = bin_dir and bin_dir in program_path.parents
+
+            program_info[program_name] = program_executable, is_bundled
+
+        return program_info
+
+    executables_info = _get_executables_info(program_names)
+    if not executables_info:
+        logger.warning("hook-pygraphviz: no graphviz program executable was discovered!")
+        return []
+
+    # Display info
+    for program_name in program_names:
+        info = executables_info.get(program_name, None)
+        if info is None:
+            logger.debug("hook-pygraphviz: %r: not found!", program_name)
+        else:
+            program_path, is_bundled = info
+            logger.debug(
+                "hook-pygraphviz: %r [%s]: %r", program_name, 'bundled' if is_bundled else 'system', program_path
+            )
+
+    # Construct binaries list and check that all programs are collected from the same location
+    binaries = []
+
+    program_locations = set()
+    program_bundled = []
+
+    for program_name, (program_path, is_bundled) in executables_info.items():
+        binaries.append((program_path, os.path.join('pygraphviz', 'bin') if is_bundled else '.'))
+
+        # Validation
+        program_location = pathlib.Path(program_path).parent
+        program_locations.add(program_location)
+        program_bundled.append(is_bundled)
+
+    if len(program_locations) != 1:
+        raise SystemExit(
+            "ERROR: collection of graphviz programs from multiple locations is not supported! "
+            f"Location: {sorted(program_locations)}"
+        )
+
+    if all(program_bundled):
+        logger.info("hook-pygraphviz: graphviz programs were collected from the package/wheel.")
+    elif not all(program_bundled):
+        logger.info("hook-pygraphviz: graphviz programs were collected from system installation.")
+    else:
+        raise SystemExit(
+            "ERROR: a mixture of bundled and system graphviz programs is not supported!"
+        )
+
+    return binaries
+
+
+def _find_graphviz_shared_library():
+    # Get path to pygraphviz._graphviz extension module
+    extension_file = pathlib.Path(get_module_file_attribute('pygraphviz._graphviz')).resolve()
+    pacakge_directory = extension_file.parent
+
+    # Path to bundled libraries directory used by pygraphviz >= 2.0 wheels:
+    #  - Windows: package_directory/../pygraphviz.libs (delvewheel)
+    #  - macOS: package_directory/.dylibs (relocate)
+    #  - linux: package_directory/../pygraphviz.libs (auditwheel)
+    if compat.is_darwin:
+        bundled_lib_dir = pacakge_directory / ".dylibs"
+    else:
+        bundled_lib_dir = pacakge_directory.parent / "pygraphviz.libs"
+
+    # Perform binary dependency analysis on the extension module
+    graphviz_lib_candidates = ['cdt', 'gvc', 'cgraph']
+
+    search_paths = [bundled_lib_dir] if bundled_lib_dir.is_dir() else []
+    if hasattr(bindepend, 'get_imports'):
+        # PyInstaller >= 6.0
+        extension_imports = [
+            path for name, path in bindepend.get_imports(str(extension_file), search_paths)
+            if path is not None
+        ]
+    else:
+        # PyInstaller < 6.0
+        extension_imports = bindepend.getImports(str(extension_file))
+        # The old getImports() does not perform explicit fullpath resolution; so on Windows, it returns just basenames.
+        if compat.is_win:
+            extension_imports = [
+                bindepend.getfullnameof(name, search_paths) for name in extension_imports
+            ]  # NOTE: unresolved paths will be empty and discarded below
+
+    graphviz_lib_paths = [
+        pathlib.Path(path).resolve() for path in extension_imports
+        if any(candidate in os.path.basename(path) for candidate in graphviz_lib_candidates)
+    ]
+
+    if not graphviz_lib_paths:
+        return None, False
+
+    return graphviz_lib_paths[0], graphviz_lib_paths[0].parent == bundled_lib_dir
+
+
+binaries = []
+datas = []
+
+is_pygraphviz2 = is_module_satisfies("pygraphviz >= 2.0")
+
+# Collect graphviz programs - either from the build system, or from wheel (pygraphviz >= 2.0)
+binaries += _find_graphviz_programs(is_pygraphviz2)
+
+# Find the graphviz shared library against which the pygraphviz._graphviz extension is linked
+graphviz_library, is_bundled = _find_graphviz_shared_library()
+if not graphviz_library:
+    logger.warning("hook-pygraphviz: could not determine location of graphviz shared libraries!")
+else:
+    logger.info(
+        "hook-pygraphviz: graphviz shared library: %r (%s)",
+        str(graphviz_library),
+        'bundled' if is_bundled else 'system',
     )
 
-    logger.debug("hook-pygraphviz: collecting graphviz program executables...")
-    for program_name in progs:
-        program_binary = shutil.which(program_name)
-        if not program_binary:
-            logger.debug("hook-pygaphviz: graphviz program %r not found!", program_name)
-            continue
-
-        # Ensure that the program executable was found in the same directory as the `dot` executable. This should
-        # prevent us from falling back to other graphviz installations that happen to be in PATH.
-        if pathlib.Path(program_binary).parent != bin_dir:
-            logger.debug(
-                "hook-pygraphviz: found program %r (%r) outside of directory %r - ignoring!",
-                program_name, program_binary, str(bin_dir)
-            )
-            continue
-
-        logger.debug("hook-pygraphviz: collecting graphviz program %r: %r", program_name, program_binary)
-        binaries += [(program_binary, '.')]
-
-    # Graphviz shared libraries should be automatically collected when PyInstaller performs binary dependency
-    # analysis of the collected program executables as part of the main build process. However, we need to manually
-    # collect plugins and their accompanying config file.
-    logger.debug("hook-pygraphviz: looking for graphviz plugin directory...")
-    if compat.is_win:
-        # Under Windows, we have several installation variants:
-        #  - official installers and builds from https://gitlab.com/graphviz/graphviz/-/releases
-        #  - chocolatey
-        #  - msys2
-        #  - Anaconda
-        # In all variants, the plugins and the config file are located in the `bin` directory, next to the program
-        # executables.
-        plugin_dir = bin_dir
-        plugin_dest_dir = '.'  # Collect into top-level application directory.
-        # Official builds and Anaconda use unversioned `gvplugin-{name}.dll` plugin names, while msys2 uses
-        # versioned `libgvplugin-{name}-{version}.dll` plugin names (with "lib" prefix).
-        plugin_pattern = '*gvplugin*.dll'
+    if is_bundled:
+        if compat.is_win:
+            # Just in case, explicitly collect delvewheel directory
+            if is_module_satisfies("PyInstaller >= 5.6"):
+                from PyInstaller.utils.hooks import collect_delvewheel_libs_directory
+                datas, binaries = collect_delvewheel_libs_directory("pygraphviz", datas=datas, binaries=binaries)
+            else:
+                graphviz_library_dir = graphviz_library.parent
+                datas += [(str(graphviz_library_dir), graphviz_library_dir.name)]
+        elif compat.is_linux:
+            # Suppress creation of top-level symlinks for wheel-bundled libraries.
+            # Requires PyInstaller >= 6.11.0; no-op in earlier versions.
+            bindepend_symlink_suppression = ['**/pygraphviz.libs/lib*.so*']
     else:
-        # Perform binary dependency analysis on the `dot` executable to obtain the path to graphiz shared libraries.
-        # These need to be in the library search path for the programs to work, or discoverable via run-paths
-        # (e.g., Anaconda on Linux and macOS, Homebrew on macOS).
-        graphviz_lib_candidates = ['cdt', 'gvc', 'cgraph']
-
-        if hasattr(bindepend, 'get_imports'):
-            # PyInstaller >= 6.0
-            dot_imports = [path for name, path in bindepend.get_imports(dot_binary) if path is not None]
+        # System copy; try to collect graphviz plugins
+        if compat.is_win:
+            # Under Windows, we have several installation variants:
+            #  - official installers and builds from https://gitlab.com/graphviz/graphviz/-/releases
+            #  - chocolatey
+            #  - msys2
+            #  - Anaconda
+            # In all variants, the plugins and the config file are located in the `bin` directory, next to the program
+            # executables and shared libraries.
+            plugin_dir = graphviz_library.parent
+            plugin_dest_dir = '.'  # Collect into top-level application directory.
+            # Official builds and Anaconda use unversioned `gvplugin-{name}.dll` plugin names, while msys2 uses
+            # versioned `libgvplugin-{name}-{version}.dll` plugin names (with "lib" prefix).
+            plugin_pattern = '*gvplugin*.dll'
         else:
-            # PyInstaller < 6.0
-            dot_imports = bindepend.getImports(dot_binary)
+            # Plugins should be located in `graphviz` directory next to shared libraries.
+            plugin_dir = graphviz_library.parent / 'graphviz'
+            plugin_dest_dir = 'graphviz'  # Collect into graphviz sub-directory.
 
-        graphviz_lib_paths = [
-            path for path in dot_imports
-            if any(candidate in os.path.basename(path) for candidate in graphviz_lib_candidates)
-        ]
+            if compat.is_darwin:
+                plugin_pattern = '*gvplugin*.dylib'
+            else:
+                # Collect only versioned .so library files (for example, `/lib64/graphviz/libgvplugin_core.so.6` and
+                # `/lib64/graphviz/libgvplugin_core.so.6.0.0`; the former usually being a symbolic link to the latter).
+                # The unversioned .so library files (such as `lib64/graphviz/libgvplugin_core.so`), if available, are
+                # meant for linking (and are usually installed as part of development package).
+                plugin_pattern = '*gvplugin*.so.*'
 
-        if not graphviz_lib_paths:
-            logger.warning("hook-pygraphviz: could not determine location of graphviz shared libraries!")
-            return binaries, datas
+        logger.info("hook-pygraphviz: collecting graphviz plugins from directory: %r", str(plugin_dir))
 
-        graphviz_lib_dir = pathlib.Path(graphviz_lib_paths[0]).parent
-        logger.debug("hook-pygraphviz: location of graphviz shared libraries: %r", str(graphviz_lib_dir))
-
-        # Plugins should be located in `graphviz` directory next to shared libraries.
-        plugin_dir = graphviz_lib_dir / 'graphviz'
-        plugin_dest_dir = 'graphviz'  # Collect into graphviz sub-directory.
-
-        if compat.is_darwin:
-            plugin_pattern = '*gvplugin*.dylib'
-        else:
-            # Collect only versioned .so library files (for example, `/lib64/graphviz/libgvplugin_core.so.6` and
-            # `/lib64/graphviz/libgvplugin_core.so.6.0.0`; the former usually being a symbolic link to the latter).
-            # The unversioned .so library files (such as `lib64/graphviz/libgvplugin_core.so`), if available, are
-            # meant for linking (and are usually installed as part of development package).
-            plugin_pattern = '*gvplugin*.so.*'
-
-    if not plugin_dir.is_dir():
-        logger.warning("hook-pygraphviz: could not determine location of graphviz plugins!")
-        return binaries, datas
-
-    logger.info("hook-pygraphviz: collecting graphviz plugins from directory: %r", str(plugin_dir))
-
-    binaries += [(str(file), plugin_dest_dir) for file in plugin_dir.glob(plugin_pattern)]
-    datas += [(str(file), plugin_dest_dir) for file in plugin_dir.glob("config*")]  # e.g., `config6`
-
-    return binaries, datas
-
-
-binaries, datas = _collect_graphviz_files()
+        binaries += [(str(file), plugin_dest_dir) for file in plugin_dir.glob(plugin_pattern)]
+        datas += [(str(file), plugin_dest_dir) for file in plugin_dir.glob("config*")]  # e.g., `config6`

--- a/news/1031.update.rst
+++ b/news/1031.update.rst
@@ -1,0 +1,3 @@
+Update ``pygraphviz`` hook for improved compatibility with ``pygraphviz``
+2.0 and its new binary wheels that are available for macOS, Windows, and
+Linux.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -98,6 +98,8 @@ pydicom==3.0.2; python_version >= "3.10"
 pyecharts==2.1.0
 pyexcelerate==0.13.0
 pyexcel_ods==0.6.0
+# pygraphviz requires graphviz to be provided by the environment (linux distribution, homebrew, or Anaconda).
+pygraphviz==1.14; (sys_platform == "darwin" or sys_platform == "linux") and python_version >= "3.10"
 pylibmagic==0.5.0; sys_platform != "win32"
 pylint==4.0.6; python_version >= "3.10"
 pymeshlab==2025.7.post1; python_version >= "3.10"
@@ -311,9 +313,6 @@ pylsl==1.18.2; (sys_platform == "darwin" or sys_platform == "win32") and python_
 
 # PyTaskbar only runs on Windows
 PyTaskbar==0.1.1; sys_platform == "win32" and python_version >= "3.10"
-
-# pygraphviz requires graphviz to be provided by the environment (linux distribution, homebrew, or Anaconda).
-pygraphviz==1.14; (sys_platform == "darwin" or sys_platform == "linux") and python_version >= "3.10"
 
 # Include the requirements for testing
 -r requirements-test.txt

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -98,8 +98,7 @@ pydicom==3.0.2; python_version >= "3.10"
 pyecharts==2.1.0
 pyexcelerate==0.13.0
 pyexcel_ods==0.6.0
-# pygraphviz requires graphviz to be provided by the environment (linux distribution, homebrew, or Anaconda).
-pygraphviz==1.14; (sys_platform == "darwin" or sys_platform == "linux") and python_version >= "3.10"
+pygraphviz==2.0; python_version >= "3.10"
 pylibmagic==0.5.0; sys_platform != "win32"
 pylint==4.0.6; python_version >= "3.10"
 pymeshlab==2025.7.post1; python_version >= "3.10"

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -11,6 +11,7 @@
 # ------------------------------------------------------------------
 
 import pathlib
+import sys
 
 import pytest
 from PyInstaller import isolated
@@ -1141,18 +1142,127 @@ def test_twisted_custom_reactor(pyi_builder):
 
 @importorskip("pygraphviz")
 def test_pygraphviz_bundled_programs(pyi_builder):
+    @isolated.decorate
+    def _get_programs_info():
+        import pathlib
+
+        import pygraphviz
+
+        # Check if this is pygraphviz >= 2.0
+        try:
+            pygraphviz_v2 = int(pygraphviz.__version__.split('.')[0]) >= 2
+        except Exception:
+            pygraphviz_v2 = False
+
+        # Check if pygraphviz/bin directory exists
+        try:
+            import pygraphviz.bin
+            bin_dir = pygraphviz.bin.__path__[0]
+            bin_dir = pathlib.Path(bin_dir).resolve()
+        except ImportError:
+            bin_dir = None
+
+        if pygraphviz_v2:
+            # https://github.com/pygraphviz/pygraphviz/blob/pygraphviz-2.0/pygraphviz/agraph.py#L1334-L1343
+            program_names = (
+                "gc",
+                "acyclic",
+                "gvpr",
+                "gvcolor",
+                "ccomps",
+                "sccmap",
+                "tred",
+                "unflatten",
+            )
+        else:
+            # https://github.com/pygraphviz/pygraphviz/blob/pygraphviz-1.14/pygraphviz/agraph.py#L1330-L1348
+            program_names = (
+                "neato",
+                "dot",
+                "twopi",
+                "circo",
+                "fdp",
+                "nop",
+                "osage",
+                "patchwork",
+                "gc",
+                "acyclic",
+                "gvpr",
+                "gvcolor",
+                "ccomps",
+                "sccmap",
+                "tred",
+                "sfdp",
+                "unflatten",
+            )
+
+        # Resolve every program using pygraphviz's own resolver, and determine if executable is bundled with package
+        # (PyPI wheel) or taken from system.
+        program_info = {}
+        g = pygraphviz.agraph.AGraph()
+        for program_name in program_names:
+            try:
+                program_executable = g._get_prog(program_name)
+            except Exception:
+                continue
+
+            program_path = pathlib.Path(program_executable).resolve()
+            is_bundled = bool(bin_dir and bin_dir in program_path.parents)
+
+            program_info[program_name] = is_bundled
+
+        return program_info
+
+    # Look up graphviz executable information, and require at least one executable to be successfully resolved.
+    programs_info = _get_programs_info()
+    assert programs_info
+
+    app_args = []
+    print("graphviz programs:", file=sys.stderr)
+    for name, bundled in programs_info.items():
+        print(f" - {name}, {'bundled' if bundled else 'system'}", file=sys.stderr)
+        app_args.append(f"{name}:{int(bundled)}")
+
     # Test that the frozen application is using collected graphviz executables instead of system-installed ones.
     pyi_builder.test_source("""
         import sys
-        import os
+        import pathlib
+
         import pygraphviz
 
-        bundle_dir = os.path.normpath(sys._MEIPASS)
-        dot_path = os.path.normpath(pygraphviz.AGraph()._get_prog('dot'))
+        if len(sys.argv) < 2:
+            raise SystemExit("At least one program name needs to be provided!")
 
-        assert os.path.commonprefix([dot_path, bundle_dir]) == bundle_dir, \
-            f"Invalid program path: {dot_path}!"
-        """)
+        top_level_app_dir = pathlib.Path(sys._MEIPASS).resolve()
+        package_dir = pathlib.Path(pygraphviz.__path__[0]).resolve()
+
+        print(f"Top-level application directory: {str(top_level_app_dir)!r}", file=sys.stderr)
+        print(f"Package directory: {str(package_dir)!r}", file=sys.stderr)
+
+        g = pygraphviz.agraph.AGraph()
+        for arg in sys.argv[1:]:
+            # Parse argument: "name:bundled", where bundled=<0|1>
+            tokens = arg.split(':')
+            assert len(tokens) == 2, "Invalid argument: should be in name:bundled format!"
+            name = tokens[0]
+            package_bundled = bool(int(tokens[1]))
+
+            print(f"Checking: {name!r}, package-bundled: {package_bundled}", file=sys.stderr)
+
+            program_path = pygraphviz.AGraph()._get_prog(name)
+            program_path = pathlib.Path(program_path).resolve()
+
+            print(f"Path: {str(program_path)!r}", file=sys.stderr)
+
+            # Ensure the program is part of frozen application bundle
+            assert top_level_app_dir in program_path.parents, \
+                f"Path for program {name!r}, {str(program_path)!r} is not rooted in top-level application directory!"
+
+            # If program was originally bundled with the package, ensure that this is still the case.
+            if package_bundled:
+                assert package_dir in program_path.parents, \
+                    f"Path for program {name!r}, {str(program_path)!r} is not rooted in package directory!"
+        """, app_args=app_args)
 
 
 @importorskip("pygraphviz")


### PR DESCRIPTION
Update `pygraphviz` hook for compatibility with `pygraphviz` >= 2.0, which now also provides binary wheels with bundled `graphviz` programs and libraries for Windows, macOS, and linux.

Use `pygraphviz`'s own resolver for resolving paths to `graphviz` programs that need to be collected (be it from the build system, or from `pygraphviz/bin` directory in case of new 2.0 binary wheels). Since `pygraphviz` 2.0 uses fewer of programs (and also limits their resolution in its resolver), detect version and use version-appropriate list.

Avoid trying to collect `graphviz` plugins when using wheel-bundled libraries; resolve the path of shared library against which `pygraphviz._graphviz` extension is linked, and use its location to determine bundled vs. system status. Use the same location to collect plugins in the latter case. (Previously, the hook tried to infer location from shared libraries used by `dot` executable, but this executable is not needed by `pygraphviz` 2.0 anymore...).