### PR TITLE
Hook for procrastinate

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -192,6 +192,10 @@ jobs:
           # test_langchain_with_ollama requires langchain-ollama to be installed together with langchain
           pip show -qq langchain && pip install --prefer-binary langchain-ollama
 
+          # procrastinate depends on psycopg[pool]; the binary extra is required so that psycopg can be
+          # imported without a system-provided libpq.
+          pip show -qq procrastinate && pip install --prefer-binary psycopg[binary]
+
           # Install PyInstaller
           pip install ${{ matrix.pyinstaller }}
 

--- a/_pyinstaller_hooks_contrib/stdhooks/hook-procrastinate.py
+++ b/_pyinstaller_hooks_contrib/stdhooks/hook-procrastinate.py
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2026 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files, copy_metadata
+
+# `procrastinate` reads its SQL files (`sql/queries.sql`, `sql/schema.sql`, and the migrations in
+# `sql/migrations`) via `importlib.resources`.
+datas = collect_data_files('procrastinate')
+
+# `procrastinate.metadata` reads the distribution metadata via `importlib.metadata` when the top-level
+# `procrastinate` package is imported.
+datas += copy_metadata('procrastinate')

--- a/news/1036.new.rst
+++ b/news/1036.new.rst
@@ -1,0 +1,3 @@
+Add hook for ``procrastinate``, which loads its SQL data files via
+``importlib.resources`` and its own distribution metadata via
+``importlib.metadata``.

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -90,6 +90,10 @@ pinyin==0.4.0
 platformdirs==4.10.1; python_version >= "3.10"
 plotly==6.9.0
 plum-dispatch==2.9.0; python_version >= "3.10"
+procrastinate==3.9.0; python_version >= "3.10"
+# procrastinate depends on psycopg[pool]; the binary extra is required so that psycopg can be
+# imported without a system-provided libpq.
+psycopg[binary]==3.3.4; python_version >= "3.10"
 publicsuffix2==2.20191221
 pycparser==3.0; python_version >= "3.10"
 pycryptodome==3.23.0

--- a/requirements-test-libraries.txt
+++ b/requirements-test-libraries.txt
@@ -91,9 +91,6 @@ platformdirs==4.10.1; python_version >= "3.10"
 plotly==6.9.0
 plum-dispatch==2.9.0; python_version >= "3.10"
 procrastinate==3.9.0; python_version >= "3.10"
-# procrastinate depends on psycopg[pool]; the binary extra is required so that psycopg can be
-# imported without a system-provided libpq.
-psycopg[binary]==3.3.4; python_version >= "3.10"
 publicsuffix2==2.20191221
 pycparser==3.0; python_version >= "3.10"
 pycryptodome==3.23.0

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -3470,3 +3470,21 @@ def test_plum(pyi_builder):
         s = Serializer()
         assert s.serialize(timedelta(seconds=90)) == "0:01:30"
 """)
+
+
+@xfail(reason='Requires hook for procrastinate.')
+@importorskip("procrastinate")
+def test_procrastinate(pyi_builder):
+    pyi_builder.test_source("""
+        import procrastinate
+        from procrastinate.schema import SchemaManager
+
+        # procrastinate.metadata reads the distribution metadata when the top-level package is imported.
+        assert procrastinate.__version__
+
+        # procrastinate.sql parses sql/queries.sql when it is imported.
+        assert 'defer_jobs' in procrastinate.sql.queries
+
+        # sql/schema.sql is read on demand.
+        assert 'CREATE TABLE' in SchemaManager.get_schema()
+""")

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -3472,7 +3472,6 @@ def test_plum(pyi_builder):
 """)
 
 
-@xfail(reason='Requires hook for procrastinate.')
 @importorskip("procrastinate")
 def test_procrastinate(pyi_builder):
     pyi_builder.test_source("""


### PR DESCRIPTION
<!---
Please review the summary checklist before submitting your pull request
https://github.com/pyinstaller/pyinstaller-hooks-contrib?tab=readme-ov-file#summary
--->
`procrastinate` needs two things that PyInstaller does not pick up by itself:

  - its SQL data files (`sql/queries.sql`, `sql/schema.sql` and the migrations),
    which it reads via `importlib.resources`
  - its own distribution metadata, which it reads via `importlib.metadata`
    when the package is imported
